### PR TITLE
Streamline mutation and recombination

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -291,7 +291,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/doc/md/RELEASE_NOTES.md
+++ b/doc/md/RELEASE_NOTES.md
@@ -6,6 +6,8 @@ milestones (target version numbers for these features to go live) because that i
 
 ## 0.5.7
 
+* Mutation and recombination are now merged into one path.  See fwdpp/mutate_recombine.hpp.  The entry points into the
+  old API are marked deprecated.  This addresses issue #54 via pull request #55.
 * Travis builds now use -Wl,-rpath when linking to dependencies, solving run-time link errors during "make check" on OS X.
 
 ## 0.5.6

--- a/examples/Makefile.in
+++ b/examples/Makefile.in
@@ -350,7 +350,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/experimental_examples/Makefile.in
+++ b/experimental_examples/Makefile.in
@@ -259,7 +259,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/fwdpp/Makefile.am
+++ b/fwdpp/Makefile.am
@@ -21,7 +21,8 @@ pkginclude_HEADERS=debug.hpp \
 	util.hpp \
 	sugar.hpp \
 	demography.hpp \
-	version.hpp
+	version.hpp \
+	mutate_recombine.hpp
 
 
 

--- a/fwdpp/Makefile.in
+++ b/fwdpp/Makefile.in
@@ -298,7 +298,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
@@ -328,7 +327,8 @@ pkginclude_HEADERS = debug.hpp \
 	util.hpp \
 	sugar.hpp \
 	demography.hpp \
-	version.hpp
+	version.hpp \
+	mutate_recombine.hpp
 
 all: all-recursive
 

--- a/fwdpp/experimental/Makefile.in
+++ b/fwdpp/experimental/Makefile.in
@@ -256,7 +256,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/fwdpp/experimental/sample_diploid.hpp
+++ b/fwdpp/experimental/sample_diploid.hpp
@@ -170,28 +170,12 @@ namespace KTfwd
                     if (gsl_rng_uniform(r) < 0.5)
                         std::swap(p2g1, p2g2);
 
-                    dip.first = recombination(gametes, gamete_recycling_bin,
-                                              neutral, selected, rec_pol, p1g1,
-                                              p1g2, mutations)
-                                    .first;
-                    dip.second = recombination(gametes, gamete_recycling_bin,
-                                               neutral, selected, rec_pol,
-                                               p2g1, p2g2, mutations)
-                                     .first;
-
-                    gametes[dip.first].n++;
-                    gametes[dip.second].n++;
-
-                    // now, add new mutations
-                    dip.first = mutate_gamete_recycle(
-                        mutation_recycling_bin, gamete_recycling_bin, r, mu,
-                        gametes, mutations, dip.first, mmodel, gpolicy_mut);
-                    dip.second = mutate_gamete_recycle(
-                        mutation_recycling_bin, gamete_recycling_bin, r, mu,
-                        gametes, mutations, dip.second, mmodel, gpolicy_mut);
-
-                    assert(gametes[dip.first].n);
-                    assert(gametes[dip.second].n);
+                    mutate_recombine_update(
+                        r, gametes, mutations,
+                        std::make_tuple(p1g1, p1g2, p2g1, p2g2), rec_pol,
+                        mmodel, mu, gamete_recycling_bin,
+                        mutation_recycling_bin, dip, neutral, selected);
+                    
                     dispatch_update(pmr, r, dip, parents[p1], parents[p2],
                                     gametes, mutations, ff);
                 }

--- a/fwdpp/extensions/Makefile.in
+++ b/fwdpp/extensions/Makefile.in
@@ -256,7 +256,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/fwdpp/internal/Makefile.in
+++ b/fwdpp/internal/Makefile.in
@@ -256,7 +256,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/fwdpp/mutate_recombine.hpp
+++ b/fwdpp/mutate_recombine.hpp
@@ -112,34 +112,7 @@ namespace KTfwd
                     }
                 neutral.insert(neutral.end(), nb, ne);
                 selected.insert(selected.end(), sb, se);
-// std::cerr << "returning a new mutant " <<
-// new_mutations.size()
-//         << '\n';
-#ifndef NDEBUG
-                std::unordered_map<uint_t, uint_t> n, s;
-                for (auto &&ni : neutral)
-                    n[ni]++;
-                for (auto &&ni : selected)
-                    s[ni]++;
-                for (auto &&ni : n)
-                    {
-                        if (ni.second > 1)
-                            {
-                                std::cout << ni.second << ": -> ";
-                                for (auto x : neutral)
-                                    {
-                                        std::cout << x << ' ';
-                                    }
-                                std::cout << '\n';
-                                for (auto mi : new_mutations)
-                                    {
-                                        std::cout << mi << ' ';
-                                    }
-                                std::cout << '\n';
-                            }
-                        assert(ni.second == 1);
-                    }
-#endif
+
                 return fwdpp_internal::recycle_gamete(
                     gametes, gamete_recycling_bin, neutral, selected);
             }
@@ -175,21 +148,16 @@ namespace KTfwd
                 if (next_mutation != new_mutations.cend()
                     && mutations[*next_mutation].pos < *i)
                     {
-                        // next_pos = mutations[*next_mutation].pos;
-                        // is_mut = true;
+                        const auto mut = &mutations[*next_mutation];
                         itr = fwdpp_internal::rec_gam_updater(
-                            itr, itr_e, mutations, neutral,
-                            mutations[*next_mutation].pos);
+                            itr, itr_e, mutations, neutral, mut->pos);
                         itr_s = fwdpp_internal::rec_gam_updater(
-                            itr_s, itr_s_e, mutations, selected,
-                            mutations[*next_mutation].pos);
+                            itr_s, itr_s_e, mutations, selected, mut->pos);
                         jtr = fwdpp_internal::rec_update_itr(
-                            jtr, jtr_e, mutations,
-                            mutations[*next_mutation].pos);
+                            jtr, jtr_e, mutations, mut->pos);
                         jtr_s = fwdpp_internal::rec_update_itr(
-                            jtr_s, jtr_s_e, mutations,
-                            mutations[*next_mutation].pos);
-                        if (mutations[*next_mutation].neutral)
+                            jtr_s, jtr_s_e, mutations, mut->pos);
+                        if (mut->neutral)
                             {
                                 neutral.push_back(*next_mutation);
                             }
@@ -216,39 +184,7 @@ namespace KTfwd
                         ++i;
                     }
             }
-        if (next_mutation != new_mutations.cend())
-            {
-                throw std::runtime_error("we didn't do all the mutations");
-            }
-#ifndef NDEBUG
-        std::unordered_map<uint_t, uint_t> n, s;
-        for (auto &&ni : neutral)
-            n[ni]++;
-        for (auto &&ni : selected)
-            s[ni]++;
-        for (auto &&ni : n)
-            {
-                if (ni.second > 1)
-                    {
-                        std::cout << ni.second << ": -> ";
-                        for (auto x : neutral)
-                            {
-                                std::cout << x << ' ';
-                            }
-                        std::cout << '\n';
-                        for (auto mi : new_mutations)
-                            {
-                                std::cout << mi << ' ';
-                            }
-                        std::cout << '\n';
-                    }
-                assert(ni.second == 1);
-            }
-        for (auto &&ni : s)
-            {
-                assert(ni.second == 1);
-            }
-#endif
+        assert(next_mutation == mutations.cbegin());
         return fwdpp_internal::recycle_gamete(gametes, gamete_recycling_bin,
                                               neutral, selected);
     }

--- a/fwdpp/mutate_recombine.hpp
+++ b/fwdpp/mutate_recombine.hpp
@@ -230,7 +230,7 @@ namespace KTfwd
 
     template <typename diploid_t, typename gcont_t, typename mcont_t,
               typename recmodel, typename mutmodel>
-    void
+    std::tuple<std::size_t, std::size_t, std::size_t, std::size_t>
     mutate_recombine_update(
         const gsl_rng *r, gcont_t &gametes, mcont_t &mutations,
         std::tuple<std::size_t, std::size_t, std::size_t, std::size_t>
@@ -241,6 +241,12 @@ namespace KTfwd
         diploid_t &dip,
         typename gcont_t::value_type::mutation_container &neutral,
         typename gcont_t::value_type::mutation_container &selected)
+    ///
+    /// Mechanics of merge mutation/recombination algorithm.
+    /// Introduced in 0.5.7
+    ///
+    /// \return Number of recombination breakpoints and mutations for each
+    /// gamete.
     {
         auto p1g1 = std::get<0>(parental_gametes);
         auto p1g2 = std::get<1>(parental_gametes);
@@ -256,8 +262,7 @@ namespace KTfwd
         // the integers representing the locations of the new mutations
         // in "mutations".
 
-        auto breakpoints = generate_breakpoints(std::get<0>(parental_gametes),
-                                                std::get<1>(parental_gametes),
+        auto breakpoints = generate_breakpoints(p1g1,p1g2,
                                                 gametes, mutations, rec_pol);
         auto breakpoints2
             = generate_breakpoints(p2g1, p2g2, gametes, mutations, rec_pol);
@@ -286,6 +291,11 @@ namespace KTfwd
 
         assert(gametes[dip.first].n);
         assert(gametes[dip.second].n);
+
+        auto nrec = (!breakpoints.empty()) ? breakpoints.size() - 1 : 0;
+        auto nrec2 = (!breakpoints2.empty()) ? breakpoints2.size() - 1 : 0;
+        return std::make_tuple(nrec, nrec2, new_mutations.size(),
+                               new_mutations2.size());
     }
 }
 

