### PR TITLE
Refactor discrete rec model

### DIFF
--- a/testsuite/fixtures/sugar_fixtures.hpp
+++ b/testsuite/fixtures/sugar_fixtures.hpp
@@ -65,15 +65,15 @@ class mlocuspop_popgenmut_fixture
     }
     /* We are going to generate a set of recombination
      * regions for a multi-locus
-     * simulation.  There will be five loci total.  Each locus
+     * simulation.  There will be four loci total.  Each locus
      * (i=0 through 4) will have recombination occurring on
-     * the continuous inerval [i*10,i*10+10).  Further,
+     * the continuous inerval [i,i+1).  Further,
      * each locus will have three regions of different
      * relative recombination rates.  The positions of each
      * region in each locus will be:
-     * [i*10,i*10+3)
-     * [i*10+3,i*10+7)
-     * [i*10+7,i*10+10)
+     * [i,i+1/3)
+     * [i+1/3,i+2/3)
+     * [i,i+1)
      * The relative weight on each region will be 1,10,1.
      * The total recombination rate on each region will be 1e-4
      * per diploid, per generation.
@@ -81,17 +81,32 @@ class mlocuspop_popgenmut_fixture
     std::vector<fwdpp::extensions::discrete_rec_model>
     fill_vdrm(const gsl_rng *r)
     {
+        double recrate_region = 1e-4;
         // set up a vector of extensions::discrete_rec_model
         // with different regions sizes and weights
-        double length = 10.;
         std::vector<fwdpp::extensions::discrete_rec_model> vdrm_;
         for (unsigned i = 0; i < 4; ++i)
             {
-                double begin = static_cast<double>(i) * length;
+                std::vector<
+                    fwdpp::extensions::discrete_rec_model::function_type>
+                    f;
+                std::vector<double> w{ 1., 10., 1. };
+                f.push_back([&r, i](std::vector<double> &b) {
+                    b.push_back(
+                        gsl_ran_flat(r, static_cast<double>(i),
+                                     static_cast<double>(i) + 1. / 3.));
+                });
+                f.push_back([&r, i](std::vector<double> &b) {
+                    b.push_back(
+                        gsl_ran_flat(r, static_cast<double>(i) + 1. / 3,
+                                     static_cast<double>(i) + 2. / 3.));
+                });
+                f.push_back([&r, i](std::vector<double> &b) {
+                    b.push_back(gsl_ran_flat(r, static_cast<double>(i),
+                                             static_cast<double>(i) + 1.));
+                });
                 fwdpp::extensions::discrete_rec_model drm(
-                    r, 1e-3, { begin, begin + 3., begin + 7. },
-                    { begin + 3., begin + 7., begin + length },
-                    { 1., 10., 1. });
+                    recrate_region, std::move(f), std::move(w));
                 vdrm_.emplace_back(std::move(drm));
             }
         return vdrm_;
@@ -112,15 +127,17 @@ class mlocuspop_popgenmut_fixture
         {
             using dip_t = poptype::dipvector_t::value_type::value_type;
             return std::max(
-                0., 1. + std::accumulate(
-                             diploid.begin(), diploid.end(), 0.,
-                             [&gametes, &mutations](const double d,
-                                                    const dip_t &dip) {
-                                 return d + fwdpp::additive_diploid()(
-                                                gametes[dip.first],
-                                                gametes[dip.second], mutations)
-                                        - 1.;
-                             }));
+                0., 1.
+                        + std::accumulate(
+                              diploid.begin(), diploid.end(), 0.,
+                              [&gametes, &mutations](const double d,
+                                                     const dip_t &dip) {
+                                  return d
+                                         + fwdpp::additive_diploid()(
+                                               gametes[dip.first],
+                                               gametes[dip.second], mutations)
+                                         - 1.;
+                              }));
         }
     };
     poptype pop;
@@ -132,11 +149,10 @@ class mlocuspop_popgenmut_fixture
     std::vector<fwdpp::extensions::discrete_mut_model<poptype::mcont_t>> vdmm;
     std::vector<mutmodel> bound_mmodels;
     std::vector<fwdpp::extensions::discrete_rec_model> vdrm;
+    std::vector<std::function<std::vector<double>(void)>> bound_recmodels;
     mlocuspop_popgenmut_fixture(const unsigned seed = 0)
         /*! N=1000, 4 loci */
-        : pop(poptype(1000, 4)),
-          generation(0),
-          rng(rng_t(seed)),
+        : pop(poptype(1000, 4)), generation(0), rng(rng_t(seed)),
           mu(std::vector<double>(4, 0.005)),
           rbw(std::vector<double>(3, 0.005)),
           mutmodels(
@@ -155,14 +171,13 @@ class mlocuspop_popgenmut_fixture
                           [this]() { return gsl_ran_flat(rng.get(), 1., 2.); },
                           []() { return -0.01; }, []() { return 1.; }),
                 // Locus 2: positions Uniform [2,3)
