### PR TITLE
do not check that mutation keys are sorted if gamete is extinct

### DIFF
--- a/fwdpp/sugar/poptypes/popbase.hpp
+++ b/fwdpp/sugar/poptypes/popbase.hpp
@@ -268,8 +268,14 @@ namespace KTfwd
                 }
             for (const auto &g : gametes)
                 {
-                    check_mutation_keys(g.mutations, mutations, true);
-                    check_mutation_keys(g.smutations, mutations, false);
+                    if (g.n)
+                        {
+                            //Fixed in 0.5.8: no need to check this for 
+                            //extinct gametes.
+                            check_mutation_keys(g.mutations, mutations, true);
+                            check_mutation_keys(g.smutations, mutations,
+                                                false);
+                        }
                 }
             fwdpp_internal::process_gametes(gametes, mutations, mcounts);
         }


### PR DESCRIPTION
This PR addresses another issue due to #56, wherein extinct gametes keys are required to be sorted by position.  This check is incorrect and should be skipped for extinct gametes.