--- a/fwdpp/mutate_recombine.hpp
+++ b/fwdpp/mutate_recombine.hpp
@@ -58,12 +58,14 @@ namespace KTfwd
             }
         else if (breakpoints.empty())
             {
-                neutral.clear();
-                selected.clear();
-                neutral.insert(neutral.end(), gametes[g1].mutations.begin(),
-                               gametes[g1].mutations.end());
-                selected.insert(selected.end(), gametes[g1].smutations.begin(),
-                                gametes[g1].smutations.end());
+				neutral=gametes[g1].mutations;
+				selected=gametes[g1].smutations;
+                //neutral.clear();
+                //selected.clear();
+                //neutral.insert(neutral.end(), gametes[g1].mutations.begin(),
+                //               gametes[g1].mutations.end());
+                //selected.insert(selected.end(), gametes[g1].smutations.begin(),
+                //                gametes[g1].smutations.end());
                 for (auto &&m : new_mutations)
                     {
                         auto c = (mutations[m].neutral) ? &neutral : &selected;
@@ -81,6 +83,7 @@ namespace KTfwd
                 // std::cerr << "returning a new mutant " <<
                 // new_mutations.size()
                 //         << '\n';
+#ifndef NDEBUG
                 std::unordered_map<uint_t, uint_t> n, s;
                 for (auto &&ni : neutral)
                     n[ni]++;
@@ -104,6 +107,7 @@ namespace KTfwd
                             }
                         assert(ni.second == 1);
                     }
+#endif
                 return fwdpp_internal::recycle_gamete(
                     gametes, gamete_recycling_bin, neutral, selected);
             }
@@ -180,6 +184,7 @@ namespace KTfwd
                         ++i;
                     }
             }
+#ifndef NDEBUG
         std::unordered_map<uint_t, uint_t> n, s;
         for (auto &&ni : neutral)
             n[ni]++;
@@ -207,6 +212,7 @@ namespace KTfwd
             {
                 assert(ni.second == 1);
             }
+#endif
         // std::cerr << "DONE\n";
         return fwdpp_internal::recycle_gamete(gametes, gamete_recycling_bin,
                                               neutral, selected);

--- a/fwdpp/mutate_recombine.hpp
+++ b/fwdpp/mutate_recombine.hpp
@@ -30,18 +30,24 @@ namespace KTfwd
                   [&mutations](const uint_t a, const uint_t b) {
                       return mutations[a].pos < mutations[b].pos;
                   });
+		for(auto && i : rv)
+		{
+			std::cout << rv[i].pos << ' ';
+
+		}
+		std::cout << '\n';
+		std::exit(0);
         return rv;
     }
 
-    template <typename gcont_t, typename mcont_t,typename queue_type>
+    template <typename gcont_t, typename mcont_t, typename queue_type>
     std::size_t
     mutate_recombine(
-         const std::vector<uint_t> &new_mutations,
+        const std::vector<uint_t> &new_mutations,
         const std::vector<double> &breakpoints,
         // const mutation_model &mmodel, const recombination_model &recmodel,
         const std::size_t g1, const std::size_t g2, gcont_t &gametes,
-        mcont_t &mutations,
-		queue_type & gamete_recycling_bin,
+        mcont_t &mutations, queue_type &gamete_recycling_bin,
         typename gcont_t::value_type::mutation_container &neutral,
         typename gcont_t::value_type::mutation_container &selected)
     {
@@ -58,13 +64,14 @@ namespace KTfwd
             }
         else if (breakpoints.empty())
             {
-				neutral=gametes[g1].mutations;
-				selected=gametes[g1].smutations;
-                //neutral.clear();
-                //selected.clear();
-                //neutral.insert(neutral.end(), gametes[g1].mutations.begin(),
+                neutral = gametes[g1].mutations;
+                selected = gametes[g1].smutations;
+                // neutral.clear();
+                // selected.clear();
+                // neutral.insert(neutral.end(), gametes[g1].mutations.begin(),
                 //               gametes[g1].mutations.end());
-                //selected.insert(selected.end(), gametes[g1].smutations.begin(),
+                // selected.insert(selected.end(),
+                // gametes[g1].smutations.begin(),
                 //                gametes[g1].smutations.end());
                 for (auto &&m : new_mutations)
                     {
@@ -80,9 +87,9 @@ namespace KTfwd
                                        }),
                                    m);
                     }
-                // std::cerr << "returning a new mutant " <<
-                // new_mutations.size()
-                //         << '\n';
+// std::cerr << "returning a new mutant " <<
+// new_mutations.size()
+//         << '\n';
 #ifndef NDEBUG
                 std::unordered_map<uint_t, uint_t> n, s;
                 for (auto &&ni : neutral)
