### PR TITLE
Generalized rec rate variation

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -291,6 +291,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/examples/K_linked_regions_generalized_rec.cc
+++ b/examples/K_linked_regions_generalized_rec.cc
@@ -1,0 +1,111 @@
+/*! \include K_linked_regions_generalized_rec.cc
+  Simple example building up variation in recombination
+  rate using KTfwd::general_rec_variation
+*/
+
+#include <iostream>
+#include <fwdpp/diploid.hh>
+#ifdef HAVE_LIBSEQUENCE
+#include <Sequence/SimData.hpp>
+#endif
+#include <vector>
+#include <list>
+#include <sstream>
+// Use mutation model from sugar layer
+#include <fwdpp/sugar/infsites.hpp>
+#include <fwdpp/sugar/sampling.hpp>
+using mtype = KTfwd::popgenmut;
+#define SINGLEPOP_SIM
+#include <common_ind.hpp>
+
+int
+main(int argc, char **argv)
+{
+    int argument = 1;
+    if (argc != 8)
+        {
+            std::cerr << "Incorrect number of arguments.\n"
+                      << "Usage:\n"
+                      << argv[0] << " N theta rho rbw K ngens seed\n"
+                      << "Where:\n"
+                      << "N = population size (number of diploids)\n"
+                      << "theta = 4Nu, the scaled neutral mutation "
+                         "rate,summed over all loci\n"
+                      << "rho = 4Nr, the scale recombination rate, summed "
+                         "over all loci\n"
+                      << "rbw = the recombination rate between locus i and "
+                         "i+1, constant for all i.\n"
+                      << "K = the number of loci in the simulation\n"
+                      << "ngens = length of simulation in generatios\n"
+                      << "seed = seed value for random number generations\n";
+            std::exit(0);
+        }
+    const unsigned N = atoi(argv[argument++]);   // Number of diploids
+    const double theta = atof(argv[argument++]); // 4*n*mutation rate.  Note:
+    // mutation rate is per
+    // REGION, not SITE!!
+    const double rho = atof(argv[argument++]); // 4*n*recombination rate.
+    // Note: recombination rate is
+    // per REGION, not SITE!!
+    const double rbw = atof(argv[argument++]); // rec rate b/w loci.
+    const unsigned K = atoi(argv[argument++]); // Number of loci in simulation
+    const unsigned ngens = atoi(argv[argument++]); //# generations to simulatae
+    const unsigned seed
+        = atoi(argv[argument++]); // Number of loci in simulation
+
+	const double mu = theta/double(4*N);
+
+    /*
+      littler r is the recombination rate per region per generation.
+    */
+    const double littler = rho / double(4 * N * K);
+
+    // Initiate random number generation system
+    GSLrng r(seed);
+
+    unsigned twoN = 2 * N;
+
+    singlepop_t pop(N);
+    pop.mutations.reserve(
+        size_t(2 * std::ceil(std::log(2 * N) * (theta) + 0.667 * (theta))));
+    unsigned generation = 0;
+    double wbar;
+
+    KTfwd::general_rec_variation recvar;
+    for (unsigned i = 0; i < K; ++i)
+        {
+            recvar.recmap.push_back(
+                KTfwd::poisson_interval(r.get(), littler, i, i + 1.0));
+            if (i)
+                {
+                    recvar.recmap.push_back(
+                        KTfwd::crossover_point(r.get(), rbw, i + 1.0, false));
+                }
+        }
+
+    for (generation = 0; generation < ngens; ++generation)
+        {
+            // Iterate the population through 1 generation
+            KTfwd::sample_diploid(
+                r.get(), pop.gametes, pop.diploids, pop.mutations, pop.mcounts,
+                N,mu, std::bind(KTfwd::infsites(), std::placeholders::_1,
+                             std::placeholders::_2, r.get(),
+                             std::ref(pop.mut_lookup), generation, mu, 0.,
+                             [&r,K]() { return gsl_ran_flat(r.get(),0.,double(K)); },
+                             []() { return 0.; }, []() { return 0.; }),
+                recvar, std::bind(KTfwd::multiplicative_diploid(),
+                                  std::placeholders::_1, std::placeholders::_2,
+                                  std::placeholders::_3, 2.),
+                pop.neutral, pop.selected);
+            assert(check_sum(pop.gametes, K * twoN));
+            KTfwd::update_mutations(pop.mutations, pop.fixations,
+                                    pop.fixation_times, pop.mut_lookup,
+                                    pop.mcounts, generation, 2 * N);
+        }
+    auto x = KTfwd::ms_sample(r.get(), pop.mutations, pop.gametes,
+                              pop.diploids, 10, true);
+#ifdef HAVE_LIBSEQUENCE
+    Sequence::SimData a(x.begin(), x.end());
+    std::cout << a << '\n';
+#endif
+}

--- a/examples/K_linked_regions_generalized_rec.cc
+++ b/examples/K_linked_regions_generalized_rec.cc
@@ -93,9 +93,7 @@ main(int argc, char **argv)
                              std::ref(pop.mut_lookup), generation, mu, 0.,
                              [&r,K]() { return gsl_ran_flat(r.get(),0.,double(K)); },
                              []() { return 0.; }, []() { return 0.; }),
-                recvar, std::bind(KTfwd::multiplicative_diploid(),
-                                  std::placeholders::_1, std::placeholders::_2,
-                                  std::placeholders::_3, 2.),
+                recvar, KTfwd::multiplicative_diploid(),
                 pop.neutral, pop.selected);
             assert(check_sum(pop.gametes, K * twoN));
             KTfwd::update_mutations(pop.mutations, pop.fixations,

--- a/examples/K_linked_regions_multilocus.cc
+++ b/examples/K_linked_regions_multilocus.cc
@@ -142,17 +142,8 @@ main(int argc, char **argv)
         }
     auto x = KTfwd::ms_sample(r.get(), pop.mutations, pop.gametes,
                               pop.diploids, 10, true);
-    for (auto &f : pop.fixations)
-        std::cout << f.pos << ' ';
-    std::cout << '\n';
 #ifdef HAVE_LIBSEQUENCE
     for (auto &i : x)