-                std::bind(fwdpp::infsites(), std::placeholders::_1,
-                          std::placeholders::_2, this->rng.get(),
-                          std::ref(pop.mut_lookup), &this->generation, 0.0025,
-                          0.0025,
-                          [this]() {
-                              return gsl_ran_flat(this->rng.get(), 2., 3.);
-                          },
-                          []() { return -0.01; }, []() { return 1.; }),
+                std::bind(
+                    fwdpp::infsites(), std::placeholders::_1,
+                    std::placeholders::_2, this->rng.get(),
+                    std::ref(pop.mut_lookup), &this->generation, 0.0025,
+                    0.0025,
+                    [this]() { return gsl_ran_flat(this->rng.get(), 2., 3.); },
+                    []() { return -0.01; }, []() { return 1.; }),
                 // Locus 3: positions Uniform [3,4)
                 std::bind(fwdpp::infsites(), std::placeholders::_1,
                           std::placeholders::_2, this->rng.get(),
@@ -175,21 +190,15 @@ class mlocuspop_popgenmut_fixture
                       fwdpp::poisson_xover(rng.get(), 0.005, 2., 3.),
                       fwdpp::poisson_xover(rng.get(), 0.005, 3., 4.) }),
           vdmm(this->fill_vdmm(mutmodels)),
-		  bound_mmodels(fwdpp::extensions::bind_vec_dmm(rng.get(),vdmm)),
-          vdrm(this->fill_vdrm(rng.get()))
+          bound_mmodels(fwdpp::extensions::bind_vec_dmm(rng.get(), vdmm)),
+          vdrm(this->fill_vdrm(rng.get())), bound_recmodels{}
     {
         for (unsigned i = 0; i < vdrm.size(); ++i)
             {
                 pop.locus_boundaries.emplace_back(i, i + 1);
+                bound_recmodels.emplace_back(
+                    [this, i]() { return vdrm.at(i)(rng.get()); });
             }
-        //for (auto &i : vdmm)
-        //    {
-        //        auto bound_mm = [&i, this](std::queue<std::size_t> &bin,
-        //                                   poptype::mcont_t &mutations) {
-        //            return i(rng.get(), bin, mutations);
-        //        };
-        //        bound_mmodels.emplace_back(std::move(bound_mm));
-        //    }
     }
 };
 

--- a/testsuite/fixtures/sugar_fixtures.hpp
+++ b/testsuite/fixtures/sugar_fixtures.hpp
@@ -66,7 +66,7 @@ class mlocuspop_popgenmut_fixture
     /* We are going to generate a set of recombination
      * regions for a multi-locus
      * simulation.  There will be four loci total.  Each locus
-     * (i=0 through 4) will have recombination occurring on
+     * (i=0 through 3) will have recombination occurring on
      * the continuous inerval [i,i+1).  Further,
      * each locus will have three regions of different
      * relative recombination rates.  The positions of each

--- a/testsuite/integration/extensions_regionsIntegrationTest.cc
+++ b/testsuite/integration/extensions_regionsIntegrationTest.cc
@@ -151,21 +151,12 @@ BOOST_AUTO_TEST_CASE(test_bind_vec_dmm_drm)
 
     // the mutation rates to neutral/selected variants
     std::vector<double> neutral_mutrates(4, 1e-3), selected_mutrates(4, 0.);
-    // create the bound callbacks
-    //const auto bound_mutmodels
-    //    = [&rng, &vdmm](fwdpp::traits::recycling_bin_t<poptype::mcont_t>
-    //                      &mutation_recycling_bin,
-    //                  poptype::mcont_t &mutations) {
-    //          return mmodels(rng.get(), mutation_recycling_bin, mutations);
-    //      };
-    // auto bound_mutmodels = extensions::bind_vec_dmm(
-    //    vdmm, pop.mutations, pop.mut_lookup, rng.get(), neutral_mutrates,
-    //    selected_mutrates, &generation);
+
     auto interlocus_rec = fwdpp::make_binomial_interlocus_rec(
         rng.get(), rbw.data(), rbw.size());
     double wbar = sample_diploid(
         rng.get(), pop.gametes, pop.diploids, pop.mutations, pop.mcounts,
-        pop.N, &mu[0], bound_mmodels, vdrm, interlocus_rec,
+        pop.N, &mu[0], bound_mmodels, bound_recmodels, interlocus_rec,
         std::bind(multilocus_additive(), std::placeholders::_1,
                   std::placeholders::_2, std::placeholders::_3),
         pop.neutral, pop.selected);


### PR DESCRIPTION
Refactor `fwdpp::extenstions::discrete_rec_model` in terms of `std::function` + weights, similar to what #113 did for mutations.