@@ -136,35 +143,23 @@ namespace KTfwd
         auto next_mutation = new_mutations.cbegin();
         for (auto i = breakpoints.cbegin(); i != breakpoints.cend();)
             {
-                // Get the next relevant position
-                bool is_mut = false;
-                double next_pos = *i;
                 if (next_mutation != new_mutations.cend()
                     && mutations[*next_mutation].pos < *i)
                     {
-                        next_pos = mutations[*next_mutation].pos;
-                        is_mut = true;
-                    }
-                // std::cerr << is_mut << ' ' << next_pos << ' '
-                //<< std::distance(next_mutation, new_mutations.cend())
-                //<< ' ' << std::distance(i, breakpoints.cend())
-                //<< '\n';
-                itr = fwdpp_internal::rec_gam_updater(itr, itr_e, mutations,
-                                                      neutral, next_pos);
-                itr_s = fwdpp_internal::rec_gam_updater(
-                    itr_s, itr_s_e, mutations, selected, next_pos);
-                jtr = fwdpp_internal::rec_update_itr(jtr, jtr_e, mutations,
-                                                     next_pos);
-                jtr_s = fwdpp_internal::rec_update_itr(jtr_s, jtr_s_e,
-                                                       mutations, next_pos);
-
-                // std::swap(itr, jtr);
-                // std::swap(itr_s, jtr_s);
-                // std::swap(itr_e, jtr_e);
-                // std::swap(itr_s_e, jtr_s_e);
-                if (is_mut)
-                    {
-                        // std::cerr << "is a mutation!\n";
+                        // next_pos = mutations[*next_mutation].pos;
+                        // is_mut = true;
+                        itr = fwdpp_internal::rec_gam_updater(
+                            itr, itr_e, mutations, neutral,
+                            mutations[*next_mutation].pos);
+                        itr_s = fwdpp_internal::rec_gam_updater(
+                            itr_s, itr_s_e, mutations, selected,
+                            mutations[*next_mutation].pos);
+                        jtr = fwdpp_internal::rec_update_itr(
+                            jtr, jtr_e, mutations,
+                            mutations[*next_mutation].pos);
+                        jtr_s = fwdpp_internal::rec_update_itr(
+                            jtr_s, jtr_s_e, mutations,
+                            mutations[*next_mutation].pos);
                         if (mutations[*next_mutation].neutral)
                             {
                                 neutral.push_back(*next_mutation);
@@ -177,12 +172,24 @@ namespace KTfwd
                     }
                 else
                     {
+                        itr = fwdpp_internal::rec_gam_updater(
+                            itr, itr_e, mutations, neutral, *i);
+                        itr_s = fwdpp_internal::rec_gam_updater(
+                            itr_s, itr_s_e, mutations, selected, *i);
+                        jtr = fwdpp_internal::rec_update_itr(jtr, jtr_e,
+                                                             mutations, *i);
+                        jtr_s = fwdpp_internal::rec_update_itr(jtr_s, jtr_s_e,
+                                                               mutations, *i);
                         std::swap(itr, jtr);
                         std::swap(itr_s, jtr_s);
                         std::swap(itr_e, jtr_e);
                         std::swap(itr_s_e, jtr_s_e);
                         ++i;
                     }
+            }
+        if (next_mutation != new_mutations.cend())
+            {
+                throw std::runtime_error("we didn't do all the mutations");
             }
 #ifndef NDEBUG
         std::unordered_map<uint_t, uint_t> n, s;

--- a/fwdpp/mutate_recombine.hpp
+++ b/fwdpp/mutate_recombine.hpp
@@ -3,18 +3,17 @@
 
 #include <vector>
 #include <algorithm>
+#include <iostream>
 #include <fwdpp/forward_types.hpp>
-#include <fdwpp/internal/mutation_internal.hpp>
+#include <fwdpp/internal/mutation_internal.hpp>
 
 namespace KTfwd
 {
-    template <typename queue_type, typename queue_type2,
-              typename mutation_model, typename gcont_t, typename mcont_t>
+    template <typename queue_type, typename mutation_model, typename mcont_t>
     std::vector<uint_t>
     generate_new_mutations(queue_type &recycling_bin, const gsl_rng *r,
-                           const double &mu, 
-                           mcont_t &mutations, const std::size_t g,
-                           const mutation_model &mmodel)
+                           const double &mu, mcont_t &mutations,
+                           const std::size_t g, const mutation_model &mmodel)
     /// Return a vector of keys to new mutations.  The keys
     /// will be sorted according to mutation postition.
     {
@@ -26,11 +25,129 @@ namespace KTfwd
                 rv.emplace_back(fwdpp_internal::mmodel_dispatcher(
                     mmodel, g, mutations, recycling_bin));
             }
-        std::sort(mutations.begin(), mutations.end(),
+        std::sort(rv.begin(), rv.end(),
                   [&mutations](const uint_t a, const uint_t b) {
                       return mutations[a].pos < mutations[b].pos;
                   });
         return rv;
+    }
+
+    template <typename mutation_queue_type, typename gamete_queue_type,
+              typename gcont_t, typename mcont_t, typename mutation_model,
+              typename recombination_model>
+    std::size_t
+    mutate_recombine(
+        const gsl_rng *r, const double mutation_rate,
+        const mutation_model &mmodel, const recombination_model &recmodel,
+        const std::size_t g1, const std::size_t g2, gcont_t &gametes,
+        mcont_t &mutations, mutation_queue_type &mut_recycling_bin,
+        gamete_queue_type &gamete_recycling_bin,
+        typename gcont_t::value_type::mutation_container &neutral,
+        typename gcont_t::value_type::mutation_container &selected)
+    {
+        // The order here is to keep results same as previous fwdpp versions,
+        // so we generate recombination breakpoints first, and then the new
+        // mutations:
+        auto breakpoints = recmodel(gametes[g1], gametes[g2], mutations);
+        auto new_mutations = generate_new_mutations(
+            mut_recycling_bin, r, mutation_rate, mutations, g1, mmodel);
+
+        if (new_mutations.empty() && breakpoints.empty())
+            {
+                return g1;
+            }
+        else if (breakpoints.empty())
+            {
+                neutral.insert(neutral.end(), gametes[g1].mutations.begin(),
+                               gametes[g1].mutations.end());
+                selected.insert(selected.end(), gametes[g1].smutations.begin(),
+                                gametes[g1].smutations.end());
+                for (auto &&m : new_mutations)
+                    {
+                        auto c = (mutations[m].neutral) ? &neutral : &selected;
+                        c->emplace(std::upper_bound(
+                                       c->begin(), c->end(), mutations[m].pos,
+                                       [&mutations](
+                                           const double &__value,
+                                           const std::size_t __mut) noexcept {
+                                           assert(__mut < mutations.size());
+                                           return __value
+                                                  < mutations[__mut].pos;
+                                       }),
+                                   m);
+                    }
+                std::cerr << "returning a new mutant " << new_mutations.size() << '\n';
+                return fwdpp_internal::recycle_gamete(
+                    gametes, gamete_recycling_bin, neutral, selected);
+            }
+        std::cerr << breakpoints.size() << ' ' << new_mutations.size() << '\n';
+
+        assert(breakpoints.back() == std::numeric_limits<double>::max());
+		assert(std::is_sorted(breakpoints.begin(),breakpoints.end()));
+        assert(std::is_sorted(
+            new_mutations.begin(), new_mutations.end(),
+            [&mutations](const std::uint32_t i, const std::uint32_t j) {
+                return mutations[i].pos < mutations[j].pos;
+            }));
+        auto itr = gametes[g1].mutations.cbegin();
+        auto jtr = gametes[g2].mutations.cbegin();
+        auto itr_s = gametes[g1].smutations.cbegin();
+        auto jtr_s = gametes[g2].smutations.cbegin();
+        auto itr_e = gametes[g1].mutations.cend();
+        auto itr_s_e = gametes[g1].smutations.cend();
+        auto jtr_e = gametes[g2].mutations.cend();
+        auto jtr_s_e = gametes[g2].smutations.cend();
+
+        auto next_mutation = new_mutations.cbegin();
+        for (auto i = breakpoints.cbegin(); i != breakpoints.cend();)
+            {
+                // Get the next relevant position
+                bool is_mut = false;
+                double next_pos = *i;
+                if (next_mutation != new_mutations.cend()
+                    && mutations[*next_mutation].pos < *i)
+                    {
+                        next_pos = mutations[*next_mutation].pos;
+                        is_mut = true;
+                    }
+                std::cerr << is_mut << ' ' << next_pos << ' '
+                          << std::distance(next_mutation, new_mutations.cend())
+                          << ' ' << std::distance(i, breakpoints.cend())
+                          << '\n';
+                itr = fwdpp_internal::rec_gam_updater(itr, itr_e, mutations,
+                                                      neutral, next_pos);
+                itr_s = fwdpp_internal::rec_gam_updater(
+                    itr_s, itr_s_e, mutations, selected, next_pos);
+                jtr = fwdpp_internal::rec_update_itr(jtr, jtr_e, mutations,
+                                                     next_pos);
+                jtr_s = fwdpp_internal::rec_update_itr(jtr_s, jtr_s_e,
+                                                       mutations, next_pos);
+                std::swap(itr, jtr);
+                std::swap(itr_s, jtr_s);
+                std::swap(itr_e, jtr_e);
+                std::swap(itr_s_e, jtr_s_e);
+
+                if (is_mut)
+                    {
+						std::cerr << "is a mutation!\n";
+                        if (mutations[*next_mutation].neutral)
+                            {
+                                neutral.push_back(*next_mutation);
+                            }
+                        else
+                            {
+                                selected.push_back(*next_mutation);
+                            }
+                        ++next_mutation;
+                    }
+                else
+                    {
+                        ++i;
+                    }
+            }
+        std::cerr << "DONE\n";
+        return fwdpp_internal::recycle_gamete(gametes, gamete_recycling_bin,
+                                              neutral, selected);
     }
 }
 

--- a/fwdpp/mutate_recombine.hpp
+++ b/fwdpp/mutate_recombine.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <algorithm>
 #include <iostream>
+#include <unordered_map>
 #include <fwdpp/forward_types.hpp>
 #include <fwdpp/internal/mutation_internal.hpp>
 
@@ -76,19 +77,21 @@ namespace KTfwd
                                        }),
                                    m);
                     }
-                std::cerr << "returning a new mutant " << new_mutations.size() << '\n';
+                std::cerr << "returning a new mutant " << new_mutations.size()
+                          << '\n';
                 return fwdpp_internal::recycle_gamete(
                     gametes, gamete_recycling_bin, neutral, selected);
             }
         std::cerr << breakpoints.size() << ' ' << new_mutations.size() << '\n';
 
         assert(breakpoints.back() == std::numeric_limits<double>::max());
-		assert(std::is_sorted(breakpoints.begin(),breakpoints.end()));
+        assert(std::is_sorted(breakpoints.begin(), breakpoints.end()));
         assert(std::is_sorted(
             new_mutations.begin(), new_mutations.end(),
             [&mutations](const std::uint32_t i, const std::uint32_t j) {
                 return mutations[i].pos < mutations[j].pos;
             }));
+
         auto itr = gametes[g1].mutations.cbegin();
         auto jtr = gametes[g2].mutations.cbegin();
         auto itr_s = gametes[g1].smutations.cbegin();
@@ -122,14 +125,14 @@ namespace KTfwd
                                                      next_pos);
                 jtr_s = fwdpp_internal::rec_update_itr(jtr_s, jtr_s_e,
                                                        mutations, next_pos);
+
                 std::swap(itr, jtr);
                 std::swap(itr_s, jtr_s);
                 std::swap(itr_e, jtr_e);
                 std::swap(itr_s_e, jtr_s_e);
-
                 if (is_mut)
                     {
-						std::cerr << "is a mutation!\n";
+                        std::cerr << "is a mutation!\n";
                         if (mutations[*next_mutation].neutral)
                             {
                                 neutral.push_back(*next_mutation);
@@ -144,6 +147,33 @@ namespace KTfwd
                     {
                         ++i;
                     }
+            }
+        std::unordered_map<uint_t, uint_t> n, s;
+        for (auto &&ni : neutral)
+            n[ni]++;
+        for (auto &&ni : selected)
+            s[ni]++;
+        for (auto &&ni : n)
+            {
+                if (ni.second > 1)
+                    {
+                        std::cout << ni.second << ": -> ";
+                        for (auto x : neutral)
+                            {
+                                std::cout << x << ' ';
+                            }
+                        std::cout << '\n';
+                        for (auto mi : new_mutations)
+                            {
+                                std::cout << mi << ' ';
+                            }
+                        std::cout << '\n';
+                    }
+                assert(ni.second == 1);
+            }
+        for (auto &&ni : s)
+            {
+                assert(ni.second == 1);
             }
         std::cerr << "DONE\n";
         return fwdpp_internal::recycle_gamete(gametes, gamete_recycling_bin,

--- a/fwdpp/mutate_recombine.hpp
+++ b/fwdpp/mutate_recombine.hpp
@@ -30,13 +30,16 @@ namespace KTfwd
                   [&mutations](const uint_t a, const uint_t b) {
                       return mutations[a].pos < mutations[b].pos;
                   });
+		if(!rv.empty())
+		{
 		for(auto && i : rv)
 		{
-			std::cout << rv[i].pos << ' ';
+			std::cout << mutations[i].pos << ' ';
 
 		}
 		std::cout << '\n';
 		std::exit(0);
+		}
         return rv;
     }
 