-        {
-            Sequence::SimData a(i.begin(), i.end());
-            std::cout << a << '\n';
-        }
-    auto y = KTfwd::sample(r.get(), pop, 10, false);
-    for (auto &&i : y)
         {
             Sequence::SimData a(i.begin(), i.end());
             std::cout << a << '\n';

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -8,6 +8,7 @@ noinst_PROGRAMS=	diploid_ind \
 	diploid_ind_2locus \
 	K_linked_regions_multilocus \
 	K_linked_regions_extensions \
+	K_linked_regions_generalized_rec \
 	HOC_ind 
 
 #	migsel_split_ind 
@@ -22,6 +23,7 @@ bneck_selection_ind_SOURCES=bneck_selection_ind.cc common_ind.hpp
 diploid_ind_2locus_SOURCES=diploid_ind_2locus.cc common_ind.hpp
 K_linked_regions_multilocus_SOURCES=K_linked_regions_multilocus.cc common_ind.hpp
 K_linked_regions_extensions_SOURCES=K_linked_regions_extensions.cc common_ind.hpp
+K_linked_regions_generalized_rec_SOURCES=K_linked_regions_generalized_rec.cc common_ind.hpp
 HOC_ind_SOURCES=HOC_ind.cc
 
 AM_CPPFLAGS=-Wall -W -I.

--- a/examples/Makefile.in
+++ b/examples/Makefile.in
@@ -325,6 +325,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/examples/Makefile.in
+++ b/examples/Makefile.in
@@ -91,7 +91,8 @@ noinst_PROGRAMS = diploid_ind$(EXEEXT) diploid_binaryIO_ind$(EXEEXT) \
 	migsel_ind$(EXEEXT) migsel_split_ind_list$(EXEEXT) \
 	bneck_selection_ind$(EXEEXT) diploid_ind_2locus$(EXEEXT) \
 	K_linked_regions_multilocus$(EXEEXT) \
-	K_linked_regions_extensions$(EXEEXT) HOC_ind$(EXEEXT)
+	K_linked_regions_extensions$(EXEEXT) \
+	K_linked_regions_generalized_rec$(EXEEXT) HOC_ind$(EXEEXT)
 @HAVE_LIBSEQ_RUNTIME_TRUE@@HAVE_SIMDATA_HPP_TRUE@am__append_1 = -DHAVE_LIBSEQUENCE
 @DEBUG_FALSE@am__append_2 = -DNDEBUG
 subdir = examples
@@ -116,6 +117,12 @@ K_linked_regions_extensions_OBJECTS =  \
 	$(am_K_linked_regions_extensions_OBJECTS)
 K_linked_regions_extensions_LDADD = $(LDADD)
 K_linked_regions_extensions_DEPENDENCIES =
+am_K_linked_regions_generalized_rec_OBJECTS =  \
+	K_linked_regions_generalized_rec.$(OBJEXT)
+K_linked_regions_generalized_rec_OBJECTS =  \
+	$(am_K_linked_regions_generalized_rec_OBJECTS)
+K_linked_regions_generalized_rec_LDADD = $(LDADD)
+K_linked_regions_generalized_rec_DEPENDENCIES =
 am_K_linked_regions_multilocus_OBJECTS =  \
 	K_linked_regions_multilocus.$(OBJEXT)
 K_linked_regions_multilocus_OBJECTS =  \
@@ -196,6 +203,7 @@ am__v_CCLD_ = $(am__v_CCLD_@AM_DEFAULT_V@)
 am__v_CCLD_0 = @echo "  CCLD    " $@;
 am__v_CCLD_1 = 
 SOURCES = $(HOC_ind_SOURCES) $(K_linked_regions_extensions_SOURCES) \
+	$(K_linked_regions_generalized_rec_SOURCES) \
 	$(K_linked_regions_multilocus_SOURCES) \
 	$(bneck_selection_ind_SOURCES) $(diploid_binaryIO_ind_SOURCES) \
 	$(diploid_fixed_sh_ind_SOURCES) \
@@ -204,6 +212,7 @@ SOURCES = $(HOC_ind_SOURCES) $(K_linked_regions_extensions_SOURCES) \
 	$(migsel_split_ind_list_SOURCES)
 DIST_SOURCES = $(HOC_ind_SOURCES) \
 	$(K_linked_regions_extensions_SOURCES) \
+	$(K_linked_regions_generalized_rec_SOURCES) \
 	$(K_linked_regions_multilocus_SOURCES) \
 	$(bneck_selection_ind_SOURCES) $(diploid_binaryIO_ind_SOURCES) \
 	$(diploid_fixed_sh_ind_SOURCES) \
@@ -346,6 +355,7 @@ bneck_selection_ind_SOURCES = bneck_selection_ind.cc common_ind.hpp
 diploid_ind_2locus_SOURCES = diploid_ind_2locus.cc common_ind.hpp
 K_linked_regions_multilocus_SOURCES = K_linked_regions_multilocus.cc common_ind.hpp
 K_linked_regions_extensions_SOURCES = K_linked_regions_extensions.cc common_ind.hpp
+K_linked_regions_generalized_rec_SOURCES = K_linked_regions_generalized_rec.cc common_ind.hpp
 HOC_ind_SOURCES = HOC_ind.cc
 AM_CPPFLAGS = -Wall -W -I. $(am__append_2)
 AM_CXXFLAGS = $(am__append_1)
@@ -396,6 +406,10 @@ K_linked_regions_extensions$(EXEEXT): $(K_linked_regions_extensions_OBJECTS) $(K
 	@rm -f K_linked_regions_extensions$(EXEEXT)
 	$(AM_V_CXXLD)$(CXXLINK) $(K_linked_regions_extensions_OBJECTS) $(K_linked_regions_extensions_LDADD) $(LIBS)
 
+K_linked_regions_generalized_rec$(EXEEXT): $(K_linked_regions_generalized_rec_OBJECTS) $(K_linked_regions_generalized_rec_DEPENDENCIES) $(EXTRA_K_linked_regions_generalized_rec_DEPENDENCIES) 
+	@rm -f K_linked_regions_generalized_rec$(EXEEXT)
+	$(AM_V_CXXLD)$(CXXLINK) $(K_linked_regions_generalized_rec_OBJECTS) $(K_linked_regions_generalized_rec_LDADD) $(LIBS)
+
 K_linked_regions_multilocus$(EXEEXT): $(K_linked_regions_multilocus_OBJECTS) $(K_linked_regions_multilocus_DEPENDENCIES) $(EXTRA_K_linked_regions_multilocus_DEPENDENCIES) 
 	@rm -f K_linked_regions_multilocus$(EXEEXT)
 	$(AM_V_CXXLD)$(CXXLINK) $(K_linked_regions_multilocus_OBJECTS) $(K_linked_regions_multilocus_LDADD) $(LIBS)
@@ -440,6 +454,7 @@ distclean-compile:
 
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/HOC_ind.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/K_linked_regions_extensions.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/K_linked_regions_generalized_rec.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/K_linked_regions_multilocus.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/bneck_selection_ind.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/diploid_binaryIO_ind.Po@am__quote@

--- a/experimental_examples/Makefile.in
+++ b/experimental_examples/Makefile.in
@@ -257,6 +257,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/fwdpp/Makefile.am
+++ b/fwdpp/Makefile.am
@@ -11,6 +11,7 @@ pkginclude_HEADERS=debug.hpp \
 	IO.tcc \
 	mutation.hpp \
 	mutation.tcc \
+	poisson_xover.hpp \
 	recombination.hpp \
 	recombination.tcc \
 	sample_diploid.hpp \

--- a/fwdpp/Makefile.am
+++ b/fwdpp/Makefile.am
@@ -12,6 +12,7 @@ pkginclude_HEADERS=debug.hpp \
 	mutation.hpp \
 	mutation.tcc \
 	poisson_xover.hpp \
+	general_rec_variation.hpp \
 	recombination.hpp \
 	recombination.tcc \
 	sample_diploid.hpp \

--- a/fwdpp/Makefile.in
+++ b/fwdpp/Makefile.in
@@ -298,6 +298,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
@@ -317,6 +318,7 @@ pkginclude_HEADERS = debug.hpp \
 	IO.tcc \
 	mutation.hpp \
 	mutation.tcc \
+	poisson_xover.hpp \
 	recombination.hpp \
 	recombination.tcc \
 	sample_diploid.hpp \

--- a/fwdpp/Makefile.in
+++ b/fwdpp/Makefile.in
@@ -319,6 +319,7 @@ pkginclude_HEADERS = debug.hpp \
 	mutation.hpp \
 	mutation.tcc \
 	poisson_xover.hpp \
+	general_rec_variation.hpp \
 	recombination.hpp \
 	recombination.tcc \
 	sample_diploid.hpp \

--- a/fwdpp/diploid.hh
+++ b/fwdpp/diploid.hh
@@ -34,6 +34,7 @@
 #include <fwdpp/util.hpp>
 #include <fwdpp/IO.hpp>
 #include <fwdpp/recombination.hpp>
+#include <fwdpp/poisson_xover.hpp>
 #include <fwdpp/interlocus_recombination.hpp>
 #include <fwdpp/sample_diploid.hpp>
 #include <fwdpp/demography.hpp>

--- a/fwdpp/diploid.hh
+++ b/fwdpp/diploid.hh
@@ -34,6 +34,7 @@
 #include <fwdpp/util.hpp>
 #include <fwdpp/IO.hpp>
 #include <fwdpp/recombination.hpp>
+#include <fwdpp/general_rec_variation.hpp>
 #include <fwdpp/poisson_xover.hpp>
 #include <fwdpp/interlocus_recombination.hpp>
 #include <fwdpp/sample_diploid.hpp>

--- a/fwdpp/experimental/Makefile.in
+++ b/fwdpp/experimental/Makefile.in
@@ -256,6 +256,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/fwdpp/extensions/Makefile.in
+++ b/fwdpp/extensions/Makefile.in
@@ -256,6 +256,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/fwdpp/general_rec_variation.hpp
+++ b/fwdpp/general_rec_variation.hpp
@@ -13,6 +13,12 @@
 namespace KTfwd
 {
     struct poisson_interval
+    /*!
+	 * Define an interval in which
+	 * recombination events occur at a
+	 * Poisson rate and generate breakpoint
+	 * positions uniformly
+	 */
     {
         const gsl_rng* r;
         const double mean, minpos, maxpos;
@@ -51,11 +57,25 @@ namespace KTfwd
     };
 
     struct crossover_point
+    /*!
+	 * A callable object that returns a recombination
+	 * breakpoint at a specific position with a 
+	 * given probability
+	 */
     {
         const gsl_rng* r;
         const double prob, pos;
         crossover_point(const gsl_rng* r_, const double rate,
                         const double pos_, const double poisson = true)
+            /*!
+			 * \param r_ A gsl_rng that must be initialized.
+			 * \param rate_ The crossover rate. See note below.
+			 * \param pos_ The crossover position to return.
+			 * \param poisson Whether \a rate represents a Poisson process (true) or a binomial process (false).
+			 *
+			 * \note If \a poisson is true, it is converted into a probability of 
+			 * recombination using Haldane's mapping function.
+			 */
             : r{ r_ },
               prob{ (poisson) ? 0.5 * (1. - std::exp(-2.0 * rate)) : rate },
               pos{ pos_ }
@@ -89,6 +109,12 @@ namespace KTfwd
     };
 
     struct general_rec_variation
+    /*!
+	 * A generalized genetic map.
+	 * It holds a vector of functions that add recombination
+	 * breakpoints to a vector.  Examples of such functions
+	 * are KTfwd::poisson_interval and KTfwd::crossover_point.
+	 */
     {
         std::vector<std::function<void(std::vector<double>&)>> recmap;
 

--- a/fwdpp/general_rec_variation.hpp
+++ b/fwdpp/general_rec_variation.hpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <limits>
 #include <cmath>
+#include <stdexcept>
 #include <gsl/gsl_rng.h>
 #include <gsl/gsl_randist.h>
 
@@ -19,6 +20,22 @@ namespace KTfwd
                          const double minpos_, const double maxpos_)
             : r{ r_ }, mean{ mean_ }, minpos{ minpos_ }, maxpos{ maxpos_ }
         {
+            if (r == nullptr)
+                {
+                    throw std::invalid_argument("rng cannot be null pointer");
+                }
+            if (!std::isfinite(mean))
+                {
+                    throw std::invalid_argument("mean must be finite");
+                }
+            if (!std::isfinite(minpos))
+                {
+                    throw std::invalid_argument("minpos must be finite");
+                }
+            if (!std::isfinite(maxpos))
+                {
+                    throw std::invalid_argument("maxpos must be finite");
+                }
         }
 
         inline void
@@ -33,32 +50,32 @@ namespace KTfwd
         }
     };
 
-    struct poisson_point
+    struct crossover_point
     {
         const gsl_rng* r;
         const double prob, pos;
-        poisson_point(const gsl_rng* r_, const double rate, const double pos_)
-            : r{ r_ }, prob{ 0.5 * (1. - std::exp(-2.0 * rate)) }, pos{ pos_ }
+        crossover_point(const gsl_rng* r_, const double rate,
+                        const double pos_, const double poisson = true)
+            : r{ r_ },
+              prob{ (poisson) ? 0.5 * (1. - std::exp(-2.0 * rate)) : rate },
+              pos{ pos_ }
         {
-        }
-
-        inline void
-        operator()(std::vector<double>& breakpoints) const
-        {
-            if (gsl_ran_binomial(r, prob, 1))
+            if (r == nullptr)
                 {
-                    breakpoints.push_back(pos);
+                    throw std::invalid_argument("rng cannot be null pointer");
                 }
-        }
-    };
-
-    struct binomial_point
-    {
-        const gsl_rng* r;
-        const double prob, pos;
-        binomial_point(const gsl_rng* r_, const double prob_, const double pos_)
-            : r{ r_ }, prob{ prob_ }, pos{ pos_ }
-        {
+            if (!std::isfinite(rate))
+                {
+                    throw std::invalid_argument("rate must be finite");
+                }
+            if (!std::isfinite(prob))
+                {
+                    throw std::invalid_argument("prob must be finite");
+                }
+            if (!std::isfinite(pos))
+                {
+                    throw std::invalid_argument("pos must be finite");
+                }
         }
 
         inline void

--- a/fwdpp/general_rec_variation.hpp
+++ b/fwdpp/general_rec_variation.hpp
@@ -1,0 +1,91 @@
+#ifndef FWDPP_GENERAL_REC_VARIATION_HPP__
+#define FWDPP_GENERAL_REC_VARIATION_HPP__
+
+#include <vector>
+#include <functional>
+#include <algorithm>
+#include <limits>
+#include <cmath>
+#include <gsl/gsl_rng.h>
+#include <gsl/gsl_randist.h>
+
+namespace KTfwd
+{
+    struct poisson_interval
+    {
+        const gsl_rng* r;
+        const double mean, minpos, maxpos;
+        poisson_interval(const gsl_rng* r_, const double mean_,
+                         const double minpos_, const double maxpos_)
+            : r{ r_ }, mean{ mean_ }, minpos{ minpos_ }, maxpos{ maxpos_ }
+        {
+        }
+
+        inline void
+        operator()(std::vector<double>& breakpoints) const
+        {
+            auto nbreaks = gsl_ran_poisson(r, mean);
+            for (decltype(nbreaks) i = 0; i < nbreaks; ++i)
+                {
+                    double pos = gsl_ran_flat(r, minpos, maxpos);
+                    breakpoints.push_back(pos);
+                }
+        }
+    };
+
+    struct poisson_point
+    {
+        const double prob, pos;
+        poisson_point(const double rate, const double pos_)
+            : prob{ 0.5 * (1. - std::exp(-2.0 * rate)) }, pos{ pos_ }
+        {
+        }
+
+        inline void
+        operator()(std::vector<double>& breakpoints) const
+        {
+            if (gsl_ran_binomial(r, prob, 1))
+                {
+                    breakpoints.push_back(pos);
+                }
+        }
+    };
+
+    struct binomial_point
+    {
+        const double prob, pos;
+        poisson_point(const double prob_, const double pos_)
+            : prob{ prob_ }, pos{ pos_ }
+        {
+        }
+
+        inline void
+        operator()(std::vector<double>& breakpoints) const
+        {
+            if (gsl_ran_binomial(r, prob, 1))
+                {
+                    breakpoints.push_back(pos);
+                }
+        }
+    };
+
+    struct general_rec_variation
+    {
+        std::vector<std::function<void(std::vector<double>&)>> recmap;
+
+        inline std::vector<double>
+        operator()() const
+        {
+            std::vector<double> breakpoints;
+            for (const auto& f : recmap)
+                {
+                    f(breakpoints);
+                }
+            std::sort(f.begin(), f.end());
+            breakpoints.push_back(std::numeric_limits<double>::max());
+            return breakpoints;
+        }
+    };
+}
+
+#endif

--- a/fwdpp/general_rec_variation.hpp
+++ b/fwdpp/general_rec_variation.hpp
@@ -44,8 +44,10 @@ namespace KTfwd
                 }
         }
 
