### PR TITLE
refactor fwdpp::generalmut and fwdpp::generalmut_vec to use (s,h) tuples

### DIFF
--- a/testsuite/unit/sugar_generalmutTest.cc
+++ b/testsuite/unit/sugar_generalmutTest.cc
@@ -10,17 +10,20 @@
 #include <fwdpp/sugar/singlepop.hpp>
 #include <fwdpp/sugar/infsites.hpp>
 #include <fwdpp/sugar/generalmut.hpp>
+#include <iostream>
 
 struct generalmut_tuple_wrapper
 {
     fwdpp::generalmut<2>::constructor_tuple t;
     fwdpp::generalmut<2> m;
-    static const std::array<double, 2> s, h;
-    generalmut_tuple_wrapper() : t(std::make_tuple(s, h, 2.2, 11, 17)), m(t) {}
+    static const std::array<std::tuple<double, double>, 2> sh;
+    generalmut_tuple_wrapper() : t(std::make_tuple(sh, 2.2, 11, 17)), m(t) {}
 };
 
-const std::array<double, 2> generalmut_tuple_wrapper::s = { { 0.0, -0.1 } };
-const std::array<double, 2> generalmut_tuple_wrapper::h = { { 1.0, 0.25 } };
+const std::array<std::tuple<double, double>, 2> generalmut_tuple_wrapper::sh{
+    { std::tuple<double, double>{ 0.0, 1.0 },
+      std::tuple<double, double>{ -0.1, -0.25 } }
+};
 
 namespace fwdpp
 {
@@ -52,60 +55,46 @@ namespace fwdpp
     }
 }
 