--- a/fwdpp/mutate_recombine.hpp
+++ b/fwdpp/mutate_recombine.hpp
@@ -27,19 +27,19 @@ namespace KTfwd
     generate_breakpoints(const std::size_t g1, const std::size_t g2,
                          const gcont_t &gametes, const mcont_t &mutations,
                          const recombination_policy &rec_pol)
-    /*! Generate vector of recombination breakpoints
-     \param g1 Index of gamete 1
-     \param g2 Index of gamete 2
-     \param gametes Vector of gametes
-     \param mutation Vector of mutations
-     \param rec_pol Function to generate breakpoints
-
-     \return std::vector<double> containing sorted breakpoints
-
-     \note An empty return value means no breakpoints.  Otherwise,
-     the breakpoints are returned and are terminated by
-     std::numeric_limits<double>::max()
-     */
+    /// Generate vector of recombination breakpoints
+    ///
+    /// \param g1 Index of gamete 1
+    /// \param g2 Index of gamete 2
+    /// \param gametes Vector of gametes
+    /// \param mutation Vector of mutations
+    /// \param rec_pol Function to generate breakpoints
+    ///
+    /// \return std::vector<double> containing sorted breakpoints
+    ///
+    /// \note An empty return value means no breakpoints.  Otherwise,
+    /// the breakpoints are returned and are terminated by
+    /// std::numeric_limits<double>::max()
     {
         auto nm1
             = gametes[g1].mutations.size() + gametes[g1].smutations.size();
@@ -60,20 +60,20 @@ namespace KTfwd
                            const double &mu, gcont_t &gametes,
                            mcont_t &mutations, const std::size_t g,
                            const mutation_model &mmodel)
-    /*!
-         Return a vector of keys to new mutations.  The keys
-     will be sorted according to mutation postition.
-
-         \param recycling_bin The queue for recycling mutations
-         \param r A random number generator
-         \param mu The total mutation rate
-                 \param gametes Vector of gametes
-         \param mutations Vector of mutations
-                 \param g index of gamete to mutate
-         \param mmodel The mutation policy
-
-         \return Vector of mutation keys, sorted according to position
-         */
+    ///
+    /// Return a vector of keys to new mutations.  The keys
+    /// will be sorted according to mutation postition.
+    ///
+    /// \param recycling_bin The queue for recycling mutations
+    /// \param r A random number generator
+    /// \param mu The total mutation rate
+    /// \param gametes Vector of gametes
+    /// \param mutations Vector of mutations
+    /// \param g index of gamete to mutate
+    /// \param mmodel The mutation policy
+    ///
+    /// \return Vector of mutation keys, sorted according to position
+    ///
     {
         unsigned nm = gsl_ran_poisson(r, mu);
         std::vector<uint_t> rv;
@@ -135,6 +135,30 @@ namespace KTfwd
         queue_type &gamete_recycling_bin,
         typename gcont_t::value_type::mutation_container &neutral,
         typename gcont_t::value_type::mutation_container &selected)
+    ///
+    /// Update apply new mutations and recombination events to 
+    /// an offspring's gamete.
+    ///
+    /// \param new_mutations Keys to new mutations
+    /// \param breakpoints Recombination breakpoints
+    /// \param g1 Parental gamete 1
+    /// \param g2 Parental gamete 2
+    /// \param gametes The vector of gametes in the population
+    /// \param mutation The vector of mutations in the population
+    /// \param gamete_recycling_bin FIFO queue for gamete recycling
+    /// \param neutral Temporary container for updating neutral mutations
+    /// \param selected Temporary container for updatng selected positions
+    ///
+    /// \return The index of the new offspring gamete in \a gametes.
+    ///
+    /// \note For efficiency, it is helpful if \a new_mutations is sorted
+    /// by mutation position.  KTfwd::generate_new_mutations exists to help in that
+    /// regard. Many of the evolve functions used in this library and other
+    /// packages by the author will use KTfwd::generate_breakpoints to 
+    /// generate \a breakpoints.  That is not, however, required.
+    /// 
+    /// \version
+    /// This function was added in fwdpp 0.5.7.
     {
         if (new_mutations.empty() && breakpoints.empty())
             {
@@ -242,11 +266,34 @@ namespace KTfwd
         typename gcont_t::value_type::mutation_container &neutral,
         typename gcont_t::value_type::mutation_container &selected)
     ///
-    /// Mechanics of merge mutation/recombination algorithm.
-    /// Introduced in 0.5.7
+    /// "Convenience" function for generating offspring gametes.  
+    /// 
+    /// This function calls KTfwd::generate_breakpoints, 
+    /// KTfwd::generate_new_mutations, and KTfwd::mutate_recombine,
+    /// resulting in two offspring gametes.
+    ///
+    /// \param r A gsl_rng *
+    /// \param gametes Vector of gametes in population
+    /// \param mutations Vector of mutations in population
+    /// \param parental_gametes Tuple of gamete keys for each parent
+    /// \param rec_pol Policy to generate recombination breakpoints
+    /// \param mmodel Policy to generate new mutations
+    /// \param gamete_recycling_bin FIFO queue for gamete recycling
+    /// \param mutation_recycling_bin FIFO queue for mutation recycling
+    /// \param dip The offspring
+    /// \param neutral Temporary container for updating neutral mutations
+    /// \param selected Temporary container for updating selected mutations
     ///
     /// \return Number of recombination breakpoints and mutations for each
     /// gamete.
+    ///
+    /// \note
+    /// \a parental_gametes should contain parent one/gamete one, 
+    /// parent one/gamete two, parent two/gamete one, 
+    /// and parent two/gamete two, in that order.
+    /// 
+    /// \version
+    /// Added in fwdpp 0.5.7.
     {
         auto p1g1 = std::get<0>(parental_gametes);
         auto p1g2 = std::get<1>(parental_gametes);
@@ -262,8 +309,8 @@ namespace KTfwd
         // the integers representing the locations of the new mutations
         // in "mutations".
 
-        auto breakpoints = generate_breakpoints(p1g1,p1g2,
-                                                gametes, mutations, rec_pol);
+        auto breakpoints
+            = generate_breakpoints(p1g1, p1g2, gametes, mutations, rec_pol);
         auto breakpoints2
             = generate_breakpoints(p2g1, p2g2, gametes, mutations, rec_pol);
         auto new_mutations = generate_new_mutations(

--- a/fwdpp/mutate_recombine.hpp
+++ b/fwdpp/mutate_recombine.hpp
@@ -33,25 +33,24 @@ namespace KTfwd
         return rv;
     }
 
-    template <typename mutation_queue_type, typename gamete_queue_type,
-              typename gcont_t, typename mcont_t, typename mutation_model,
-              typename recombination_model>
+    template <typename gcont_t, typename mcont_t,typename queue_type>
     std::size_t
     mutate_recombine(
-        const gsl_rng *r, const double mutation_rate,
-        const mutation_model &mmodel, const recombination_model &recmodel,
+         const std::vector<uint_t> &new_mutations,
+        const std::vector<double> &breakpoints,
+        // const mutation_model &mmodel, const recombination_model &recmodel,
         const std::size_t g1, const std::size_t g2, gcont_t &gametes,
-        mcont_t &mutations, mutation_queue_type &mut_recycling_bin,
-        gamete_queue_type &gamete_recycling_bin,
+        mcont_t &mutations,
+		queue_type & gamete_recycling_bin,
         typename gcont_t::value_type::mutation_container &neutral,
         typename gcont_t::value_type::mutation_container &selected)
     {
         // The order here is to keep results same as previous fwdpp versions,
         // so we generate recombination breakpoints first, and then the new
         // mutations:
-        auto breakpoints = recmodel(gametes[g1], gametes[g2], mutations);
-        auto new_mutations = generate_new_mutations(
-            mut_recycling_bin, r, mutation_rate, mutations, g1, mmodel);
+        // auto breakpoints = recmodel(gametes[g1], gametes[g2], mutations);
+        // auto new_mutations = generate_new_mutations(
+        //    mut_recycling_bin, r, mutation_rate, mutations, g1, mmodel);
 
         if (new_mutations.empty() && breakpoints.empty())
             {
@@ -79,8 +78,9 @@ namespace KTfwd
                                        }),
                                    m);
                     }
-                //std::cerr << "returning a new mutant " << new_mutations.size()
-                 //         << '\n';
+                // std::cerr << "returning a new mutant " <<
+                // new_mutations.size()
+                //         << '\n';
                 std::unordered_map<uint_t, uint_t> n, s;
                 for (auto &&ni : neutral)
                     n[ni]++;
