### PR TITLE
remove any notion of, or dependency on, a specific ploidy from popbase

### DIFF
--- a/fwdpp/sugar/poptypes/mlocuspop.hpp
+++ b/fwdpp/sugar/poptypes/mlocuspop.hpp
@@ -25,20 +25,20 @@ namespace fwdpp
         template <typename mutation_type, typename mcont, typename gcont,
                   typename dipvector, typename mvector, typename ftvector,
                   typename lookup_table_type>
-        class mlocuspop : public popbase<mutation_type, mcont, gcont, dipvector,
-                                        mvector, ftvector, lookup_table_type>
+        class mlocuspop : public popbase<mutation_type, mcont, gcont, mvector,
+                                         ftvector, lookup_table_type>
         {
           private:
             void
-            process_diploid_input()
+            process_individual_input()
             {
                 std::vector<uint_t> gcounts(this->gametes.size(), 0);
                 for (auto &&locus : diploids)
                     {
                         for (auto &&dip : locus)
                             {
-                                this->validate_diploid_keys(dip.first,
-                                                            dip.second);
+                                this->validate_individual_keys(dip.first);
+                                this->validate_individual_keys(dip.second);
                                 gcounts[dip.first]++;
                                 gcounts[dip.second]++;
                             }
@@ -52,32 +52,30 @@ namespace fwdpp
             mlocuspop(const mlocuspop &) = default;
             mlocuspop &operator=(mlocuspop &&) = default;
             mlocuspop &operator=(const mlocuspop &) = default;
+            using dipvector_t = dipvector;
+            using diploid_t = typename dipvector::value_type;
             //! Dispatch tags for other parts of sugar layer
             using popmodel_t = sugar::MULTILOC_TAG;
             //! Typedef for base class
-            using popbase_t = popbase<mutation_type, mcont, gcont, dipvector,
-                                      mvector, ftvector, lookup_table_type>;
+            using popbase_t = popbase<mutation_type, mcont, gcont, mvector,
+                                      ftvector, lookup_table_type>;
 
-            static_assert(
-                traits::is_multilocus_diploid_t<
-                    typename popbase_t::dipvector_t::value_type>::value,
-                "Require that dipvector_t::value_type be a diploid");
+            static_assert(traits::is_multilocus_diploid_t<diploid_t>::value,
+                          "Require that dipvector_t::value_type be a diploid");
 
             //! Population size
             uint_t N;
 
             //! Container of individuals
-            typename popbase_t::dipvector_t diploids;
+            dipvector_t diploids;
 
             /*! The positional boundaries of each locus/region,
              *  expressed as half-open intervals [min,max).
-             *  If nothing is provided, the intervals are assigned
-             *  [0,i+1) for all 0 <= i < nloci.
              */
             std::vector<std::pair<double, double>> locus_boundaries;
+
             /*! Construct with population size, number of loci,
-             *  and locus boundaries.  If no locus boundaries
-             *  are provided, default values are assigned.
+             *  and locus boundaries.
              */
             mlocuspop(
                 const uint_t &__N, const uint_t &__nloci,
@@ -87,10 +85,7 @@ namespace fwdpp
                     reserve_size
                 = 100)
                 : popbase_t(__nloci * __N, reserve_size), N(__N),
-                  diploids(__N, typename popbase_t::diploid_t(
-                                    __nloci,
-                                    typename popbase_t::diploid_t::value_type(
-                                        0, 0))),
+                  diploids(__N, diploid_t(__nloci, {0,0})),
                   locus_boundaries(locus_boundaries_)
             {
             }
@@ -106,7 +101,7 @@ namespace fwdpp
                   N(d.size()), diploids(std::forward<diploids_input>(d)),
                   locus_boundaries(locus_boundaries_)
             {
-                this->process_diploid_input();
+                this->process_individual_input();
             }
 
             bool

--- a/fwdpp/sugar/poptypes/popbase.hpp
+++ b/fwdpp/sugar/poptypes/popbase.hpp
@@ -12,7 +12,7 @@ namespace fwdpp
     namespace sugar
     {
         template <typename mutation_type, typename mcont, typename gcont,
-                  typename dipvector, typename mvector, typename ftvector,
+                  typename mvector, typename ftvector,
                   typename lookup_table_type>
         class popbase
         /*!
@@ -30,10 +30,10 @@ namespace fwdpp
             /// This function is used to validate input
             /// data.  It should be called from constructors
             /// allowing the initialization of populations
-            /// from pre-calculated diploids, gametes, and mutations.
+            /// from pre-calculated individuals, gametes, and mutations.
             /// \version
             /// Added in 0.5.7
-            virtual void process_diploid_input() = 0;
+            virtual void process_individual_input() = 0;
             void check_mutation_keys(
                 const typename gcont::value_type::mutation_container &m,
                 const mcont &mutations, const bool neutrality);
@@ -44,18 +44,16 @@ namespace fwdpp
             // derived classes implement constructors based
             // on user input of population data.
             void
-            validate_diploid_keys(const std::size_t first,
-                                  const std::size_t second)
+            validate_individual_keys(const std::size_t key)
             {
-                if (first >= this->gametes.size()
-                    || second >= this->gametes.size())
+                if (key >= this->gametes.size())
                     {
                         throw std::out_of_range(
-                            "diploid contains out of range keys");
+                            "individual contains out of range keys");
                     }
-                if (!this->gametes[first].n || !this->gametes[second].n)
+                if (!this->gametes[key].n)
                     {
-                        throw std::runtime_error("diploid refers to "
+                        throw std::runtime_error("key refers to "
                                                  "gamete marked as "
                                                  "extinct");
                     }
@@ -65,11 +63,11 @@ namespace fwdpp
             {
                 for (std::size_t i = 0; i < gcounts.size(); ++i)
                     {
-                        if (gcounts[i] != this->gametes[i].n)
+                        if (gcounts[i] != this->gametes.at(i).n)
                             {
                                 throw std::runtime_error(
                                     "gamete count does not match number of "
-                                    "diploids referring to it");
+                                    "individuals referring to it");
                             }
                     }
             }
@@ -84,10 +82,6 @@ namespace fwdpp
             using mutation_t = mutation_type;
             //! Gamete type
             using gamete_t = typename gcont::value_type;
-            //! Diploid vector type
-            using dipvector_t = dipvector;
-            //! Diploid type
-            using diploid_t = typename dipvector_t::value_type;
             //! Mutation vec type
             using mcont_t = mcont;
             //! Mutation count vector type
@@ -159,8 +153,7 @@ namespace fwdpp
                 typename gamete_t::mutation_container::size_type reserve_size
                 = 100)
                 : // No muts in the population
-                  mutations(mcont_t()),
-                  mcounts(mcount_t()),
+                  mutations(mcont_t()), mcounts(mcount_t()),
                   // The population contains a single gamete in 2N copies
                   gametes(gcont(1, gamete_t(2 * popsize))),
                   neutral(typename gamete_t::mutation_container()),
@@ -214,10 +207,10 @@ namespace fwdpp
         };
 
         template <typename mutation_type, typename mcont, typename gcont,
-                  typename dipvector, typename mvector, typename ftvector,
+                  typename mvector, typename ftvector,
                   typename lookup_table_type>
         void
-        popbase<mutation_type, mcont, gcont, dipvector, mvector, ftvector,
+        popbase<mutation_type, mcont, gcont, mvector, ftvector,
                 lookup_table_type>::
             check_mutation_keys(
                 const typename gcont::value_type::mutation_container &m,
@@ -252,10 +245,10 @@ namespace fwdpp
         }
 
         template <typename mutation_type, typename mcont, typename gcont,
-                  typename dipvector, typename mvector, typename ftvector,
+                  typename mvector, typename ftvector,
                   typename lookup_table_type>
         void
-        popbase<mutation_type, mcont, gcont, dipvector, mvector, ftvector,
+        popbase<mutation_type, mcont, gcont, mvector, ftvector,
                 lookup_table_type>::fill_internal_structures()
         {
             mut_lookup.clear();
@@ -270,8 +263,8 @@ namespace fwdpp
                 {
                     if (g.n)
                         {
-                            //Fixed in 0.5.8: no need to check this for 
-                            //extinct gametes.
+                            // Fixed in 0.5.8: no need to check this for
+                            // extinct gametes.
                             check_mutation_keys(g.mutations, mutations, true);
                             check_mutation_keys(g.smutations, mutations,
                                                 false);

--- a/fwdpp/sugar/poptypes/slocuspop.hpp
+++ b/fwdpp/sugar/poptypes/slocuspop.hpp
@@ -13,7 +13,7 @@ namespace fwdpp
     namespace sugar
     {
         /*!
-          \brief Abstraction of what is needed to simulate a 
+          \brief Abstraction of what is needed to simulate a
           single-locus population.
 
           All that is missing is the mutation_type and the container types.
@@ -25,18 +25,18 @@ namespace fwdpp
         template <typename mutation_type, typename mcont, typename gcont,
                   typename dipvector, typename mvector, typename ftvector,
                   typename lookup_table_type>
-        class slocuspop
-            : public popbase<mutation_type, mcont, gcont, dipvector, mvector,
-                             ftvector, lookup_table_type>
+        class slocuspop : public popbase<mutation_type, mcont, gcont, mvector,
+                                         ftvector, lookup_table_type>
         {
           private:
             void
-            process_diploid_input()
+            process_individual_input()
             {
                 std::vector<uint_t> gcounts(this->gametes.size(), 0);
                 for (auto &&dip : diploids)
                     {
-                        this->validate_diploid_keys(dip.first, dip.second);
+                        this->validate_individual_keys(dip.first);
+                        this->validate_individual_keys(dip.second);
                         gcounts[dip.first]++;
                         gcounts[dip.second]++;
                     }
@@ -52,19 +52,21 @@ namespace fwdpp
             //! Population size
             uint_t N;
 
+            using dipvector_t = dipvector;
+            using diploid_t = typename dipvector::value_type;
             //! Typedef for base class
-            using popbase_t = popbase<mutation_type, mcont, gcont, dipvector,
-                                      mvector, ftvector, lookup_table_type>;
+            using popbase_t = popbase<mutation_type, mcont, gcont, mvector,
+                                      ftvector, lookup_table_type>;
             //! Dispatch tag for other parts of sugar layer
             using popmodel_t = sugar::SINGLELOC_TAG;
             //! Fitness function signature compatible with this type
             using fitness_t
-                = fwdpp::traits::fitness_fxn_t<typename popbase_t::dipvector_t,
+                = fwdpp::traits::fitness_fxn_t<dipvector_t,
                                                typename popbase_t::gcont_t,
                                                typename popbase_t::mcont_t>;
 
             //! Container of diploids
-            typename popbase_t::dipvector_t diploids;
+            dipvector_t diploids;
 
             //! Constructor
             explicit slocuspop(
@@ -74,8 +76,7 @@ namespace fwdpp
                 = 100)
                 : popbase_t(popsize, reserve_size), N(popsize),
                   // All N diploids contain the only gamete in the pop
-                  diploids(typename popbase_t::dipvector_t(
-                      popsize, typename popbase_t::diploid_t(0, 0)))
+                  diploids(dipvector_t(popsize, diploid_t(0, 0)))
             {
             }
 
@@ -89,7 +90,7 @@ namespace fwdpp
                   diploids(std::forward<diploids_input>(d))
             //! Constructor for pre-determined population status
             {
-                this->process_diploid_input();
+                this->process_individual_input();
             }
 
             bool


### PR DESCRIPTION
Refactors `fwdpp::sugar::popbase` to not depend on a specific ploidy.  This change both enables ploidy values other than two and enables `slocuspop` and `mlocuspop` objects based on the same mutation/gamete types to inherit from a common base class.

This is an ABI change, but not an API change.