+        template <typename... args>
         inline void
-        operator()(std::vector<double>& breakpoints) const
+        operator()(std::vector<double>& breakpoints, args&&...) const
+        /// Variadic to be combatible with richer recombination policy requirements
         {
             auto nbreaks = gsl_ran_poisson(r, mean);
             for (decltype(nbreaks) i = 0; i < nbreaks; ++i)
@@ -98,8 +100,10 @@ namespace KTfwd
                 }
         }
 
+        template <typename... args>
         inline void
-        operator()(std::vector<double>& breakpoints) const
+        operator()(std::vector<double>& breakpoints, args&&...) const
+        /// Variadic to be combatible with richer recombination policy requirements
         {
             if (gsl_ran_binomial(r, prob, 1))
                 {

--- a/fwdpp/general_rec_variation.hpp
+++ b/fwdpp/general_rec_variation.hpp
@@ -35,9 +35,10 @@ namespace KTfwd
 
     struct poisson_point
     {
+        const gsl_rng* r;
         const double prob, pos;
-        poisson_point(const double rate, const double pos_)
-            : prob{ 0.5 * (1. - std::exp(-2.0 * rate)) }, pos{ pos_ }
+        poisson_point(const gsl_rng* r_, const double rate, const double pos_)
+            : r{ r_ }, prob{ 0.5 * (1. - std::exp(-2.0 * rate)) }, pos{ pos_ }
         {
         }
 
@@ -53,9 +54,10 @@ namespace KTfwd
 
     struct binomial_point
     {
+        const gsl_rng* r;
         const double prob, pos;
-        poisson_point(const double prob_, const double pos_)
-            : prob{ prob_ }, pos{ pos_ }
+        binomial_point(const gsl_rng* r_, const double prob_, const double pos_)
+            : r{ r_ }, prob{ prob_ }, pos{ pos_ }
         {
         }
 
@@ -81,7 +83,7 @@ namespace KTfwd
                 {
                     f(breakpoints);
                 }
-            std::sort(f.begin(), f.end());
+            std::sort(breakpoints.begin(), breakpoints.end());
             breakpoints.push_back(std::numeric_limits<double>::max());
             return breakpoints;
         }

--- a/fwdpp/general_rec_variation.hpp
+++ b/fwdpp/general_rec_variation.hpp
@@ -30,6 +30,10 @@ namespace KTfwd
                 {
                     throw std::invalid_argument("rng cannot be null pointer");
                 }
+            if (mean < 0.)
+                {
+                    throw std::invalid_argument("mean must be non-negative");
+                }
             if (!std::isfinite(mean))
                 {
                     throw std::invalid_argument("mean must be finite");
@@ -82,6 +86,11 @@ namespace KTfwd
               prob{ (poisson) ? 0.5 * (1. - std::exp(-2.0 * rate)) : rate },
               pos{ pos_ }
         {
+            if (rate < 0. || prob < 0.)
+                {
+                    throw std::invalid_argument(
+                        "recombination probability must be non-negative");
+                }
             if (r == nullptr)
                 {
                     throw std::invalid_argument("rng cannot be null pointer");

--- a/fwdpp/general_rec_variation.hpp
+++ b/fwdpp/general_rec_variation.hpp
@@ -131,6 +131,10 @@ namespace KTfwd
     {
         std::vector<std::function<void(std::vector<double>&)>> recmap;
 
+        general_rec_variation() : recmap{}
+        {
+        }
+
         inline std::vector<double>
         operator()() const
         {

--- a/fwdpp/internal/Makefile.in
+++ b/fwdpp/internal/Makefile.in
@@ -256,6 +256,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/fwdpp/internal/type_traits.hpp
+++ b/fwdpp/internal/type_traits.hpp
@@ -195,8 +195,9 @@ namespace KTfwd
 
             template <typename gcont_t_or_gamete_t, typename mcont_t>
             struct rich_recmodel_t<gcont_t_or_gamete_t, mcont_t,
-                              typename void_t<typename gcont_t_or_gamete_t::
-                                                  value_type>::type>
+                                   typename void_t<
+                                       typename gcont_t_or_gamete_t::
+                                           value_type>::type>
             {
                 using type = typename std::
                     conditional<is_gamete<typename gcont_t_or_gamete_t::
@@ -211,34 +212,36 @@ namespace KTfwd
             };
 
             template <typename recmodel_t, typename gamete_t, typename mcont_t,
-                      typename = void>
+                      typename = void, typename = void, typename = void>
             struct is_rec_model : std::false_type
-            {
-            };
-
-            template <typename recmodel_t, typename gamete_t, typename mcont_t>
-            struct dispatchable_rec_model
-                : std::is_same<
-                      typename std::result_of<decltype (
-                          &dispatch_recombination_policy<const recmodel_t &,
-                                                         const gamete_t &,
-                                                         const gamete_t &,
-                                                         const mcont_t &>)(
-                          const recmodel_t &, const gamete_t &,
-                          const gamete_t &, const mcont_t &)>::type,
-                      std::vector<double>>
             {
             };
 
             template <typename recmodel_t, typename gamete_t, typename mcont_t>
             struct is_rec_model<recmodel_t, gamete_t, mcont_t,
                                 typename void_t<
-                                    typename mcont_t::value_type>::type>
-                : std::
-                      integral_constant<bool,
-                                        dispatchable_rec_model<recmodel_t,
-                                                               gamete_t,
-                                                               mcont_t>::value>
+                                    typename std::result_of<recmodel_t()>::
+                                        type>::type,
+                                typename std::enable_if<is_gamete<gamete_t>::
+                                                            value>::type,
+                                typename std::enable_if<is_mutation<
+                                    typename mcont_t::value_type>::value>::
+                                    type> : std::true_type
+            {
+            };
+
+            template <typename recmodel_t, typename gamete_t, typename mcont_t>
+            struct is_rec_model<recmodel_t, gamete_t, mcont_t,
+                                typename void_t<
+                                    typename std::result_of<recmodel_t(
+                                        const gamete_t &, const gamete_t &,
+                                        const mcont_t &)>::type>::type,
+                                typename std::enable_if<is_gamete<gamete_t>::
+                                                            value>::type,
+                                typename std::enable_if<is_mutation<
+                                    typename mcont_t::value_type>::value>::
+                                    type> : std::true_type
+
             {
             };
 

--- a/fwdpp/internal/type_traits.hpp
+++ b/fwdpp/internal/type_traits.hpp
@@ -211,17 +211,21 @@ namespace KTfwd
                                 void>::type;
             };
 
-            template <typename recmodel_t, typename gamete_t, typename mcont_t,
+            template <typename recmodel_t, typename diploid_t,
+                      typename gamete_t, typename mcont_t, typename = void,
                       typename = void, typename = void, typename = void>
             struct is_rec_model : std::false_type
             {
             };
 
-            template <typename recmodel_t, typename gamete_t, typename mcont_t>
-            struct is_rec_model<recmodel_t, gamete_t, mcont_t,
+            template <typename recmodel_t, typename diploid_t,
+                      typename gamete_t, typename mcont_t>
+            struct is_rec_model<recmodel_t, diploid_t, gamete_t, mcont_t,
                                 typename void_t<
                                     typename std::result_of<recmodel_t()>::
                                         type>::type,
+                                typename std::enable_if<is_diploid<diploid_t>::
+                                                            value>::type,
                                 typename std::enable_if<is_gamete<gamete_t>::
                                                             value>::type,
                                 typename std::enable_if<is_mutation<
@@ -230,18 +234,38 @@ namespace KTfwd
             {
             };
 
-            template <typename recmodel_t, typename gamete_t, typename mcont_t>
-            struct is_rec_model<recmodel_t, gamete_t, mcont_t,
+            template <typename recmodel_t, typename diploid_t,
+                      typename gamete_t, typename mcont_t>
+            struct is_rec_model<recmodel_t, diploid_t, gamete_t, mcont_t,
                                 typename void_t<
                                     typename std::result_of<recmodel_t(
                                         const gamete_t &, const gamete_t &,
                                         const mcont_t &)>::type>::type,
+                                typename std::enable_if<is_diploid<diploid_t>::
+                                                            value>::type,
                                 typename std::enable_if<is_gamete<gamete_t>::
                                                             value>::type,
                                 typename std::enable_if<is_mutation<
                                     typename mcont_t::value_type>::value>::
                                     type> : std::true_type
+            {
+            };
 
+            template <typename recmodel_t, typename diploid_t,
+                      typename gamete_t, typename mcont_t>
+            struct is_rec_model<recmodel_t, diploid_t, gamete_t, mcont_t,
+                                typename void_t<
+                                    typename std::result_of<recmodel_t(
+                                        const diploid_t &, const gamete_t &,
+                                        const gamete_t &,
+                                        const mcont_t &)>::type>::type,
+                                typename std::enable_if<is_diploid<diploid_t>::
+                                                            value>::type,
+                                typename std::enable_if<is_gamete<gamete_t>::
+                                                            value>::type,
+                                typename std::enable_if<is_mutation<
+                                    typename mcont_t::value_type>::value>::
+                                    type> : std::true_type
             {
             };
 

--- a/fwdpp/mutate_recombine.hpp
+++ b/fwdpp/mutate_recombine.hpp
@@ -15,7 +15,6 @@
 #include <gsl/gsl_rng.h>
 #include <gsl/gsl_randist.h>
 #include <fwdpp/forward_types.hpp>
-#include <fwdpp/type_traits.hpp>
 #include <fwdpp/internal/mutation_internal.hpp>
 #include <fwdpp/internal/rec_gamete_updater.hpp>
 
@@ -24,7 +23,7 @@ namespace KTfwd
     template <typename recombination_policy, typename... args>
     inline typename std::result_of<recombination_policy()>::type
     dispatch_recombination_policy(const recombination_policy &rec_pol,
-                                  args &&... )
+                                  args &&...)
     {
         return rec_pol();
     }
@@ -36,7 +35,12 @@ namespace KTfwd
     {
         return rec_pol(std::forward<args>(a)...);
     }
+}
 
+#include <fwdpp/type_traits.hpp>
+
+namespace KTfwd
+{
     template <typename recombination_policy, typename gcont_t,
               typename mcont_t>
     std::vector<double>

--- a/fwdpp/mutate_recombine.hpp
+++ b/fwdpp/mutate_recombine.hpp
@@ -21,20 +21,26 @@
 
 namespace KTfwd
 {
-    template <typename recombination_policy, typename... args>
+    template <typename recombination_policy, typename gamete_t,
+              typename mcont_t>
     inline typename std::result_of<recombination_policy()>::type
     dispatch_recombination_policy(const recombination_policy &rec_pol,
-                                  args &&...)
+                                  gamete_t &&, gamete_t &&, mcont_t &&)
     {
         return rec_pol();
     }
 
-    template <typename recombination_policy, typename... args>
-    inline typename std::result_of<recombination_policy(args &&...)>::type
-    dispatch_recombination_policy(const recombination_policy &rec_pol,
-                                  args &&... a)
+    template <typename recombination_policy, typename gamete_t,
+              typename mcont_t>
+    inline
+        typename std::result_of<recombination_policy(gamete_t &&, gamete_t &&,
+                                                     mcont_t &&)>::type
+        dispatch_recombination_policy(const recombination_policy &rec_pol,
+                                      gamete_t &&g1, gamete_t &&g2,
+                                      mcont_t &&mutations)
     {
-        return rec_pol(std::forward<args>(a)...);
+        return rec_pol(std::forward<gamete_t>(g1), std::forward<gamete_t>(g2),
+                       std::forward<mcont_t>(mutations));
     }
 
     template <typename recombination_policy, typename gcont_t,

--- a/fwdpp/mutate_recombine.hpp
+++ b/fwdpp/mutate_recombine.hpp
@@ -14,6 +14,7 @@
 #include <tuple>
 #include <gsl/gsl_rng.h>
 #include <gsl/gsl_randist.h>
+#include <fwdpp/type_traits.hpp>
 #include <fwdpp/forward_types.hpp>
 #include <fwdpp/internal/mutation_internal.hpp>
 #include <fwdpp/internal/rec_gamete_updater.hpp>
@@ -35,12 +36,7 @@ namespace KTfwd
     {
         return rec_pol(std::forward<args>(a)...);
     }
-}
 
-#include <fwdpp/type_traits.hpp>
-
-namespace KTfwd
-{
     template <typename recombination_policy, typename gcont_t,
               typename mcont_t>
     std::vector<double>

--- a/fwdpp/poisson_xover.hpp
+++ b/fwdpp/poisson_xover.hpp
@@ -1,0 +1,60 @@
+#ifndef FWDPP_POISSON_XOVER_HPP__
+#define FWDPP_POISSON_XOVER_HPP__
+
+#include <vector>
+#include <algorithm>
+#include <gsl/gsl_rng.h>
+#include <gsl/gsl_randist.h>
+
+namespace KTfwd
+{
+    struct poisson_xover
+    /*!
+      \brief Simple model of crossing-over.
+      Generates a Poisson-distributed number of recombination breakpoints with
+      mean \a littler that
+      are uniformly-distributed between \a minpos and \a maxpos
+     */
+    {
+        const gsl_rng *r;
+        const double recrate, minpos, maxpos;
+
+        explicit poisson_xover(const gsl_rng *r_, const double recrate_,
+                               const double minpos_, const double maxpos_)
+            : r{ r_ }, recrate{ recrate_ }, minpos{ minpos_ },
+              maxpos{ maxpos_ }
+        /*!
+          \param r A gsl_rng
+          \param littler The recombination rate (per diploid_, per region)
+          \param minpos The minimum recombination position allowed
+          \param maxpos The maximum recombination position allowed
+          the gametes & mutations involve in an x-over.
+         */
+        {
+        }
+
+        poisson_xover(const poisson_xover &) = default;
+        poisson_xover(poisson_xover &&) = default;
+
+        std::vector<double>
+        operator()() const
+        {
+            unsigned nbreaks
+                = (recrate > 0) ? gsl_ran_poisson(r, recrate) : 0u;
+            if (!nbreaks)
+                return {};
+
+            std::vector<double> pos;
+            pos.reserve(nbreaks + 1);
+            for (unsigned i = 0; i < nbreaks; ++i)
+                {
+                    pos.emplace_back(gsl_ran_flat(r, minpos, maxpos));
+                }
+            std::sort(pos.begin(), pos.end());
+            // Note: this is required for all vectors of breakpoints!
+            pos.emplace_back(std::numeric_limits<double>::max());
+            return pos;
+        }
+    };
+}
+#endif

--- a/fwdpp/recombination.hpp
+++ b/fwdpp/recombination.hpp
@@ -55,21 +55,7 @@ namespace KTfwd
             return pos;
         }
 
-        static std::function<std::vector<double>()>
-        bind(const gsl_rng *r, const double recrate, const double minpos,
-             const double maxpos)
-        /*!
-         * Generate a callable function that satisfies concept
-         * of a recombination policy.
-         */
-        {
-            return [p = poisson_xover(r, recrate, minpos, maxpos)]()
-                ->std::vector<double>
-            {
-                return p();
-            };
-        }
-    };
+};
 
     /*!
       Recombine gametes[g1] and gametes[g2] at positions determined by rec_pol

--- a/fwdpp/recombination.hpp
+++ b/fwdpp/recombination.hpp
@@ -7,56 +7,6 @@
 
 namespace KTfwd
 {
-    struct poisson_xover
-    /*!
-      \brief Simple model of crossing-over.
-      Generates a Poisson-distributed number of recombination breakpoints with
-      mean \a littler that
-      are uniformly-distributed between \a minpos and \a maxpos
-     */
-    {
-        const gsl_rng *r;
-        const double recrate, minpos, maxpos;
-
-        explicit poisson_xover(const gsl_rng *r_, const double recrate_,
-                               const double minpos_, const double maxpos_)
-            : r{ r_ }, recrate{ recrate_ }, minpos{ minpos_ },
-              maxpos{ maxpos_ }
-        /*!
-          \param r A gsl_rng
-          \param littler The recombination rate (per diploid_, per region)
-          \param minpos The minimum recombination position allowed
-          \param maxpos The maximum recombination position allowed
-          the gametes & mutations involve in an x-over.
-         */
-        {
-        }
-
-        poisson_xover(const poisson_xover &) = default;
-        poisson_xover(poisson_xover &&) = default;
-
-        std::vector<double>
-        operator()() const
-        {
-            unsigned nbreaks
-                = (recrate > 0) ? gsl_ran_poisson(r, recrate) : 0u;
-            if (!nbreaks)
-                return {};
-
-            std::vector<double> pos;
-            pos.reserve(nbreaks + 1);
-            for (unsigned i = 0; i < nbreaks; ++i)
-                {
-                    pos.emplace_back(gsl_ran_flat(r, minpos, maxpos));
-                }
-            std::sort(pos.begin(), pos.end());
-            // Note: this is required for all vectors of breakpoints!
-            pos.emplace_back(std::numeric_limits<double>::max());
-            return pos;
-        }
-
-};
-
     /*!
       Recombine gametes[g1] and gametes[g2] at positions determined by rec_pol
 

--- a/fwdpp/recombination.tcc
+++ b/fwdpp/recombination.tcc
@@ -50,10 +50,10 @@ namespace KTfwd
                   const recpol_t &rec_pol, const std::size_t g1,
                   const std::size_t g2, const mcont_t &mutations)
     {
-        static_assert(
-            traits::is_rec_model<recpol_t, typename gcont_t::value_type,
-                                 mcont_t>::value,
-            "type recpol_t is not a valid recombination policy");
+        // static_assert(
+        //    traits::is_rec_model<recpol_t, typename gcont_t::value_type,
+        //                         mcont_t>::value,
+        //    "type recpol_t is not a valid recombination policy");
         if (g1 == g2)
             {
                 return std::make_pair(g1, 0u);

--- a/fwdpp/sugar/Makefile.in
+++ b/fwdpp/sugar/Makefile.in
@@ -298,6 +298,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/fwdpp/sugar/gsl/Makefile.in
+++ b/fwdpp/sugar/gsl/Makefile.in
@@ -256,6 +256,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/fwdpp/sugar/poptypes/Makefile.in
+++ b/fwdpp/sugar/poptypes/Makefile.in
@@ -256,6 +256,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/fwdpp/sugar/sampling/Makefile.in
+++ b/fwdpp/sugar/sampling/Makefile.in
@@ -256,6 +256,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/fwdpp/tags/Makefile.in
+++ b/fwdpp/tags/Makefile.in
@@ -256,6 +256,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/fwdpp/type_traits.hpp
+++ b/fwdpp/type_traits.hpp
@@ -102,17 +102,20 @@ namespace KTfwd
          * Wraps a static constant to test that recmodel_t is a valid
          * recombination function/policy
          */
-        template <typename recmodel_t, typename gamete_t, typename mcont_t>
+        template <typename recmodel_t, typename diploid_t, typename gamete_t,
+                  typename mcont_t>
         using is_rec_model
-            = traits::internal::is_rec_model<recmodel_t, gamete_t, mcont_t>;
+            = traits::internal::is_rec_model<recmodel_t, diploid_t, gamete_t,
+                                             mcont_t>;
 
         /*!
          * Convenience wrapper for
          * KTfwd::traits::is_rec_model<recmodel_t,gamete_c,mcont_t>::type
          */
-        template <typename recmodel_t, typename gamete_t, typename mcont_t>
-        using is_rec_model_t =
-            typename is_rec_model<recmodel_t, gamete_t, mcont_t>::type;
+        template <typename recmodel_t, typename diploid_t, typename gamete_t,
+                  typename mcont_t>
+        using is_rec_model_t = typename is_rec_model<recmodel_t, diploid_t,
+                                                     gamete_t, mcont_t>::type;
 
         /*!
          * Defines a struct with a single member typedef called type.
@@ -164,7 +167,7 @@ namespace KTfwd
         template <typename gcont_t_or_gamete_t, typename mcont_t>
         using rich_recmodel_t =
             typename traits::internal::rich_recmodel_t<gcont_t_or_gamete_t,
-                                                  mcont_t>::type;
+                                                       mcont_t>::type;
 
         // clang-format off
         /*!

--- a/fwdpp/type_traits.hpp
+++ b/fwdpp/type_traits.hpp
@@ -243,9 +243,9 @@ namespace KTfwd
             = is_mutation_model<mmodel_t, mcont_t, gcont_t>::value;
 
         //! \ingroup Cpp14
-        template <typename recmodel_t, typename gamete_t, typename mcont_t>
+        template <typename recmodel_t, typename diploid_t, typename gamete_t, typename mcont_t>
         constexpr bool is_rec_model_v
-            = is_rec_model<recmodel_t, gamete_t, mcont_t>::value;
+            = is_rec_model<recmodel_t, diploid_t, gamete_t, mcont_t>::value;
 
         //! \ingroup Cpp14
         template <typename ff, typename dipvector_t, typename gcont_t,

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -249,6 +249,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -7,7 +7,7 @@ check_PROGRAMS=unit/fwdpp_unit_tests unit/extensions_unit_tests unit/sugar_unit_
 TESTS=$(check_PROGRAMS)
 
 #Unit test targets:
-unit_fwdpp_unit_tests_SOURCES=unit/fwdpp_unit_tests.cc unit/mutateTest.cc unit/gameteTest.cc unit/utilTest.cc unit/type_traitsTest.cc unit/recombinationTest.cc unit/demographyTest.cc unit/siteDepFitnessTest.cc unit/serializationTest.cc unit/ms_samplingTest.cc unit/mlocusCrossoverTest.cc unit/gamete_cleanerTest.cc
+unit_fwdpp_unit_tests_SOURCES=unit/fwdpp_unit_tests.cc unit/mutateTest.cc unit/gameteTest.cc unit/utilTest.cc unit/type_traitsTest.cc unit/recombinationTest.cc unit/demographyTest.cc unit/siteDepFitnessTest.cc unit/serializationTest.cc unit/ms_samplingTest.cc unit/mlocusCrossoverTest.cc unit/gamete_cleanerTest.cc unit/test_general_rec_variation.cc
 unit_extensions_unit_tests_SOURCES=unit/extensions_unit_test.cc unit/extensions_regionsTest.cc unit/extensions_callbacksTest.cc
 unit_sugar_unit_tests_SOURCES=unit/sugar_unit_tests.cc \
 	unit/sugar_GSLrngTest.cc \

--- a/testsuite/Makefile.in
+++ b/testsuite/Makefile.in
@@ -538,6 +538,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/testsuite/Makefile.in
+++ b/testsuite/Makefile.in
@@ -144,7 +144,8 @@ am__unit_fwdpp_unit_tests_SOURCES_DIST = unit/fwdpp_unit_tests.cc \
 	unit/type_traitsTest.cc unit/recombinationTest.cc \
 	unit/demographyTest.cc unit/siteDepFitnessTest.cc \
 	unit/serializationTest.cc unit/ms_samplingTest.cc \
-	unit/mlocusCrossoverTest.cc unit/gamete_cleanerTest.cc
+	unit/mlocusCrossoverTest.cc unit/gamete_cleanerTest.cc \
+	unit/test_general_rec_variation.cc
 @BUNIT_TEST_PRESENT_TRUE@am_unit_fwdpp_unit_tests_OBJECTS =  \
 @BUNIT_TEST_PRESENT_TRUE@	unit/fwdpp_unit_tests.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	unit/mutateTest.$(OBJEXT) \
@@ -157,7 +158,8 @@ am__unit_fwdpp_unit_tests_SOURCES_DIST = unit/fwdpp_unit_tests.cc \
 @BUNIT_TEST_PRESENT_TRUE@	unit/serializationTest.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	unit/ms_samplingTest.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	unit/mlocusCrossoverTest.$(OBJEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	unit/gamete_cleanerTest.$(OBJEXT)
+@BUNIT_TEST_PRESENT_TRUE@	unit/gamete_cleanerTest.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	unit/test_general_rec_variation.$(OBJEXT)
 unit_fwdpp_unit_tests_OBJECTS = $(am_unit_fwdpp_unit_tests_OBJECTS)
 unit_fwdpp_unit_tests_LDADD = $(LDADD)
 am__unit_sugar_unit_tests_SOURCES_DIST = unit/sugar_unit_tests.cc \
@@ -550,7 +552,7 @@ top_srcdir = @top_srcdir@
 @BUNIT_TEST_PRESENT_TRUE@TESTS = $(check_PROGRAMS)
 
 #Unit test targets:
-@BUNIT_TEST_PRESENT_TRUE@unit_fwdpp_unit_tests_SOURCES = unit/fwdpp_unit_tests.cc unit/mutateTest.cc unit/gameteTest.cc unit/utilTest.cc unit/type_traitsTest.cc unit/recombinationTest.cc unit/demographyTest.cc unit/siteDepFitnessTest.cc unit/serializationTest.cc unit/ms_samplingTest.cc unit/mlocusCrossoverTest.cc unit/gamete_cleanerTest.cc
+@BUNIT_TEST_PRESENT_TRUE@unit_fwdpp_unit_tests_SOURCES = unit/fwdpp_unit_tests.cc unit/mutateTest.cc unit/gameteTest.cc unit/utilTest.cc unit/type_traitsTest.cc unit/recombinationTest.cc unit/demographyTest.cc unit/siteDepFitnessTest.cc unit/serializationTest.cc unit/ms_samplingTest.cc unit/mlocusCrossoverTest.cc unit/gamete_cleanerTest.cc unit/test_general_rec_variation.cc
 @BUNIT_TEST_PRESENT_TRUE@unit_extensions_unit_tests_SOURCES = unit/extensions_unit_test.cc unit/extensions_regionsTest.cc unit/extensions_callbacksTest.cc
 @BUNIT_TEST_PRESENT_TRUE@unit_sugar_unit_tests_SOURCES = unit/sugar_unit_tests.cc \
 @BUNIT_TEST_PRESENT_TRUE@	unit/sugar_GSLrngTest.cc \
@@ -682,6 +684,8 @@ unit/mlocusCrossoverTest.$(OBJEXT): unit/$(am__dirstamp) \
 	unit/$(DEPDIR)/$(am__dirstamp)
 unit/gamete_cleanerTest.$(OBJEXT): unit/$(am__dirstamp) \
 	unit/$(DEPDIR)/$(am__dirstamp)
+unit/test_general_rec_variation.$(OBJEXT): unit/$(am__dirstamp) \
+	unit/$(DEPDIR)/$(am__dirstamp)
 
 unit/fwdpp_unit_tests$(EXEEXT): $(unit_fwdpp_unit_tests_OBJECTS) $(unit_fwdpp_unit_tests_DEPENDENCIES) $(EXTRA_unit_fwdpp_unit_tests_DEPENDENCIES) unit/$(am__dirstamp)
 	@rm -f unit/fwdpp_unit_tests$(EXEEXT)
@@ -748,6 +752,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/sugar_popgenmut.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/sugar_samplingTest.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/sugar_unit_tests.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/test_general_rec_variation.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/type_traitsTest.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/utilTest.Po@am__quote@
 

--- a/testsuite/fixtures/sugar_fixtures.hpp
+++ b/testsuite/fixtures/sugar_fixtures.hpp
@@ -7,6 +7,7 @@
 #include <fwdpp/sugar/multiloc.hpp>
 #include <fwdpp/sugar/infsites.hpp>
 #include <fwdpp/sugar/GSLrng_t.hpp>
+#include <fwdpp/poisson_xover.hpp>
 #include <fwdpp/recombination.hpp>
 #include <fwdpp/fitness_models.hpp>
 #include <fwdpp/extensions/regions.hpp>

--- a/testsuite/unit/extensions_regionsTest.cc
+++ b/testsuite/unit/extensions_regionsTest.cc
@@ -119,6 +119,7 @@ BOOST_AUTO_TEST_CASE(bound_drm_is_recmodel)
     static_assert(
         KTfwd::traits::
             is_rec_model<decltype(drm),
+                         singlepop_popgenmut_fixture::poptype::diploid_t,
                          singlepop_popgenmut_fixture::poptype::gamete_t,
                          singlepop_popgenmut_fixture::poptype::mcont_t>::value,
         "bound object must be valid recombination model");

--- a/testsuite/unit/test_general_rec_variation.cc
+++ b/testsuite/unit/test_general_rec_variation.cc
@@ -1,0 +1,60 @@
+/*!
+  \file test_general_rec_variation.cc
+  \ingroup unit
+  \brief Unit tests for KTfwd::general_rec_variation.  Also tests the built-in policies accompanying this type.
+*/
+
+#include <boost/test/unit_test.hpp>
+#include <fwdpp/general_rec_variation.hpp>
+#include <config.h>
+
+struct fixture
+{
+    const gsl_rng* r;
+    const double not_a_num, inf;
+    fixture()
+        : r{ gsl_rng_alloc(gsl_rng_taus) },
+          not_a_num{ std::numeric_limits<double>::quiet_NaN() },
+          inf{ std::numeric_limits<double>::infinity() }
+    {
+        gsl_rng_set(r, 42);
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(test_general_rec_variation, fixture)
+
+BOOST_AUTO_TEST_CASE(test_poisson_interval)
+{
+    BOOST_REQUIRE_THROW(KTfwd::poisson_interval(NULL, 1e-3, 0., 1.),
+                        std::invalid_argument);
+    BOOST_REQUIRE_THROW(KTfwd::poisson_interval(r, not_a_num, 0., 1.),
+                        std::invalid_argument);
+    BOOST_REQUIRE_THROW(KTfwd::poisson_interval(r, 1e-3, not_a_num, 1.),
+                        std::invalid_argument);
+    BOOST_REQUIRE_THROW(KTfwd::poisson_interval(r, 1e-3, 0., not_a_num),
+                        std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(test_crossover_point)
+{
+    BOOST_REQUIRE_THROW(KTfwd::crossover_point(NULL, 1e-3, -2),
+                        std::invalid_argument);
+    BOOST_REQUIRE_THROW(KTfwd::crossover_point(r, inf, -2),
+                        std::invalid_argument);
+    BOOST_REQUIRE_THROW(KTfwd::crossover_point(r, -2, not_a_num),
+                        std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(test_basic_use)
+{
+    KTfwd::general_rec_variation rv;
+
+    rv.recmap.push_back(KTfwd::poisson_interval(r, 1e-3, 0., 1.));
+    rv.recmap.push_back(KTfwd::crossover_point(r, 1e-3, 0.5));
+    rv.recmap.push_back(KTfwd::crossover_point(r, 1e-3, 0.5, true));
+    rv.recmap.push_back(KTfwd::crossover_point(r, 1e-3, 0.5, false));
+
+    auto x = rv();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/testsuite/unit/test_general_rec_variation.cc
+++ b/testsuite/unit/test_general_rec_variation.cc
@@ -21,6 +21,7 @@ struct fixture
     KTfwd::crossover_point ci2;
     KTfwd::crossover_point ci3;
     KTfwd::gamete g;
+    std::pair<std::size_t, std::size_t> diploid;
     std::vector<KTfwd::mutation> mutations;
 
     fixture()
@@ -29,7 +30,7 @@ struct fixture
           inf{ std::numeric_limits<double>::infinity() }, recvar{},
           pi{ r, 1e-3, 0., 1. }, ci1{ r, 1e-3, 0.5 },
           ci2{ r, 1e-3, 0.5, true }, ci3{ r, 1e-3, 0.5, false }, g{ 0 },
-          mutations{}
+          diploid{ 0, 0 }, mutations{}
     {
         gsl_rng_set(r, 42);
     }
@@ -71,7 +72,8 @@ BOOST_AUTO_TEST_CASE(test_basic_use)
 BOOST_AUTO_TEST_CASE(test_dispatch)
 {
     auto x = KTfwd::dispatch_recombination_policy(
-        std::cref(recvar), std::cref(g), std::cref(g), std::cref(mutations));
+        std::cref(recvar), std::cref(diploid), std::cref(g), std::cref(g),
+        std::cref(mutations));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/testsuite/unit/test_general_rec_variation.cc
+++ b/testsuite/unit/test_general_rec_variation.cc
@@ -1,11 +1,14 @@
 /*!
   \file test_general_rec_variation.cc
   \ingroup unit
-  \brief Unit tests for KTfwd::general_rec_variation.  Also tests the built-in policies accompanying this type.
+  \brief Unit tests for KTfwd::general_rec_variation.  Also tests the built-in
+  policies accompanying this type.
 */
 
 #include <boost/test/unit_test.hpp>
 #include <fwdpp/general_rec_variation.hpp>
+#include <fwdpp/forward_types.hpp>
+#include <fwdpp/mutate_recombine.hpp>
 #include <config.h>
 
 struct fixture
@@ -17,16 +20,16 @@ struct fixture
     KTfwd::crossover_point ci1;
     KTfwd::crossover_point ci2;
     KTfwd::crossover_point ci3;
+    KTfwd::gamete g;
+    std::vector<KTfwd::mutation> mutations;
 
     fixture()
         : r{ gsl_rng_alloc(gsl_rng_taus) },
           not_a_num{ std::numeric_limits<double>::quiet_NaN() },
-          inf{ std::numeric_limits<double>::infinity() },
-          recvar{},
-          pi{r,1e-3,0.,1.},
-          ci1{r,1e-3,0.5},
-          ci2{r,1e-3,0.5,true},
-          ci3{r,1e-3,0.5,false}
+          inf{ std::numeric_limits<double>::infinity() }, recvar{},
+          pi{ r, 1e-3, 0., 1. }, ci1{ r, 1e-3, 0.5 },
+          ci2{ r, 1e-3, 0.5, true }, ci3{ r, 1e-3, 0.5, false }, g{ 0 },
+          mutations{}
     {
         gsl_rng_set(r, 42);
     }
@@ -63,6 +66,12 @@ BOOST_AUTO_TEST_CASE(test_basic_use)
     recvar.recmap.push_back(ci2);
     recvar.recmap.push_back(ci3);
     auto x = recvar();
+}
+
+BOOST_AUTO_TEST_CASE(test_dispatch)
+{
+    auto x = KTfwd::dispatch_recombination_policy(
+        std::cref(recvar), std::cref(g), std::cref(g), std::cref(mutations));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/testsuite/unit/test_general_rec_variation.cc
+++ b/testsuite/unit/test_general_rec_variation.cc
@@ -12,10 +12,21 @@ struct fixture
 {
     const gsl_rng* r;
     const double not_a_num, inf;
+    KTfwd::general_rec_variation recvar;
+    KTfwd::poisson_interval pi;
+    KTfwd::crossover_point ci1;
+    KTfwd::crossover_point ci2;
+    KTfwd::crossover_point ci3;
+
     fixture()
         : r{ gsl_rng_alloc(gsl_rng_taus) },
           not_a_num{ std::numeric_limits<double>::quiet_NaN() },
-          inf{ std::numeric_limits<double>::infinity() }
+          inf{ std::numeric_limits<double>::infinity() },
+          recvar{},
+          pi{r,1e-3,0.,1.},
+          ci1{r,1e-3,0.5},
+          ci2{r,1e-3,0.5,true},
+          ci3{r,1e-3,0.5,false}
     {
         gsl_rng_set(r, 42);
     }
@@ -47,14 +58,11 @@ BOOST_AUTO_TEST_CASE(test_crossover_point)
 
 BOOST_AUTO_TEST_CASE(test_basic_use)
 {
-    KTfwd::general_rec_variation rv;
-
-    rv.recmap.push_back(KTfwd::poisson_interval(r, 1e-3, 0., 1.));
-    rv.recmap.push_back(KTfwd::crossover_point(r, 1e-3, 0.5));
-    rv.recmap.push_back(KTfwd::crossover_point(r, 1e-3, 0.5, true));
-    rv.recmap.push_back(KTfwd::crossover_point(r, 1e-3, 0.5, false));
-
-    auto x = rv();
+    recvar.recmap.push_back(pi);
+    recvar.recmap.push_back(ci1);
+    recvar.recmap.push_back(ci2);
+    recvar.recmap.push_back(ci3);
+    auto x = recvar();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/testsuite/unit/type_traitsTest.cc
+++ b/testsuite/unit/type_traitsTest.cc
@@ -147,6 +147,16 @@ BOOST_AUTO_TEST_CASE(is_recmodel_test)
     v = KTfwd::traits::is_rec_model<decltype(mock_not_rec), int,
                                     mcont_t>::value;
     BOOST_REQUIRE_EQUAL(v, false);
+
+    // Now, we test that the types can be dispatched
+    auto r1 = KTfwd::dispatch_recombination_policy(
+        rm, gcont_t::value_type(0), gcont_t::value_type(0), mcont_t());
+    v = std::is_same<decltype(r1), std::vector<double>>::value;
+    BOOST_REQUIRE_EQUAL(v, true);
+    auto r2 = KTfwd::dispatch_recombination_policy(
+        mock_rec, gcont_t::value_type(0), gcont_t::value_type(0), mcont_t());
+    v = std::is_same<decltype(r2), std::vector<double>>::value;
+    BOOST_REQUIRE_EQUAL(v, true);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/testsuite/unit/type_traitsTest.cc
+++ b/testsuite/unit/type_traitsTest.cc
@@ -140,6 +140,13 @@ BOOST_AUTO_TEST_CASE(is_recmodel_test)
     v = KTfwd::traits::is_rec_model<decltype(mock_rec), gcont_t::value_type,
                                     mcont_t>::value;
     BOOST_REQUIRE_EQUAL(v, true);
+
+    // Test that this is not a valid rec policy
+    auto mock_not_rec = [&rm](const int, int, const mcont_t &) -> decltype(
+        rm()) { return rm(); };
+    v = KTfwd::traits::is_rec_model<decltype(mock_not_rec), int,
+                                    mcont_t>::value;
+    BOOST_REQUIRE_EQUAL(v, false);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/testsuite/unit/type_traitsTest.cc
+++ b/testsuite/unit/type_traitsTest.cc
@@ -125,8 +125,8 @@ BOOST_AUTO_TEST_CASE(is_recmodel_test)
                             KTfwd::traits::rich_recmodel_t<gcont_t::value_type,
                                                            mcont_t>>::value;
     BOOST_REQUIRE_EQUAL(v, false);
-    v = KTfwd::traits::is_rec_model<decltype(rm), gcont_t::value_type,
-                                    mcont_t>::value;
+    v = KTfwd::traits::is_rec_model<decltype(rm), dipvector_t::value_type,
+                                    gcont_t::value_type, mcont_t>::value;
     BOOST_REQUIRE_EQUAL(v, true);
 
     auto mock_rec
@@ -137,24 +137,38 @@ BOOST_AUTO_TEST_CASE(is_recmodel_test)
                             KTfwd::traits::rich_recmodel_t<gcont_t::value_type,
                                                            mcont_t>>::value;
     BOOST_REQUIRE_EQUAL(v, true);
-    v = KTfwd::traits::is_rec_model<decltype(mock_rec), gcont_t::value_type,
-                                    mcont_t>::value;
+    v = KTfwd::traits::is_rec_model<decltype(mock_rec),
+                                    dipvector_t::value_type,
+                                    gcont_t::value_type, mcont_t>::value;
+    BOOST_REQUIRE_EQUAL(v, true);
+
+    auto mock_rec_diploid
+        = [&rm](const dipvector_t::value_type &, const gcont_t::value_type &,
+                const gcont_t::value_type &,
+                const mcont_t &) -> decltype(rm()) { return rm(); };
+
+    v = KTfwd::traits::is_rec_model<decltype(mock_rec_diploid),
+                                    dipvector_t::value_type,
+                                    gcont_t::value_type, mcont_t>::value;
     BOOST_REQUIRE_EQUAL(v, true);
 
     // Test that this is not a valid rec policy
     auto mock_not_rec = [&rm](const int, int, const mcont_t &) -> decltype(
         rm()) { return rm(); };
-    v = KTfwd::traits::is_rec_model<decltype(mock_not_rec), int,
+    v = KTfwd::traits::is_rec_model<decltype(mock_not_rec),
+                                    dipvector_t::value_type, int,
                                     mcont_t>::value;
     BOOST_REQUIRE_EQUAL(v, false);
 
     // Now, we test that the types can be dispatched
     auto r1 = KTfwd::dispatch_recombination_policy(
-        rm, gcont_t::value_type(0), gcont_t::value_type(0), mcont_t());
+        rm, dipvector_t::value_type(), gcont_t::value_type(0),
+        gcont_t::value_type(0), mcont_t());
     v = std::is_same<decltype(r1), std::vector<double>>::value;
     BOOST_REQUIRE_EQUAL(v, true);
     auto r2 = KTfwd::dispatch_recombination_policy(
-        mock_rec, gcont_t::value_type(0), gcont_t::value_type(0), mcont_t());
+        mock_rec, dipvector_t::value_type(), gcont_t::value_type(0),
+        gcont_t::value_type(0), mcont_t());
     v = std::is_same<decltype(r2), std::vector<double>>::value;
     BOOST_REQUIRE_EQUAL(v, true);
 }

--- a/testsuite/unit/type_traitsTest.cc
+++ b/testsuite/unit/type_traitsTest.cc
@@ -10,6 +10,7 @@
 #include <config.h>
 #include "../fixtures/fwdpp_fixtures.hpp"
 #include <fwdpp/fitness_models.hpp>
+#include <fwdpp/poisson_xover.hpp>
 #include <fwdpp/recombination.hpp>
 #include <boost/test/unit_test.hpp>
 #include <fwdpp/type_traits.hpp>

--- a/testsuite/unit/type_traitsTest.cc
+++ b/testsuite/unit/type_traitsTest.cc
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(is_not_fitness_model)
         "foo");
 }
 
-BOOST_AUTO_TEST_CASE(is_recmodel_test)
+BOOST_AUTO_TEST_CASE(is_empty_recmodel_test)
 {
 
     KTfwd::poisson_xover rm(r, 1e-3, 0., 1.);
@@ -128,49 +128,65 @@ BOOST_AUTO_TEST_CASE(is_recmodel_test)
     v = KTfwd::traits::is_rec_model<decltype(rm), dipvector_t::value_type,
                                     gcont_t::value_type, mcont_t>::value;
     BOOST_REQUIRE_EQUAL(v, true);
-
-    auto mock_rec
-        = [&rm](const gcont_t::value_type &, const gcont_t::value_type &,
-                const mcont_t &) -> decltype(rm()) { return rm(); };
-
-    v = std::is_convertible<decltype(mock_rec),
-                            KTfwd::traits::rich_recmodel_t<gcont_t::value_type,
-                                                           mcont_t>>::value;
-    BOOST_REQUIRE_EQUAL(v, true);
-    v = KTfwd::traits::is_rec_model<decltype(mock_rec),
-                                    dipvector_t::value_type,
-                                    gcont_t::value_type, mcont_t>::value;
-    BOOST_REQUIRE_EQUAL(v, true);
-
-    auto mock_rec_diploid
-        = [&rm](const dipvector_t::value_type &, const gcont_t::value_type &,
-                const gcont_t::value_type &,
-                const mcont_t &) -> decltype(rm()) { return rm(); };
-
-    v = KTfwd::traits::is_rec_model<decltype(mock_rec_diploid),
-                                    dipvector_t::value_type,
-                                    gcont_t::value_type, mcont_t>::value;
-    BOOST_REQUIRE_EQUAL(v, true);
-
-    // Test that this is not a valid rec policy
-    auto mock_not_rec = [&rm](const int, int, const mcont_t &) -> decltype(
-        rm()) { return rm(); };
-    v = KTfwd::traits::is_rec_model<decltype(mock_not_rec),
-                                    dipvector_t::value_type, int,
-                                    mcont_t>::value;
-    BOOST_REQUIRE_EQUAL(v, false);
-
     // Now, we test that the types can be dispatched
     auto r1 = KTfwd::dispatch_recombination_policy(
         rm, dipvector_t::value_type(), gcont_t::value_type(0),
         gcont_t::value_type(0), mcont_t());
     v = std::is_same<decltype(r1), std::vector<double>>::value;
     BOOST_REQUIRE_EQUAL(v, true);
+}
+
+BOOST_AUTO_TEST_CASE(is_gamete_recmodel_test)
+{
+    KTfwd::poisson_xover rm(r, 1e-3, 0., 1.);
+    auto mock_rec
+        = [&rm](const gcont_t::value_type &, const gcont_t::value_type &,
+                const mcont_t &) -> decltype(rm()) { return rm(); };
+
+    auto v = std::
+        is_convertible<decltype(mock_rec),
+                       KTfwd::traits::rich_recmodel_t<gcont_t::value_type,
+                                                      mcont_t>>::value;
+    BOOST_REQUIRE_EQUAL(v, true);
+    v = KTfwd::traits::is_rec_model<decltype(mock_rec),
+                                    dipvector_t::value_type,
+                                    gcont_t::value_type, mcont_t>::value;
+    BOOST_REQUIRE_EQUAL(v, true);
     auto r2 = KTfwd::dispatch_recombination_policy(
         mock_rec, dipvector_t::value_type(), gcont_t::value_type(0),
         gcont_t::value_type(0), mcont_t());
     v = std::is_same<decltype(r2), std::vector<double>>::value;
     BOOST_REQUIRE_EQUAL(v, true);
+}
+
+BOOST_AUTO_TEST_CASE(is_diploid_recmodel_test)
+{
+    KTfwd::poisson_xover rm(r, 1e-3, 0., 1.);
+    auto mock_rec_diploid
+        = [&rm](const dipvector_t::value_type &, const gcont_t::value_type &,
+                const gcont_t::value_type &,
+                const mcont_t &) -> decltype(rm()) { return rm(); };
+
+    auto v = KTfwd::traits::is_rec_model<decltype(mock_rec_diploid),
+                                         dipvector_t::value_type,
+                                         gcont_t::value_type, mcont_t>::value;
+    BOOST_REQUIRE_EQUAL(v, true);
+    auto r2 = KTfwd::dispatch_recombination_policy(
+        mock_rec_diploid, dipvector_t::value_type(), gcont_t::value_type(0),
+        gcont_t::value_type(0), mcont_t());
+    v = std::is_same<decltype(r2), std::vector<double>>::value;
+}
+
+BOOST_AUTO_TEST_CASE(is_not_recmodel_test)
+{
+    KTfwd::poisson_xover rm(r, 1e-3, 0., 1.);
+    // Test that this is not a valid rec policy
+    auto mock_not_rec = [&rm](const int, int, const mcont_t &) -> decltype(
+        rm()) { return rm(); };
+    auto v = KTfwd::traits::is_rec_model<decltype(mock_not_rec),
+                                         dipvector_t::value_type, int,
+                                         mcont_t>::value;
+    BOOST_REQUIRE_EQUAL(v, false);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/testsuite/util/quick_evolve_sugar.hpp
+++ b/testsuite/util/quick_evolve_sugar.hpp
@@ -8,6 +8,7 @@
 
 #include <exception>
 #include <cmath>
+#include <fwdpp/poisson_xover.hpp>
 #include <fwdpp/recombination.hpp>
 #include <fwdpp/fitness_models.hpp>
 #include <fwdpp/sample_diploid.hpp>


### PR DESCRIPTION
This PR builds on the API changes from #74 and introduces a way to completely generalize the construction of a recombination map.

- [x] Needs an example program mimicking `K_linked_regions_multilocus.cc`.
- [x] Augment #75 to make the dispatch code more specific -- void, requires gametes, requires diploids, should all be possible.

Also:

Need to think through the potential for compatibility of `general_rec_variation` w/policies requiring gamete and/or diploid data.  I worry that this is a nasty SFINAE problem w.r.to overloads of`operator()`.