@@ -109,7 +109,8 @@ namespace KTfwd
             }
         neutral.clear();
         selected.clear();
-        //std::cerr << breakpoints.size() << ' ' << new_mutations.size() << '\n';
+        // std::cerr << breakpoints.size() << ' ' << new_mutations.size() <<
+        // '\n';
 
         assert(breakpoints.back() == std::numeric_limits<double>::max());
         assert(std::is_sorted(breakpoints.begin(), breakpoints.end()));
@@ -140,10 +141,10 @@ namespace KTfwd
                         next_pos = mutations[*next_mutation].pos;
                         is_mut = true;
                     }
-                //std::cerr << is_mut << ' ' << next_pos << ' '
-                          //<< std::distance(next_mutation, new_mutations.cend())
-                          //<< ' ' << std::distance(i, breakpoints.cend())
-                          //<< '\n';
+                // std::cerr << is_mut << ' ' << next_pos << ' '
+                //<< std::distance(next_mutation, new_mutations.cend())
+                //<< ' ' << std::distance(i, breakpoints.cend())
+                //<< '\n';
                 itr = fwdpp_internal::rec_gam_updater(itr, itr_e, mutations,
                                                       neutral, next_pos);
                 itr_s = fwdpp_internal::rec_gam_updater(
@@ -159,7 +160,7 @@ namespace KTfwd
                 // std::swap(itr_s_e, jtr_s_e);
                 if (is_mut)
                     {
-                        //std::cerr << "is a mutation!\n";
+                        // std::cerr << "is a mutation!\n";
                         if (mutations[*next_mutation].neutral)
                             {
                                 neutral.push_back(*next_mutation);
@@ -206,7 +207,7 @@ namespace KTfwd
             {
                 assert(ni.second == 1);
             }
-        //std::cerr << "DONE\n";
+        // std::cerr << "DONE\n";
         return fwdpp_internal::recycle_gamete(gametes, gamete_recycling_bin,
                                               neutral, selected);
     }

--- a/fwdpp/mutate_recombine.hpp
+++ b/fwdpp/mutate_recombine.hpp
@@ -59,6 +59,8 @@ namespace KTfwd
             }
         else if (breakpoints.empty())
             {
+                neutral.clear();
+                selected.clear();
                 neutral.insert(neutral.end(), gametes[g1].mutations.begin(),
                                gametes[g1].mutations.end());
                 selected.insert(selected.end(), gametes[g1].smutations.begin(),
@@ -77,12 +79,37 @@ namespace KTfwd
                                        }),
                                    m);
                     }
-                std::cerr << "returning a new mutant " << new_mutations.size()
-                          << '\n';
+                //std::cerr << "returning a new mutant " << new_mutations.size()
+                 //         << '\n';
+                std::unordered_map<uint_t, uint_t> n, s;
+                for (auto &&ni : neutral)
+                    n[ni]++;
+                for (auto &&ni : selected)
+                    s[ni]++;
+                for (auto &&ni : n)
+                    {
+                        if (ni.second > 1)
+                            {
+                                std::cout << ni.second << ": -> ";
+                                for (auto x : neutral)
+                                    {
+                                        std::cout << x << ' ';
+                                    }
+                                std::cout << '\n';
+                                for (auto mi : new_mutations)
+                                    {
+                                        std::cout << mi << ' ';
+                                    }
+                                std::cout << '\n';
+                            }
+                        assert(ni.second == 1);
+                    }
                 return fwdpp_internal::recycle_gamete(
                     gametes, gamete_recycling_bin, neutral, selected);
             }
-        std::cerr << breakpoints.size() << ' ' << new_mutations.size() << '\n';
+        neutral.clear();
+        selected.clear();
+        //std::cerr << breakpoints.size() << ' ' << new_mutations.size() << '\n';
 
         assert(breakpoints.back() == std::numeric_limits<double>::max());
         assert(std::is_sorted(breakpoints.begin(), breakpoints.end()));
@@ -113,10 +140,10 @@ namespace KTfwd
                         next_pos = mutations[*next_mutation].pos;
                         is_mut = true;
                     }
-                std::cerr << is_mut << ' ' << next_pos << ' '
-                          << std::distance(next_mutation, new_mutations.cend())
-                          << ' ' << std::distance(i, breakpoints.cend())
-                          << '\n';
+                //std::cerr << is_mut << ' ' << next_pos << ' '
+                          //<< std::distance(next_mutation, new_mutations.cend())
+                          //<< ' ' << std::distance(i, breakpoints.cend())
+                          //<< '\n';
                 itr = fwdpp_internal::rec_gam_updater(itr, itr_e, mutations,
                                                       neutral, next_pos);
                 itr_s = fwdpp_internal::rec_gam_updater(
@@ -126,13 +153,13 @@ namespace KTfwd
                 jtr_s = fwdpp_internal::rec_update_itr(jtr_s, jtr_s_e,
                                                        mutations, next_pos);
 
-                std::swap(itr, jtr);
-                std::swap(itr_s, jtr_s);
-                std::swap(itr_e, jtr_e);
-                std::swap(itr_s_e, jtr_s_e);
+                // std::swap(itr, jtr);
+                // std::swap(itr_s, jtr_s);
+                // std::swap(itr_e, jtr_e);
+                // std::swap(itr_s_e, jtr_s_e);
                 if (is_mut)
                     {
-                        std::cerr << "is a mutation!\n";
+                        //std::cerr << "is a mutation!\n";
                         if (mutations[*next_mutation].neutral)
                             {
                                 neutral.push_back(*next_mutation);
@@ -145,6 +172,10 @@ namespace KTfwd
                     }
                 else
                     {
+                        std::swap(itr, jtr);
+                        std::swap(itr_s, jtr_s);
+                        std::swap(itr_e, jtr_e);
+                        std::swap(itr_s_e, jtr_s_e);
                         ++i;
                     }
             }
@@ -175,7 +206,7 @@ namespace KTfwd
             {
                 assert(ni.second == 1);
             }
-        std::cerr << "DONE\n";
+        //std::cerr << "DONE\n";
         return fwdpp_internal::recycle_gamete(gametes, gamete_recycling_bin,
                                               neutral, selected);
     }

--- a/fwdpp/mutate_recombine.hpp
+++ b/fwdpp/mutate_recombine.hpp
@@ -11,6 +11,8 @@
 #include <vector>
 #include <algorithm>
 #include <cassert>
+#include <gsl/gsl_rng.h>
+#include <gsl/gsl_randist.h>
 #include <fwdpp/forward_types.hpp>
 #include <fwdpp/internal/mutation_internal.hpp>
 #include <fwdpp/internal/rec_gamete_updater.hpp>
@@ -49,11 +51,13 @@ namespace KTfwd
         return rec_pol(gametes[g1], gametes[g2], mutations);
     }
 
-    template <typename queue_type, typename mutation_model, typename mcont_t>
+    template <typename queue_type, typename mutation_model, typename gcont_t,
+              typename mcont_t>
     std::vector<uint_t>
     generate_new_mutations(queue_type &recycling_bin, const gsl_rng *r,
-                           const double &mu, mcont_t &mutations,
-                           const std::size_t g, const mutation_model &mmodel)
+                           const double &mu, gcont_t &gametes,
+                           mcont_t &mutations, const std::size_t g,
+                           const mutation_model &mmodel)
     /*!
          Return a vector of keys to new mutations.  The keys
      will be sorted according to mutation postition.
@@ -61,6 +65,7 @@ namespace KTfwd
          \param recycling_bin The queue for recycling mutations
          \param r A random number generator
          \param mu The total mutation rate
+		 \param gametes Vector of gametes
          \param mutations Vector of mutations
 		 \param g index of gamete to mutate
          \param mmodel The mutation policy
@@ -74,7 +79,7 @@ namespace KTfwd
         for (unsigned i = 0; i < nm; ++i)
             {
                 rv.emplace_back(fwdpp_internal::mmodel_dispatcher(
-                    mmodel, g, mutations, recycling_bin));
+                    mmodel, gametes[g], mutations, recycling_bin));
             }
         std::sort(rv.begin(), rv.end(),
                   [&mutations](const uint_t a, const uint_t b) {
@@ -216,7 +221,7 @@ namespace KTfwd
                         ++i;
                     }
             }
-        assert(next_mutation == mutations.cend());
+        assert(next_mutation == new_mutations.cend());
         return fwdpp_internal::recycle_gamete(gametes, gamete_recycling_bin,
                                               neutral, selected);
     }

--- a/fwdpp/mutate_recombine.hpp
+++ b/fwdpp/mutate_recombine.hpp
@@ -1,0 +1,37 @@
+#ifndef FWDPP_MUTATE_RECOMBINE_HPP__
+#define FWDPP_MUTATE_RECOMBINE_HPP__
+
+#include <vector>
+#include <algorithm>
+#include <fwdpp/forward_types.hpp>
+#include <fdwpp/internal/mutation_internal.hpp>
+
+namespace KTfwd
+{
+    template <typename queue_type, typename queue_type2,
+              typename mutation_model, typename gcont_t, typename mcont_t>
+    std::vector<uint_t>
+    generate_new_mutations(queue_type &recycling_bin, const gsl_rng *r,
+                           const double &mu, 
+                           mcont_t &mutations, const std::size_t g,
+                           const mutation_model &mmodel)
+    /// Return a vector of keys to new mutations.  The keys
+    /// will be sorted according to mutation postition.
+    {
+        unsigned nm = gsl_ran_poisson(r, mu);
+        std::vector<uint_t> rv;
+        rv.reserve(nm);
+        for (unsigned i = 0; i < nm; ++i)
+            {
+                rv.emplace_back(fwdpp_internal::mmodel_dispatcher(
+                    mmodel, g, mutations, recycling_bin));
+            }
+        std::sort(mutations.begin(), mutations.end(),
+                  [&mutations](const uint_t a, const uint_t b) {
+                      return mutations[a].pos < mutations[b].pos;
+                  });
+        return rv;
+    }
+}
+
+#endif

--- a/fwdpp/mutation.hpp
+++ b/fwdpp/mutation.hpp
@@ -24,6 +24,9 @@ namespace KTfwd
       \note g is passed non-const and will be modified by mutation events.
       \note Used in invididual-based forward simulations.
       \return The location of the newly-mutated gamete in gametes.
+     
+      \deprecated
+      Deprecated in 0.5.7.
     */
     template <typename queue_type, typename queue_type2,
               typename mutation_model, typename gamete_insertion_policy,

