### PR TITLE
Fix multilocus sugar sampling

### DIFF
--- a/fwdpp/sugar/poptypes/multiloc.hpp
+++ b/fwdpp/sugar/poptypes/multiloc.hpp
@@ -93,13 +93,6 @@ namespace KTfwd
                                         0, 0))),
                   locus_boundaries(locus_boundaries_)
             {
-                if (locus_boundaries.empty())
-                    {
-                        for (uint_t i = 0; i < __nloci; ++i)
-                            {
-                                this->locus_boundaries.emplace_back(i, i + 1);
-                            }
-                    }
             }
 
             template <typename diploids_input, typename gametes_input,

--- a/fwdpp/sugar/sampling.hpp
+++ b/fwdpp/sugar/sampling.hpp
@@ -210,7 +210,7 @@ namespace KTfwd
                     "locus boundaries required when adding fixations");
             }
         if (individuals.empty())
-            return sample_t();
+            return std::vector<sample_t>();
         if (std::find_if(
                 individuals.begin(), individuals.end(),
                 [&p](const unsigned &u) { return u >= p.diploids.size(); })

--- a/fwdpp/sugar/sampling/sampling_details.hpp
+++ b/fwdpp/sugar/sampling/sampling_details.hpp
@@ -126,7 +126,7 @@ namespace KTfwd
         for (std::size_t i = 0; i < sample.size(); ++i)
             {
                 finish_sample(sample[i], fixations, nsam, removeFixed,
-                              sugar::treat_neutral::ALL, locus_boundaries[i]);
+                              sugar::treat_neutral::ALL, locus_boundaries.at(i));
             }
     }
 
@@ -142,10 +142,10 @@ namespace KTfwd
             {
                 finish_sample(sample[i].first, fixations, nsam, removeFixed,
                               sugar::treat_neutral::NEUTRAL,
-                              locus_boundaries[i]);
+                              locus_boundaries.at(i));
                 finish_sample(sample[i].second, fixations, nsam, removeFixed,
                               sugar::treat_neutral::SELECTED,
-                              locus_boundaries[i]);
+                              locus_boundaries.at(i));
             }
     }
 

--- a/fwdpp/sugar/sampling/sampling_details.hpp
+++ b/fwdpp/sugar/sampling/sampling_details.hpp
@@ -174,7 +174,7 @@ namespace KTfwd
         const std::vector<std::pair<double, double>> &locus_boundaries)
     {
         auto temp = fwdpp_internal::ms_sample_separate_mlocus(
-            p.mutations, p.gamtes, p.diploids, individuals,
+            p.mutations, p.gametes, p.diploids, individuals,
             2 * individuals.size(), removeFixed);
         if (!removeFixed && temp.size() != locus_boundaries.size())
             {
@@ -189,8 +189,12 @@ namespace KTfwd
                 std::move(i.second.begin(), i.second.end(),
                           std::back_inserter(rv[j]));
             }
-        finish_sample(rv, p.fixations, 2 * individuals.size(), removeFixed,
-                      sugar::treat_neutral::ALL);
+        for(std::size_t i = 0 ; i < locus_boundaries.size() ; ++i)
+            {
+                finish_sample(rv.at(i), p.fixations, 2 * individuals.size(),
+                              removeFixed, sugar::treat_neutral::ALL,
+                              locus_boundaries.at(i));
+            }
         return rv;
     }
 }

--- a/testsuite/fixtures/sugar_fixtures.hpp
+++ b/testsuite/fixtures/sugar_fixtures.hpp
@@ -79,7 +79,7 @@ class multiloc_popgenmut_fixture
 {
   private:
     std::vector<KTfwd::extensions::discrete_mut_model>
-    fill_vdmm()
+    fill_vdmm(std::vector<std::pair<double,double>> & locus_boundaries)
     {
         double length = 10.;
         // create a vector of extensions::discrete_mut_model
@@ -87,6 +87,7 @@ class multiloc_popgenmut_fixture
         for (unsigned i = 0; i < 4; ++i)
             {
                 double begin = static_cast<double>(i) * length;
+                locus_boundaries.push_back(std::make_pair(begin,begin+length));
                 KTfwd::extensions::discrete_mut_model dmm(
                     { begin }, { begin + length }, { 1. }, {}, {}, {}, {});
                 vdmm_.emplace_back(std::move(dmm));
@@ -219,7 +220,7 @@ class multiloc_popgenmut_fixture
                                 4., std::placeholders::_1,
                                 std::placeholders::_2,
                                 std::placeholders::_3) }),
-          vdmm(this->fill_vdmm()),
+          vdmm(this->fill_vdmm(pop.locus_boundaries)),
           vdrm(this->fill_vdrm())
     {
     }

--- a/testsuite/unit/sugar_samplingTest.cc
+++ b/testsuite/unit/sugar_samplingTest.cc
@@ -3,9 +3,11 @@
   \ingroup unit
   \brief Testing KTfwd::sample and KTfwd::sample_separate
 */
+
 #include <config.h>
 #include <boost/test/unit_test.hpp>
 #include <testsuite/fixtures/sugar_fixtures.hpp>
+#include <testsuite/util/quick_evolve_sugar.hpp>
 #include <fwdpp/sugar/sampling.hpp>
 #include <fwdpp/sugar/GSLrng_t.hpp>
 #include <fwdpp/debug.hpp>
@@ -236,6 +238,21 @@ BOOST_AUTO_TEST_CASE(multilocus_test_sep_empty)
             BOOST_REQUIRE(i.first.empty() == true);
             BOOST_REQUIRE(i.second.empty() == true);
         }
+}
+
+BOOST_AUTO_TEST_CASE(multilocus_test_sampling)
+{
+    simulate_mlocuspop(pop, rng, mutmodels, recmodels, multilocus_additive(),
+                       mu, rbw, generation);
+    auto s = KTfwd::sample_separate(rng.get(), pop, 20, true);
+    s = KTfwd::sample_separate(rng.get(), pop, 20, false);
+    auto s2 = KTfwd::sample(rng.get(), pop, 20, true);
+    s2 = KTfwd::sample(rng.get(), pop, 20, false);
+    pop.locus_boundaries.clear();
+    BOOST_REQUIRE_THROW(s = KTfwd::sample_separate(rng.get(), pop, 20, false),
+                        std::runtime_error);
+    BOOST_REQUIRE_THROW(s2 = KTfwd::sample(rng.get(), pop, 20, false),
+                        std::runtime_error);
 }
 
 BOOST_AUTO_TEST_CASE(multilocus_test_empty)


### PR DESCRIPTION
This PR addresses #69.  It also fixes errors in sampling from multilocus populations.  These errors resulted in failure to compile and not in runtime errors.