+using ttype = fwdpp::generalmut<4>::array_t::value_type;
+
 BOOST_AUTO_TEST_SUITE(generalmutTest)
 
 BOOST_AUTO_TEST_CASE(construct_2)
 {
-    fwdpp::generalmut<2> p({ { 0.5, -1 } }, { { 1, 0 } }, 0.001, 1);
+    fwdpp::generalmut<2> p({ std::tuple<double, double>{ 0.5, -1 },
+                             std::tuple<double, double>{ 1, 0 } },
+                           0.001, 1);
     BOOST_CHECK_EQUAL(std::tuple_size<decltype(p)::array_t>(), 2);
-    BOOST_CHECK_EQUAL(p.s.size(), 2);
-    BOOST_CHECK_EQUAL(p.h.size(), 2);
-}
-
-BOOST_AUTO_TEST_CASE(construct_2b)
-{
-    fwdpp::generalmut<2> p({ { 0.5 } }, { { 1, 0 } }, 0.001, 1);
-    BOOST_CHECK_EQUAL(std::tuple_size<decltype(p)::array_t>(), 2);
-    BOOST_CHECK_EQUAL(p.s.size(), 2);
-    BOOST_CHECK_EQUAL(p.h.size(), 2);
-}
-
-BOOST_AUTO_TEST_CASE(construct_2c)
-{
-    fwdpp::generalmut<2> p({ { 0.5 } }, { { 1 } }, 0.001, 1);
-    BOOST_CHECK_EQUAL(std::tuple_size<decltype(p)::array_t>(), 2);
-    BOOST_CHECK_EQUAL(p.s.size(), 2);
-    BOOST_CHECK_EQUAL(p.h.size(), 2);
+    BOOST_CHECK_EQUAL(p.sh.size(), 2);
 }
 
 BOOST_AUTO_TEST_CASE(construct_4)
 {
-    fwdpp::generalmut<4> p({ { 0.5, -1, 2.0, 3.0 } }, { { 1, 0, -1, 1 } },
-                           0.001, 1);
+    fwdpp::generalmut<4> p(
+        { ttype{ 0.5, 1 }, ttype{ -1, 0 }, ttype{ 2.0, -1 }, ttype{ 3.0, 1 } },
+        0.001, 1);
     BOOST_CHECK_EQUAL(std::tuple_size<decltype(p)::array_t>(), 4);
-    BOOST_CHECK_EQUAL(p.s.size(), 4);
-    BOOST_CHECK_EQUAL(p.h.size(), 4);
+    BOOST_CHECK_EQUAL(p.sh.size(), 4);
 }
 
 BOOST_AUTO_TEST_CASE(construct_4b)
 {
-    fwdpp::generalmut<4> p({ { 0.5 } }, { { 1, 0, -1, 1 } }, 0.001, 1);
-    BOOST_CHECK_EQUAL(std::tuple_size<decltype(p)::array_t>(), 4);
-    BOOST_CHECK_EQUAL(p.s.size(), 4);
-    BOOST_CHECK_EQUAL(p.h.size(), 4);
+    fwdpp::generalmut<4> p({ ttype{ 0.5,0.1 } }, 0.001, 1);
+    BOOST_REQUIRE_EQUAL(p.sh.size(), 4);
 }
 
 BOOST_AUTO_TEST_CASE(construct_4c)
 {
-    fwdpp::generalmut<4> p({ { 0.5 } }, { { 1 } }, 0.001, 1);
+    fwdpp::generalmut<4> p({ ttype{ 0.5,1. } }, 0.001, 1);
     BOOST_CHECK_EQUAL(std::tuple_size<decltype(p)::array_t>(), 4);
-    BOOST_CHECK_EQUAL(p.s.size(), 4);
-    BOOST_CHECK_EQUAL(p.h.size(), 4);
+    BOOST_REQUIRE_EQUAL(p.sh.size(), 4);
 }
 
 BOOST_AUTO_TEST_CASE(serialize)
 {
-    fwdpp::generalmut<4> p({ { 0.5 } }, { { 1, 0, -1, 1 } }, 0.001, 1, 14);
+    fwdpp::generalmut<4> p(
+        { ttype{ 0.5, 1 }, ttype{ -1, 0 }, ttype{ 2.0, -1 }, ttype{ 3.0, 1 } },
+        0.001, 1);
     std::ostringstream o;
     fwdpp::io::serialize_mutation<fwdpp::generalmut<4>>()(o, p);
     std::istringstream i(o.str());
@@ -124,8 +113,7 @@ BOOST_AUTO_TEST_CASE(copy_pop1)
 
 BOOST_FIXTURE_TEST_CASE(construct_from_tuple, generalmut_tuple_wrapper)
 {
-    BOOST_REQUIRE(m.s == s);
-    BOOST_REQUIRE(m.h == h);
+    BOOST_REQUIRE(m.sh == sh);
     BOOST_REQUIRE_EQUAL(m.pos, 2.2);
     BOOST_REQUIRE_EQUAL(m.g, 11);
     BOOST_REQUIRE_EQUAL(m.xtra, 17);

--- a/testsuite/unit/sugar_generalmut_vecTest.cc
+++ b/testsuite/unit/sugar_generalmut_vecTest.cc
@@ -3,12 +3,9 @@
   \ingroup unit
   \brief Testing fwdpp::generalmut_vec
 */
-#include <unistd.h>
 #include <config.h>
 #include <sstream>
 #include <boost/test/unit_test.hpp>
-#include <fwdpp/diploid.hh>
-#include <fwdpp/sugar/GSLrng_t.hpp>
 #include <fwdpp/sugar/singlepop.hpp>
 #include <fwdpp/sugar/generalmut.hpp>
 

--- a/testsuite/unit/sugar_generalmut_vecTest.cc
+++ b/testsuite/unit/sugar_generalmut_vecTest.cc
@@ -16,65 +16,28 @@ struct generalmut_vec_tuple_wrapper
 {
     fwdpp::generalmut_vec::constructor_tuple t;
     fwdpp::generalmut_vec m;
-    static const std::vector<double> s, h;
+    static const std::vector<std::tuple<double,double>> sh;
     generalmut_vec_tuple_wrapper()
-        : t(std::make_tuple(s, h, 2.2, 11, 17)), m(t)
+        : t(std::make_tuple(sh, 2.2, 11, 17)), m(t)
     {
     }
 };
 
-const std::vector<double> generalmut_vec_tuple_wrapper::s = { { 0.0, -0.1 } };
-const std::vector<double> generalmut_vec_tuple_wrapper::h = { { 1.0, 0.25 } };
+using ttype = fwdpp::generalmut_vec::array_t::value_type;
+
+const fwdpp::generalmut_vec::array_t generalmut_vec_tuple_wrapper::sh = { ttype{ 0.0,1.},ttype{ -0.1,0.25 } };
 
 BOOST_AUTO_TEST_SUITE(generalmut_vecTest)
 
 BOOST_AUTO_TEST_CASE(construct_2)
 {
-    fwdpp::generalmut_vec p({ { 0.5, -1 } }, { { 1, 0 } }, 0.001, 1);
-    BOOST_CHECK_EQUAL(p.s.size(), 2);
-    BOOST_CHECK_EQUAL(p.h.size(), 2);
+    fwdpp::generalmut_vec p({ ttype{ 0.5, -1 } , ttype { 1, 0 } }, 0.001, 1);
+    BOOST_CHECK_EQUAL(p.sh.size(), 2);
 }
 
-BOOST_AUTO_TEST_CASE(construct_2b)
-{
-    fwdpp::generalmut_vec p({ 0.5 }, { { 1, 0 } }, 0.001, 1);
-    BOOST_CHECK_EQUAL(p.s.size(), 1);
-    BOOST_CHECK_EQUAL(p.h.size(), 2);
-}
-
-BOOST_AUTO_TEST_CASE(construct_2c)
-{
-    fwdpp::generalmut_vec p({ 0.5 }, { 1 }, 0.001, 1);
-    BOOST_CHECK_EQUAL(p.s.size(), 1);
-    BOOST_CHECK_EQUAL(p.h.size(), 1);
-}
-
-BOOST_AUTO_TEST_CASE(construct_4)
-{
-    fwdpp::generalmut_vec p({ { 0.5, -1, 2.0, 3.0 } }, { { 1, 0, -1, 1 } },
-                            0.001, 1);
-    BOOST_CHECK_EQUAL(p.s.size(), 4);
-    BOOST_CHECK_EQUAL(p.h.size(), 4);
-}
-
-BOOST_AUTO_TEST_CASE(construct_4b)
-{
-    fwdpp::generalmut_vec p({ 0.5 }, { { 1, 0, -1, 1 } }, 0.001, 1);
-    BOOST_CHECK_EQUAL(p.s.size(), 1);
-    BOOST_CHECK_EQUAL(p.h.size(), 4);
-}
-
-BOOST_AUTO_TEST_CASE(construct_4c)
-{
-    fwdpp::generalmut_vec p({ 0.5 }, { 1 }, 0.001, 1);
-    BOOST_CHECK_EQUAL(p.s.size(), 1);
-    BOOST_CHECK_EQUAL(p.h.size(), 1);
-}
-
-// Not implemented in library yet
 BOOST_AUTO_TEST_CASE(serialize)
 {
-    fwdpp::generalmut_vec p({ { 0.5, -1 } }, { { 1, 0 } }, 0.001, 1);
+    fwdpp::generalmut_vec p({ ttype{ 0.5, -1 } ,  ttype{ 1, 0 } }, 0.001, 1);
 
     std::ostringstream o;
     fwdpp::io::serialize_mutation<fwdpp::generalmut_vec>()(o, p);
@@ -82,8 +45,7 @@ BOOST_AUTO_TEST_CASE(serialize)
     std::istringstream i(o.str());
     auto p2 = fwdpp::io::deserialize_mutation<fwdpp::generalmut_vec>()(i);
 
-    BOOST_CHECK_EQUAL(p.s.size(), p2.s.size());
-    BOOST_CHECK_EQUAL(p.h.size(), p2.h.size());
+    BOOST_CHECK_EQUAL(p.sh.size(), p2.sh.size());
     BOOST_CHECK_EQUAL(p.g, p2.g);
     BOOST_CHECK_EQUAL(p.pos, p2.pos);
 }
@@ -99,8 +61,7 @@ BOOST_AUTO_TEST_CASE(copy_pop1)
 
 BOOST_FIXTURE_TEST_CASE(construct_from_tuple, generalmut_vec_tuple_wrapper)
 {
-    BOOST_REQUIRE(m.s == s);
-    BOOST_REQUIRE(m.h == h);
+    BOOST_REQUIRE(m.sh == sh);
     BOOST_REQUIRE_EQUAL(m.pos, 2.2);
     BOOST_REQUIRE_EQUAL(m.g, 11);
     BOOST_REQUIRE_EQUAL(m.xtra, 17);

--- a/testsuite/unit/sugar_generalmut_vecTest.cc
+++ b/testsuite/unit/sugar_generalmut_vecTest.cc
@@ -45,6 +45,7 @@ BOOST_AUTO_TEST_CASE(serialize)
     std::istringstream i(o.str());
     auto p2 = fwdpp::io::deserialize_mutation<fwdpp::generalmut_vec>()(i);
 
+    BOOST_REQUIRE(p.sh == p2.sh);
     BOOST_CHECK_EQUAL(p.sh.size(), p2.sh.size());
     BOOST_CHECK_EQUAL(p.g, p2.g);
     BOOST_CHECK_EQUAL(p.pos, p2.pos);


### PR DESCRIPTION
Addresses #67 by merging the two containers for s,h into one container of (s,h) tuples.