--- a/fwdpp/mutation.hpp
+++ b/fwdpp/mutation.hpp
@@ -34,7 +34,7 @@ namespace KTfwd
                                       gcont_t &gametes, mcont_t &mutations,
                                       const size_t g,
                                       const mutation_model &mmodel,
-                                      const gamete_insertion_policy &gpolicy);
+                                      const gamete_insertion_policy &gpolicy) __attribute__((deprecated));
 }
 #endif /* _FWDPP_MUTATION_HPP_ */
 #include <fwdpp/mutation.tcc>

--- a/fwdpp/recombination.hpp
+++ b/fwdpp/recombination.hpp
@@ -68,6 +68,9 @@ namespace KTfwd
       \return A pair.  The first element is the index of the recombinant
       gamete.  The second element is the number of breakpoints
       where recombination occurred.  Typically, the latter is not needed.
+      
+      \deprecated
+      Deprecated in 0.5.7.
     */
     template <typename gcont_t, typename mcont_t, typename recbin_t,
               typename recpol_t>
@@ -112,6 +115,9 @@ namespace KTfwd
 
       \return A key representing the recombinant gamete, or g1 if \a pos is
       empty
+
+      \deprecated
+      Deprecated in 0.5.7.
     */
     template <typename vec_t, typename gcont_t, typename mcont_t,
               typename queue_t>

--- a/fwdpp/recombination.hpp
+++ b/fwdpp/recombination.hpp
@@ -76,7 +76,7 @@ namespace KTfwd
                   typename gcont_t::value_type::mutation_container &neutral,
                   typename gcont_t::value_type::mutation_container &selected,
                   const recpol_t &rec_pol, const std::size_t g1,
-                  const std::size_t g2, const mcont_t &mutations);
+                  const std::size_t g2, const mcont_t &mutations) __attribute__((deprecated));
 
     /*!
       Overload for fixed xover positions.
@@ -120,7 +120,7 @@ namespace KTfwd
         const std::size_t g1, const std::size_t g2,
         queue_t &gamete_recycling_bin,
         typename gcont_t::value_type::mutation_container &neutral,
-        typename gcont_t::value_type::mutation_container &selected);
+        typename gcont_t::value_type::mutation_container &selected) __attribute__((deprecated));
 }
 #endif // __FWDPP_RECOMBINATION_HPP__
 #include <fwdpp/recombination.tcc>

--- a/fwdpp/sample_diploid.tcc
+++ b/fwdpp/sample_diploid.tcc
@@ -234,18 +234,28 @@ namespace KTfwd
                   sequential updates to iterators using binary
                   searches (std::upper_bound).
                 */
+                auto breakpoints
+                    = rec_pol(gametes[p1g1], gametes[p1g2], mutations);
+                auto breakpoints2
+                    = rec_pol(gametes[p2g1], gametes[p2g2], mutations);
+                auto new_mutations = generate_new_mutations(
+                    mut_recycling_bin, r, mu, mutations, p1g1, mmodel);
+                auto new_mutations2 = generate_new_mutations(
+                    mut_recycling_bin, r, mu, mutations, p2g2, mmodel);
+
                 dip.first = mutate_recombine(
-                    r, mu, mmodel, rec_pol, p1g1, p1g2, gametes, mutations,
-                    mut_recycling_bin, gam_recycling_bin, neutral, selected);
+                    new_mutations, breakpoints, p1g1, p1g2, gametes, mutations,
+                    gam_recycling_bin, neutral, selected);
                 dip.second = mutate_recombine(
-                    r, mu, mmodel, rec_pol, p2g1, p2g2, gametes, mutations,
-                    mut_recycling_bin, gam_recycling_bin, neutral, selected);
-//                std::cout << "counts " << gametes[dip.first].n << ' '
-//                          << gametes[dip.second].n << ' ';
+                    new_mutations2, breakpoints2, p2g1, p2g2, gametes,
+                    mutations, gam_recycling_bin, neutral, selected);
+                //                std::cout << "counts " <<
+                //                gametes[dip.first].n << ' '
+                //                          << gametes[dip.second].n << ' ';
                 gametes[dip.first].n++;
                 gametes[dip.second].n++;
-//                std::cout << gametes[dip.first].n << ' '
-//                          << gametes[dip.second].n << '\n';
+                //                std::cout << gametes[dip.first].n << ' '
+                //                          << gametes[dip.second].n << '\n';
                 // dip.first
                 //    = recombination(gametes, gam_recycling_bin, neutral,
                 //                    selected, rec_pol, p1g1, p1g2, mutations)
@@ -333,17 +343,16 @@ namespace KTfwd
         fwdpp_internal::process_gametes(gametes, mutations, mcounts);
         assert(mcounts.size() == mutations.size());
 #ifndef NDEBUG
-		unsigned XX = 0;
         for (const auto &mc : mcounts)
             {
-                if (mc >= 2 * N_next)
-                    {
-                        std::cout << mutations.size() << ' ' << mc << ' ' << mutations[XX].pos << ' '
-                                  << mutations[XX].g << ' ' << mcounts[XX]
-                                  << '\n';
-                    }
+                // if (mc >= 2 * N_next)
+                //    {
+                //        std::cout << mutations.size() << ' ' << mc << ' ' <<
+                //        mutations[XX].pos << ' '
+                //                  << mutations[XX].g << ' ' << mcounts[XX]
+                //                  << '\n';
+                //    }
                 assert(mc <= 2 * N_next);
-				XX++;
             }
 #endif
         assert(popdata_sane(diploids, gametes, mutations, mcounts));

--- a/fwdpp/sample_diploid.tcc
+++ b/fwdpp/sample_diploid.tcc
@@ -228,10 +228,12 @@ namespace KTfwd
                                                         mutations, rec_pol);
                 auto breakpoints2 = generate_breakpoints(p2g1, p2g2, gametes,
                                                          mutations, rec_pol);
-                auto new_mutations = generate_new_mutations(
-                    mut_recycling_bin, r, mu, mutations, p1g1, mmodel);
-                auto new_mutations2 = generate_new_mutations(
-                    mut_recycling_bin, r, mu, mutations, p2g2, mmodel);
+                auto new_mutations
+                    = generate_new_mutations(mut_recycling_bin, r, mu, gametes,
+                                             mutations, p1g1, mmodel);
+                auto new_mutations2
+                    = generate_new_mutations(mut_recycling_bin, r, mu, gametes,
+                                             mutations, p2g2, mmodel);
 
                 // Pass the breakpoints and new mutation keys on to
                 // KTfwd::mutate_recombine (defined in

--- a/fwdpp/sample_diploid.tcc
+++ b/fwdpp/sample_diploid.tcc
@@ -240,12 +240,12 @@ namespace KTfwd
                 dip.second = mutate_recombine(
                     r, mu, mmodel, rec_pol, p2g1, p2g2, gametes, mutations,
                     mut_recycling_bin, gam_recycling_bin, neutral, selected);
-                std::cout << "counts " << gametes[dip.first].n << ' '
-                          << gametes[dip.second].n << ' ';
+//                std::cout << "counts " << gametes[dip.first].n << ' '
+//                          << gametes[dip.second].n << ' ';
                 gametes[dip.first].n++;
                 gametes[dip.second].n++;
-                std::cout << gametes[dip.first].n << ' '
-                          << gametes[dip.second].n << '\n';
+//                std::cout << gametes[dip.first].n << ' '
+//                          << gametes[dip.second].n << '\n';
                 // dip.first
                 //    = recombination(gametes, gam_recycling_bin, neutral,
                 //                    selected, rec_pol, p1g1, p1g2, mutations)

