### PR TITLE
Streamline type traits

### DIFF
--- a/fwdpp/extensions/regions.hpp
+++ b/fwdpp/extensions/regions.hpp
@@ -216,7 +216,7 @@ namespace KTfwd
           See unit test extensions.cc for an example of use.
         */
         template <typename mcont_t, typename lookup_t, class... Args>
-        inline traits::mmodel_t<mcont_t>
+        inline traits::mutation_model<mcont_t>
         bind_dmm(const discrete_mut_model &dm, mcont_t &, lookup_t &mut_lookup,
                  Args &&... args)
         {
@@ -232,7 +232,7 @@ namespace KTfwd
          *  to KTfwd::extensions::discrete_mut_model::operator()
          */
         template <typename mcont_t, typename lookup_t, class... Args>
-        inline std::vector<traits::mmodel_t<mcont_t>>
+        inline std::vector<traits::mutation_model<mcont_t>>
         bind_vec_dmm(const std::vector<discrete_mut_model> &vdm,
                      mcont_t &mutations, lookup_t &mut_lookup,
                      const gsl_rng *r,

--- a/fwdpp/internal/type_traits.hpp
+++ b/fwdpp/internal/type_traits.hpp
@@ -89,6 +89,7 @@ namespace KTfwd
             };
 
             template <typename dipvector_t, typename gcont_t, typename mcont_t,
+                      typename = void, typename = void, typename = void,
                       typename = void>
             struct fitness_fxn
             {
@@ -100,22 +101,19 @@ namespace KTfwd
                                typename void_t<
                                    typename dipvector_t::value_type,
                                    typename gcont_t::value_type,
-                                   typename mcont_t::value_type>::type>
+                                   typename mcont_t::value_type>::type,
+                               typename std::enable_if<is_diploid<
+                                   typename dipvector_t::value_type>::value>::
+                                   type,
+                               typename std::enable_if<is_gamete<
+                                   typename gcont_t::value_type>::value>::type,
+                               typename std::enable_if<is_mutation<
+                                   typename mcont_t::value_type>::value>::type>
+
             {
-                using type = typename std::
-                    conditional<(is_diploid<
-                                     typename dipvector_t::value_type>::value
-                                 || is_multilocus_diploid<
-                                        typename dipvector_t::value_type>::
-                                        value)
-                                    && is_gamete<
-                                           typename gcont_t::value_type>::value
-                                    && is_mutation<typename mcont_t::
-                                                       value_type>::value,
-                                std::function<double(
-                                    const typename dipvector_t::value_type &,
-                                    const gcont_t &, const mcont_t &)>,
-                                void>::type;
+                using type = std::function<double(
+                    const typename dipvector_t::value_type &, const gcont_t &,
+                    const mcont_t &)>;
             };
 
             template <
@@ -153,6 +151,7 @@ namespace KTfwd
                 : std::true_type
             {
             };
+
             template <typename mmodel_t, typename mcont_t, typename gcont_t>
             struct is_mutation_model<mmodel_t, mcont_t, gcont_t,
                                      typename void_t<
@@ -234,8 +233,9 @@ namespace KTfwd
             };
 
             template <typename mcont_t>
-            struct mutation_model<mcont_t, typename void_t<
-                                         typename mcont_t::value_type>::type>
+            struct mutation_model<mcont_t,
+                                  typename void_t<
+                                      typename mcont_t::value_type>::type>
             {
                 using type = typename std::
                     conditional<is_mutation<
@@ -254,12 +254,12 @@ namespace KTfwd
 
             template <typename mcont_t, typename gcont_t>
             struct mutation_model_gamete<mcont_t, gcont_t,
-                                   typename std::enable_if<is_mutation<
-                                       typename mcont_t::value_type>::value>::
-                                       type,
-                                   typename std::enable_if<is_gamete<
-                                       typename gcont_t::value_type>::value>::
-                                       type>
+                                         typename std::enable_if<is_mutation<
+                                             typename mcont_t::
+                                                 value_type>::value>::type,
+                                         typename std::enable_if<is_gamete<
+                                             typename gcont_t::
+                                                 value_type>::value>::type>
             {
                 using type = std::function<std::size_t(
                     recycling_bin_t<mcont_t> &, typename gcont_t::value_type &,

--- a/fwdpp/internal/type_traits.hpp
+++ b/fwdpp/internal/type_traits.hpp
@@ -170,37 +170,6 @@ namespace KTfwd
             {
             };
 
-            template <typename gcont_t_or_gamete_t, typename mcont_t,
-                      typename = void>
-            struct rich_recmodel_t
-            {
-                using type = typename std::
-                    conditional<is_gamete<gcont_t_or_gamete_t>::value,
-                                std::function<std::vector<double>(
-                                    const gcont_t_or_gamete_t &,
-                                    const gcont_t_or_gamete_t &,
-                                    const mcont_t &)>,
-                                void>::type;
-            };
-
-            template <typename gcont_t_or_gamete_t, typename mcont_t>
-            struct rich_recmodel_t<gcont_t_or_gamete_t, mcont_t,
-                                   typename void_t<
-                                       typename gcont_t_or_gamete_t::
-                                           value_type>::type>
-            {
-                using type = typename std::
-                    conditional<is_gamete<typename gcont_t_or_gamete_t::
-                                              value_type>::value,
-                                std::function<std::vector<double>(
-                                    const typename gcont_t_or_gamete_t::
-                                        value_type &,
-                                    const typename gcont_t_or_gamete_t::
-                                        value_type &,
-                                    const mcont_t &)>,
-                                void>::type;
-            };
-
             template <typename recmodel_t, typename diploid_t,
                       typename gamete_t, typename mcont_t, typename = void,
                       typename = void, typename = void, typename = void>

--- a/fwdpp/internal/type_traits.hpp
+++ b/fwdpp/internal/type_traits.hpp
@@ -228,13 +228,13 @@ namespace KTfwd
             {
             };
 
-            template <typename mcont_t, typename = void> struct mmodel_t
+            template <typename mcont_t, typename = void> struct mutation_model
             {
                 using type = void;
             };
 
             template <typename mcont_t>
-            struct mmodel_t<mcont_t, typename void_t<
+            struct mutation_model<mcont_t, typename void_t<
                                          typename mcont_t::value_type>::type>
             {
                 using type = typename std::
@@ -245,28 +245,25 @@ namespace KTfwd
                                 void>::type;
             };
 
-            template <typename mcont_t, typename gcont_t, typename = void>
-            struct mmodel_gamete_t
+            template <typename mcont_t, typename gcont_t, typename = void,
+                      typename = void>
+            struct mutation_model_gamete
             {
                 using type = void;
             };
 
             template <typename mcont_t, typename gcont_t>
-            struct mmodel_gamete_t<mcont_t, gcont_t,
-                                   typename void_t<
-                                       typename mcont_t::value_type,
-                                       typename gcont_t::value_type>::type>
+            struct mutation_model_gamete<mcont_t, gcont_t,
+                                   typename std::enable_if<is_mutation<
+                                       typename mcont_t::value_type>::value>::
+                                       type,
+                                   typename std::enable_if<is_gamete<
+                                       typename gcont_t::value_type>::value>::
+                                       type>
             {
-                using type = typename std::
-                    conditional<is_mutation<
-                                    typename mcont_t::value_type>::value
-                                    && is_gamete<typename gcont_t::
-                                                     value_type>::value,
-                                std::function<std::size_t(
-                                    recycling_bin_t<mcont_t> &,
-                                    typename gcont_t::value_type &,
-                                    mcont_t &)>,
-                                void>::type;
+                using type = std::function<std::size_t(
+                    recycling_bin_t<mcont_t> &, typename gcont_t::value_type &,
+                    mcont_t &)>;
             };
         }
     }

--- a/fwdpp/internal/type_traits.hpp
+++ b/fwdpp/internal/type_traits.hpp
@@ -8,9 +8,7 @@
 #include <type_traits>
 #include <functional>
 #include <utility>
-#include <fwdpp/mutate_recombine.hpp>
 #include <fwdpp/internal/void_t.hpp>
-#include <fwdpp/internal/mutation_internal.hpp>
 
 namespace KTfwd
 {
@@ -135,48 +133,40 @@ namespace KTfwd
             };
 
             template <typename mmodel_t, typename mcont_t, typename gcont_t,
-                      typename = void>
+                      typename = void, typename = void, typename = void>
             struct is_mutation_model : std::false_type
-            {
-            };
-
-            template <typename gamete_t, typename mutation_t>
-            struct check_mmodel_types
-                : std::integral_constant<bool,
-                                         is_gamete<gamete_t>::value
-                                             && is_mutation<mutation_t>::value>
-            {
-            };
-
-            template <typename mmodel_t, typename gcont_t, typename mcont_t,
-                      typename gamete_t = typename gcont_t::value_type,
-                      typename mutation_t = typename mcont_t::value_type,
-                      typename recbin = recycling_bin_t<mcont_t>>
-            struct dispatchable_mmodel
-                : std::is_same<
-                      typename std::result_of<decltype (
-                          &fwdpp_internal::mmodel_dispatcher<mmodel_t,
-                                                             gamete_t, mcont_t,
-                                                             recbin>)(
-                          mmodel_t &, gamete_t &, mcont_t &, recbin &)>::type,
-                      std::size_t>
             {
             };
 
             template <typename mmodel_t, typename mcont_t, typename gcont_t>
             struct is_mutation_model<mmodel_t, mcont_t, gcont_t,
                                      typename void_t<
-                                         typename mcont_t::value_type,
-                                         typename gcont_t::value_type>::type>
-                : std::integral_constant<bool,
-                                         check_mmodel_types<
-                                             typename gcont_t::value_type,
-                                             typename mcont_t::value_type>::
-                                                 value
-                                             && dispatchable_mmodel<mmodel_t,
-                                                                    gcont_t,
-                                                                    mcont_t>::
-                                                    value>
+                                         typename std::result_of<mmodel_t(
+                                             recycling_bin_t<mcont_t> &,
+                                             mcont_t &)>::type>::type,
+                                     typename std::enable_if<is_mutation<
+                                         typename mcont_t::value_type>::
+                                                                 value>::type,
+                                     typename std::enable_if<is_gamete<
+                                         typename gcont_t::value_type>::
+                                                                 value>::type>
+                : std::true_type
+            {
+            };
+            template <typename mmodel_t, typename mcont_t, typename gcont_t>
+            struct is_mutation_model<mmodel_t, mcont_t, gcont_t,
+                                     typename void_t<
+                                         typename std::result_of<mmodel_t(
+                                             recycling_bin_t<mcont_t> &,
+                                             typename gcont_t::value_type &,
+                                             mcont_t &)>::type>::type,
+                                     typename std::enable_if<is_mutation<
+                                         typename mcont_t::value_type>::
+                                                                 value>::type,
+                                     typename std::enable_if<is_gamete<
+                                         typename gcont_t::value_type>::
+                                                                 value>::type>
+                : std::true_type
             {
             };
 

--- a/fwdpp/internal/type_traits.hpp
+++ b/fwdpp/internal/type_traits.hpp
@@ -234,15 +234,12 @@ namespace KTfwd
 
             template <typename mcont_t>
             struct mutation_model<mcont_t,
-                                  typename void_t<
-                                      typename mcont_t::value_type>::type>
+                                  typename std::enable_if<is_mutation<
+                                      typename mcont_t::value_type>::value>::
+                                      type>
             {
-                using type = typename std::
-                    conditional<is_mutation<
-                                    typename mcont_t::value_type>::value,
-                                std::function<std::size_t(
-                                    recycling_bin_t<mcont_t> &, mcont_t &)>,
-                                void>::type;
+                using type = std::function<std::size_t(
+                    recycling_bin_t<mcont_t> &, mcont_t &)>;
             };
 
             template <typename mcont_t, typename gcont_t, typename = void,

--- a/fwdpp/type_traits.hpp
+++ b/fwdpp/type_traits.hpp
@@ -172,7 +172,7 @@ namespace KTfwd
          */
         // clang-format on
         template <typename mcont_t>
-        using mmodel_t = typename traits::internal::mmodel_t<mcont_t>::type;
+        using mutation_model = typename traits::internal::mutation_model<mcont_t>::type;
 
         // clang-format off
 		/*!
@@ -191,8 +191,8 @@ namespace KTfwd
         */
         // clang-format on
         template <typename mcont_t, typename gcont_t>
-        using mmodel_gamete_t =
-            typename traits::internal::mmodel_gamete_t<mcont_t, gcont_t>::type;
+        using mutation_model_gamete =
+            typename traits::internal::mutation_model_gamete<mcont_t, gcont_t>::type;
 
 /*! \defgroup Cpp14
  * \brief C++14 features

--- a/fwdpp/type_traits.hpp
+++ b/fwdpp/type_traits.hpp
@@ -157,20 +157,6 @@ namespace KTfwd
 
         // clang-format off
         /*!
-		 * Infers the signature of a recombination function compatible
-		 * with the template type parameters.
-		 *
-		 * If such a function signature cannot be inferred, this
-		 * evaluates to void.
-		 */
-        // clang-format on
-        template <typename gcont_t_or_gamete_t, typename mcont_t>
-        using rich_recmodel_t =
-            typename traits::internal::rich_recmodel_t<gcont_t_or_gamete_t,
-                                                       mcont_t>::type;
-
-        // clang-format off
-        /*!
 		 * Gives the mutation model function signature corresponding to
          * mcont_t.
 		 * Applies to mutation policies that only take recycling bins

--- a/testsuite/unit/type_traitsTest.cc
+++ b/testsuite/unit/type_traitsTest.cc
@@ -117,17 +117,8 @@ BOOST_AUTO_TEST_CASE(is_empty_recmodel_test)
 
     KTfwd::poisson_xover rm(r, 1e-3, 0., 1.);
 
-    auto v
-        = std::is_convertible<decltype(rm),
-                              KTfwd::traits::rich_recmodel_t<gcont_t,
-                                                             mcont_t>>::value;
-    BOOST_REQUIRE_EQUAL(v, false);
-    v = std::is_convertible<decltype(rm),
-                            KTfwd::traits::rich_recmodel_t<gcont_t::value_type,
-                                                           mcont_t>>::value;
-    BOOST_REQUIRE_EQUAL(v, false);
-    v = KTfwd::traits::is_rec_model<decltype(rm), dipvector_t::value_type,
-                                    gcont_t::value_type, mcont_t>::value;
+    auto v = KTfwd::traits::is_rec_model<decltype(rm), dipvector_t::value_type,
+                                         gcont_t::value_type, mcont_t>::value;
     BOOST_REQUIRE_EQUAL(v, true);
     // Now, we test that the types can be dispatched
     auto r1 = KTfwd::dispatch_recombination_policy(
@@ -144,14 +135,9 @@ BOOST_AUTO_TEST_CASE(is_gamete_recmodel_test)
         = [&rm](const gcont_t::value_type &, const gcont_t::value_type &,
                 const mcont_t &) -> decltype(rm()) { return rm(); };
 
-    auto v = std::
-        is_convertible<decltype(mock_rec),
-                       KTfwd::traits::rich_recmodel_t<gcont_t::value_type,
-                                                      mcont_t>>::value;
-    BOOST_REQUIRE_EQUAL(v, true);
-    v = KTfwd::traits::is_rec_model<decltype(mock_rec),
-                                    dipvector_t::value_type,
-                                    gcont_t::value_type, mcont_t>::value;
+    auto v = KTfwd::traits::is_rec_model<decltype(mock_rec),
+                                         dipvector_t::value_type,
+                                         gcont_t::value_type, mcont_t>::value;
     BOOST_REQUIRE_EQUAL(v, true);
     auto r2 = KTfwd::dispatch_recombination_policy(
         mock_rec, dipvector_t::value_type(), gcont_t::value_type(0),

--- a/testsuite/unit/type_traitsTest.cc
+++ b/testsuite/unit/type_traitsTest.cc
@@ -10,6 +10,7 @@
 #include <config.h>
 #include "../fixtures/fwdpp_fixtures.hpp"
 #include <fwdpp/fitness_models.hpp>
+#include <fwdpp/mutate_recombine.hpp>
 #include <fwdpp/poisson_xover.hpp>
 #include <fwdpp/recombination.hpp>
 #include <boost/test/unit_test.hpp>

--- a/testsuite/unit/type_traitsTest.cc
+++ b/testsuite/unit/type_traitsTest.cc
@@ -77,12 +77,28 @@ BOOST_AUTO_TEST_CASE(is_mmodel_test)
         return KTfwd::fwdpp_internal::recycle_mutation_helper(
             rbin, __mvector, next_mut_pos[i++], 0.);
     };
-    auto v = std::is_convertible<decltype(mmodel),
-                                 KTfwd::traits::mmodel_t<mcont_t>>::value;
+    auto v
+        = std::is_convertible<decltype(mmodel),
+                              KTfwd::traits::mutation_model<mcont_t>>::value;
     BOOST_REQUIRE_EQUAL(v, true);
 
     v = KTfwd::traits::is_mutation_model<decltype(mmodel), mcont_t,
                                          gcont_t>::value;
+    BOOST_REQUIRE_EQUAL(v, true);
+}
+
+BOOST_AUTO_TEST_CASE(is_mmodel_gamete_test)
+{
+    // Fake a mutation model requiring a gamete.
+    // The function itself is invalid in implementation,
+    // but the purpose here is to test the signature.
+    auto m = [](KTfwd::traits::recycling_bin_t<mcont_t> &,
+                const gcont_t::value_type &,
+                const mcont_t &) -> std::size_t { return 1; };
+    auto v = std::
+        is_convertible<decltype(m),
+                       KTfwd::traits::mutation_model_gamete<mcont_t,
+                                                            gcont_t>>::value;
     BOOST_REQUIRE_EQUAL(v, true);
 }
 


### PR DESCRIPTION
This PR tidies up the namespace `KTfwd::traits::internal`.  The main goal is to get rid of use of `std::conditional`, which makes the SFINAE logic too hard to read.  The changes also pre-adapt the `traits` sub-library for #80.