--- a/fwdpp/sample_diploid.tcc
+++ b/fwdpp/sample_diploid.tcc
@@ -11,6 +11,7 @@
 
 #include <fwdpp/debug.hpp>
 #include <fwdpp/mutation.hpp>
+#include <fwdpp/mutate_recombine.hpp>
 #include <fwdpp/internal/recycling.hpp>
 #include <fwdpp/internal/gsl_discrete.hpp>
 #include <fwdpp/internal/gamete_cleaner.hpp>
@@ -171,8 +172,8 @@ namespace KTfwd
         fwdpp_internal::gsl_ran_discrete_t_ptr lookup(
             gsl_ran_discrete_preproc(N_curr, fitnesses.data()));
         const auto parents(diploids); // Copy the parents, which is trivally
-                                      // fast for the vast majority of use
-                                      // cases.
+        // fast for the vast majority of use
+        // cases.
 
         // Change the population size
         if (diploids.size() != N_next)
@@ -233,45 +234,55 @@ namespace KTfwd
                   sequential updates to iterators using binary
                   searches (std::upper_bound).
                 */
-                dip.first
-                    = recombination(gametes, gam_recycling_bin, neutral,
-                                    selected, rec_pol, p1g1, p1g2, mutations)
-                          .first;
-                dip.second
-                    = recombination(gametes, gam_recycling_bin, neutral,
-                                    selected, rec_pol, p2g1, p2g2, mutations)
-                          .first;
+                dip.first = mutate_recombine(
+                    r, mu, mmodel, rec_pol, p1g1, p1g2, gametes, mutations,
+                    mut_recycling_bin, gam_recycling_bin, neutral, selected);
+                dip.second = mutate_recombine(
+                    r, mu, mmodel, rec_pol, p2g1, p2g2, gametes, mutations,
+                    mut_recycling_bin, gam_recycling_bin, neutral, selected);
+				gametes[dip.first].n++;
+				gametes[dip.second].n++;
+                // dip.first
+                //    = recombination(gametes, gam_recycling_bin, neutral,
+                //                    selected, rec_pol, p1g1, p1g2, mutations)
+                //          .first;
+                // dip.second
+                //    = recombination(gametes, gam_recycling_bin, neutral,
+                //                    selected, rec_pol, p2g1, p2g2, mutations)
+                //          .first;
 
-                // update gamete counts
-                gametes[dip.first].n++;
-                gametes[dip.second].n++;
+                //// update gamete counts
+                // gametes[dip.first].n++;
+                // gametes[dip.second].n++;
 
-                /*
-                  Now, add new mutations to the first and second gamete of the
-                  offspring.
+                ///*
+                //  Now, add new mutations to the first and second gamete of
+                //  the
+                //  offspring.
 
-                  In fwdpp, mutation keys in gametes are "less-than" sorted
-                  according to mutation position.
+                //  In fwdpp, mutation keys in gametes are "less-than" sorted
+                //  according to mutation position.
 
-                  The keys to mutations are inserted into the correct place
-                  which is found by a binary search (std::upper_bound).
+                //  The keys to mutations are inserted into the correct place
+                //  which is found by a binary search (std::upper_bound).
 
-                  I think that there are ways to improve the speed of this part
-                  of the code in order to reduce calls
-                  to memmove/memcpy, but profiling suggests that the payoff
-                  would be small.  (Note that memmove/memcyp is
-                  never called direclty.  Rather, they are called indirectly
-                  via the insert() member function of the relevant
-                  container type.)
+                //  I think that there are ways to improve the speed of this
+                //  part
+                //  of the code in order to reduce calls
+                //  to memmove/memcpy, but profiling suggests that the payoff
+                //  would be small.  (Note that memmove/memcyp is
+                //  never called direclty.  Rather, they are called indirectly
+                //  via the insert() member function of the relevant
+                //  container type.)
 
-                  The implementation details are found in fwdpp/mutation.hpp
-                */
-                dip.first = mutate_gamete_recycle(
-                    mut_recycling_bin, gam_recycling_bin, r, mu, gametes,
-                    mutations, dip.first, mmodel, gpolicy_mut);
-                dip.second = mutate_gamete_recycle(
-                    mut_recycling_bin, gam_recycling_bin, r, mu, gametes,
-                    mutations, dip.second, mmodel, gpolicy_mut);
+                //  The implementation details are found in fwdpp/mutation.hpp
+                //*/
+                // dip.first = mutate_gamete_recycle(
+                //    mut_recycling_bin, gam_recycling_bin, r, mu, gametes,
+                //    mutations, dip.first, mmodel, gpolicy_mut);
+                // dip.second = mutate_gamete_recycle(
+                //    mut_recycling_bin, gam_recycling_bin, r, mu, gametes,
+                //    mutations, dip.second, mmodel, gpolicy_mut);
 
                 assert(gametes[dip.first].n);
                 assert(gametes[dip.second].n);
@@ -497,7 +508,7 @@ namespace KTfwd
                                 || (*(f + popi) > 0.
                                     && gsl_rng_uniform(r)
                                            < *(f + popi)))) // individual is
-                                                            // inbred
+                            // inbred
                             {
                                 p2 = p1;
                             }
@@ -585,7 +596,7 @@ namespace KTfwd
         const uint_t &N_next, const double *mu,
         const mutation_model_container &mmodel,
         const recombination_policy_container &rec_policies,
-		const std::vector<std::function<unsigned(void)>> & interlocus_rec,
+        const std::vector<std::function<unsigned(void)>> &interlocus_rec,
         const diploid_fitness_function &ff,
         typename gamete_type::mutation_container &neutral,
         typename gamete_type::mutation_container &selected, const double &f,
@@ -632,7 +643,7 @@ namespace KTfwd
             gsl_ran_discrete_preproc(fitnesses.size(), fitnesses.data()));
 
         const auto parents(diploids); // Copy the parents.  Exact copy of
-                                      // diploids--same fitnesses, etc.
+        // diploids--same fitnesses, etc.
 
         // Change the population size and reset dptr to avoid iterator
         // invalidation
@@ -653,7 +664,7 @@ namespace KTfwd
                 assert(p2 < N_curr);
                 dip = fwdpp_internal::multilocus_rec_mut(
                     r, parents[p1], parents[p2], mut_recycling_bin,
-                    gamete_recycling_bin, rec_policies, interlocus_rec, 
+                    gamete_recycling_bin, rec_policies, interlocus_rec,
                     ((gsl_rng_uniform(r) < 0.5) ? 1 : 0),
                     ((gsl_rng_uniform(r) < 0.5) ? 1 : 0), gametes, mutations,
                     neutral, selected, mu, mmodel, gpolicy_mut);
@@ -691,7 +702,7 @@ namespace KTfwd
         std::vector<uint_t> &mcounts, const uint_t &N, const double *mu,
         const mutation_model_container &mmodel,
         const recombination_policy_container &rec_policies,
-		const std::vector<std::function<unsigned(void)>> & interlocus_rec,
+        const std::vector<std::function<unsigned(void)>> &interlocus_rec,
         const diploid_fitness_function &ff,
         typename gamete_type::mutation_container &neutral,
         typename gamete_type::mutation_container &selected, const double &f,
@@ -699,8 +710,8 @@ namespace KTfwd
         const gamete_insertion_policy &gpolicy_mut)
     {
         return sample_diploid(r, gametes, diploids, mutations, mcounts, N, N,
-                              mu, mmodel, rec_policies, interlocus_rec, 
-                              ff, neutral, selected, f, mp, gpolicy_mut);
+                              mu, mmodel, rec_policies, interlocus_rec, ff,
+                              neutral, selected, f, mp, gpolicy_mut);
     }
 }
 

--- a/fwdpp/sample_diploid.tcc
+++ b/fwdpp/sample_diploid.tcc
@@ -240,8 +240,12 @@ namespace KTfwd
                 dip.second = mutate_recombine(
                     r, mu, mmodel, rec_pol, p2g1, p2g2, gametes, mutations,
                     mut_recycling_bin, gam_recycling_bin, neutral, selected);
-				gametes[dip.first].n++;
-				gametes[dip.second].n++;
+                std::cout << "counts " << gametes[dip.first].n << ' '
+                          << gametes[dip.second].n << ' ';
+                gametes[dip.first].n++;
+                gametes[dip.second].n++;
+                std::cout << gametes[dip.first].n << ' '
+                          << gametes[dip.second].n << '\n';
                 // dip.first
                 //    = recombination(gametes, gam_recycling_bin, neutral,
                 //                    selected, rec_pol, p1g1, p1g2, mutations)
@@ -329,9 +333,17 @@ namespace KTfwd
         fwdpp_internal::process_gametes(gametes, mutations, mcounts);
         assert(mcounts.size() == mutations.size());
 #ifndef NDEBUG
+		unsigned XX = 0;
         for (const auto &mc : mcounts)
             {
+                if (mc >= 2 * N_next)
+                    {
+                        std::cout << mutations.size() << ' ' << mc << ' ' << mutations[XX].pos << ' '
+                                  << mutations[XX].g << ' ' << mcounts[XX]
+                                  << '\n';
+                    }
                 assert(mc <= 2 * N_next);
+				XX++;
             }
 #endif
         assert(popdata_sane(diploids, gametes, mutations, mcounts));

--- a/fwdpp/sample_diploid.tcc
+++ b/fwdpp/sample_diploid.tcc
@@ -234,15 +234,13 @@ namespace KTfwd
                   sequential updates to iterators using binary
                   searches (std::upper_bound).
                 */
-                auto breakpoints
-                    = rec_pol(gametes[p1g1], gametes[p1g2], mutations);
-                auto breakpoints2
-                    = rec_pol(gametes[p2g1], gametes[p2g2], mutations);
+                auto breakpoints = generate_breakpoints(p1g1,p1g2,gametes,mutations,rec_pol);
+                auto breakpoints2 = generate_breakpoints(p2g1,p2g2,gametes,mutations,rec_pol);
                 auto new_mutations = generate_new_mutations(
                     mut_recycling_bin, r, mu, mutations, p1g1, mmodel);
                 auto new_mutations2 = generate_new_mutations(
                     mut_recycling_bin, r, mu, mutations, p2g2, mmodel);
-
+                //std::cout << breakpoints.size() << ' ' << breakpoints2.size() << '\n';
                 dip.first = mutate_recombine(
                     new_mutations, breakpoints, p1g1, p1g2, gametes, mutations,
                     gam_recycling_bin, neutral, selected);

--- a/fwdpp/sugar/Makefile.in
+++ b/fwdpp/sugar/Makefile.in
@@ -298,7 +298,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/fwdpp/sugar/gsl/Makefile.in
+++ b/fwdpp/sugar/gsl/Makefile.in
@@ -256,7 +256,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/fwdpp/sugar/poptypes/Makefile.in
+++ b/fwdpp/sugar/poptypes/Makefile.in
@@ -256,7 +256,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/fwdpp/sugar/sampling/Makefile.in
+++ b/fwdpp/sugar/sampling/Makefile.in
@@ -256,7 +256,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/fwdpp/tags/Makefile.in
+++ b/fwdpp/tags/Makefile.in
@@ -256,7 +256,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -249,7 +249,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/testsuite/Makefile.in
+++ b/testsuite/Makefile.in
@@ -535,7 +535,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/testsuite/unit/mlocusCrossoverTest.cc
+++ b/testsuite/unit/mlocusCrossoverTest.cc
@@ -10,7 +10,7 @@
 // which means we don't have to write as much boilerplate code to test the more
 // complex logic.
 // Plus, mutation stuff is unit-tested elsewhere
-#define FWDPP_UNIT_TESTING
+// #define FWDPP_UNIT_TESTING
 #include <fwdpp/diploid.hh>
 #include <boost/test/unit_test.hpp>
 #include <unistd.h>
@@ -76,7 +76,8 @@ setup3locus2(gcont_t &gametes, mcont_t &mutations, diploid_t &diploid)
 
 struct always_recombine
 {
-    inline unsigned operator()() const
+    inline unsigned
+    operator()() const
     {
         return 1u;
     }
@@ -87,8 +88,8 @@ BOOST_FIXTURE_TEST_SUITE(multilocus_rec_mutTest,
 
 BOOST_AUTO_TEST_CASE(test_flexibility)
 {
-    std::vector<double> rates{1e-3,0.1};
-    auto x = KTfwd::make_poisson_interlocus_rec(r,rates.data(),rates.size());
+    std::vector<double> rates{ 1e-3, 0.1 };
+    auto x = KTfwd::make_poisson_interlocus_rec(r, rates.data(), rates.size());
     x.emplace_back(always_recombine());
 }
 
@@ -136,9 +137,18 @@ BOOST_AUTO_TEST_CASE(three_locus_test_1)
         [&r_bw_loci]() { return static_cast<unsigned>(r_bw_loci[1]); }
     };
 
+    auto fake_mut_pol
+        = [](std::queue<std::size_t> &, decltype(mutations) &) { return 0; };
+    std::vector<std::function<std::size_t(std::queue<std::size_t> &,
+                                          decltype(mutations) &)>>
+        mutation_models{ fake_mut_pol, fake_mut_pol };
+
+    double mu[2] = { 0.0, 0.0 };
+
     auto offspring = KTfwd::fwdpp_internal::multilocus_rec_mut(
         r, diploid, diploid2, mutation_recycling_bin, gamete_recycling_bin,
-        recpols, interlocus_rec, 0, 0, gametes, mutations, neutral, selected);
+        recpols, interlocus_rec, 0, 0, gametes, mutations, neutral, selected,
+        &mu[0], mutation_models, KTfwd::emplace_back());
 
     BOOST_CHECK_EQUAL(gametes[offspring[0].first].mutations.size(), 0);
     BOOST_CHECK_EQUAL(gametes[offspring[1].first].mutations.size(), 0);
@@ -191,9 +201,18 @@ BOOST_AUTO_TEST_CASE(three_locus_test_2)
         [&r_bw_loci]() { return static_cast<unsigned>(r_bw_loci[1]); }
     };
 
+    auto fake_mut_pol
+        = [](std::queue<std::size_t> &, decltype(mutations) &) { return 0; };
+    std::vector<std::function<std::size_t(std::queue<std::size_t> &,
+                                          decltype(mutations) &)>>
+        mutation_models{ fake_mut_pol, fake_mut_pol };
+
+    double mu[2] = { 0.0, 0.0 };
+
     auto offspring = KTfwd::fwdpp_internal::multilocus_rec_mut(
         r, diploid, diploid2, mutation_recycling_bin, gamete_recycling_bin,
-        recpols, interlocus_rec, 0, 0, gametes, mutations, neutral, selected);
+        recpols, interlocus_rec, 0, 0, gametes, mutations, neutral, selected,
+        &mu[0], mutation_models, KTfwd::emplace_back());
 
     BOOST_CHECK_EQUAL(gametes[offspring[0].first].mutations.size(), 0);
     BOOST_CHECK_EQUAL(gametes[offspring[1].first].mutations.size(), 1);
@@ -249,10 +268,18 @@ BOOST_AUTO_TEST_CASE(three_locus_test_3)
         [&r_bw_loci]() { return static_cast<unsigned>(r_bw_loci[0]); },
         [&r_bw_loci]() { return static_cast<unsigned>(r_bw_loci[1]); }
     };
+    auto fake_mut_pol
+        = [](std::queue<std::size_t> &, decltype(mutations) &) { return 0; };
+    std::vector<std::function<std::size_t(std::queue<std::size_t> &,
+                                          decltype(mutations) &)>>
+        mutation_models{ fake_mut_pol, fake_mut_pol };
+
+    double mu[2] = { 0.0, 0.0 };
 
     auto offspring = KTfwd::fwdpp_internal::multilocus_rec_mut(
         r, diploid, diploid2, mutation_recycling_bin, gamete_recycling_bin,
-        recpols, interlocus_rec, 0, 0, gametes, mutations, neutral, selected);
+        recpols, interlocus_rec, 0, 0, gametes, mutations, neutral, selected,
+        &mu[0], mutation_models, KTfwd::emplace_back());
 
     BOOST_CHECK_EQUAL(gametes[offspring[0].first].mutations.size(), 2);
     BOOST_CHECK_EQUAL(gametes[offspring[1].first].mutations.size(), 1);
@@ -307,10 +334,19 @@ BOOST_AUTO_TEST_CASE(three_locus_test_4)
         [&r_bw_loci]() { return static_cast<unsigned>(r_bw_loci[0]); },
         [&r_bw_loci]() { return static_cast<unsigned>(r_bw_loci[1]); }
     };
+    auto fake_mut_pol
+        = [](std::queue<std::size_t> &, decltype(mutations) &) { return 0; };
+    std::vector<std::function<std::size_t(std::queue<std::size_t> &,
+                                          decltype(mutations) &)>>
+        mutation_models{ fake_mut_pol, fake_mut_pol };
+
+    double mu[2] = { 0.0, 0.0 };
 
     auto offspring = KTfwd::fwdpp_internal::multilocus_rec_mut(
         r, diploid, diploid2, mutation_recycling_bin, gamete_recycling_bin,
-        recpols, interlocus_rec, 0, 0, gametes, mutations, neutral, selected);
+        recpols, interlocus_rec, 0, 0, gametes, mutations, neutral, selected,
+        &mu[0], mutation_models, KTfwd::emplace_back());
+
     BOOST_CHECK_EQUAL(gametes[offspring[0].first].mutations.size(), 2);
     BOOST_CHECK_EQUAL(gametes[offspring[1].first].mutations.size(), 1);
     BOOST_CHECK_EQUAL(mutations[gametes[offspring[1].first].mutations[0]].pos,


### PR DESCRIPTION
This PR is a WIP to address #54.  It needs to be applied to all "evolve" functions.  There is a lot of cleanup to do, and I need to decide how to deprecate the old API.

One issue on this is that the unit tests will be affected by API deprecation.