### PR TITLE
Juvenile migration example

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -2,7 +2,8 @@ noinst_PROGRAMS=	diploid_ind \
 	diploid_fixed_sh_ind \
 	K_linked_regions_multilocus \
 	K_linked_regions_extensions \
-	K_linked_regions_generalized_rec 
+	K_linked_regions_generalized_rec \
+	juvenile_migration
 
 
 diploid_ind_SOURCES=diploid_ind.cc common_ind.hpp
@@ -10,6 +11,7 @@ diploid_fixed_sh_ind_SOURCES=diploid_fixed_sh_ind.cc common_ind.hpp
 K_linked_regions_multilocus_SOURCES=K_linked_regions_multilocus.cc common_ind.hpp
 K_linked_regions_extensions_SOURCES=K_linked_regions_extensions.cc common_ind.hpp
 K_linked_regions_generalized_rec_SOURCES=K_linked_regions_generalized_rec.cc common_ind.hpp
+juvenile_migration_SOURCES=juvenile_migration.cc common_ind.hpp
 
 AM_CPPFLAGS=-Wall -W -I.
 

--- a/examples/Makefile.in
+++ b/examples/Makefile.in
@@ -89,7 +89,8 @@ POST_UNINSTALL = :
 noinst_PROGRAMS = diploid_ind$(EXEEXT) diploid_fixed_sh_ind$(EXEEXT) \
 	K_linked_regions_multilocus$(EXEEXT) \
 	K_linked_regions_extensions$(EXEEXT) \
-	K_linked_regions_generalized_rec$(EXEEXT)
+	K_linked_regions_generalized_rec$(EXEEXT) \
+	juvenile_migration$(EXEEXT)
 @HAVE_LIBSEQ_RUNTIME_TRUE@@HAVE_SIMDATA_HPP_TRUE@am__append_1 = -DHAVE_LIBSEQUENCE
 @DEBUG_FALSE@am__append_2 = -DNDEBUG
 subdir = examples
@@ -130,6 +131,10 @@ am_diploid_ind_OBJECTS = diploid_ind.$(OBJEXT)
 diploid_ind_OBJECTS = $(am_diploid_ind_OBJECTS)
 diploid_ind_LDADD = $(LDADD)
 diploid_ind_DEPENDENCIES =
+am_juvenile_migration_OBJECTS = juvenile_migration.$(OBJEXT)
+juvenile_migration_OBJECTS = $(am_juvenile_migration_OBJECTS)
+juvenile_migration_LDADD = $(LDADD)
+juvenile_migration_DEPENDENCIES =
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
 am__v_P_0 = false
@@ -174,11 +179,13 @@ am__v_CCLD_1 =
 SOURCES = $(K_linked_regions_extensions_SOURCES) \
 	$(K_linked_regions_generalized_rec_SOURCES) \
 	$(K_linked_regions_multilocus_SOURCES) \
-	$(diploid_fixed_sh_ind_SOURCES) $(diploid_ind_SOURCES)
+	$(diploid_fixed_sh_ind_SOURCES) $(diploid_ind_SOURCES) \
+	$(juvenile_migration_SOURCES)
 DIST_SOURCES = $(K_linked_regions_extensions_SOURCES) \
 	$(K_linked_regions_generalized_rec_SOURCES) \
 	$(K_linked_regions_multilocus_SOURCES) \
-	$(diploid_fixed_sh_ind_SOURCES) $(diploid_ind_SOURCES)
+	$(diploid_fixed_sh_ind_SOURCES) $(diploid_ind_SOURCES) \
+	$(juvenile_migration_SOURCES)
 am__can_run_installinfo = \
   case $$AM_UPDATE_INFO_DIR in \
     n|no|NO) false;; \
@@ -307,6 +314,7 @@ diploid_fixed_sh_ind_SOURCES = diploid_fixed_sh_ind.cc common_ind.hpp
 K_linked_regions_multilocus_SOURCES = K_linked_regions_multilocus.cc common_ind.hpp
 K_linked_regions_extensions_SOURCES = K_linked_regions_extensions.cc common_ind.hpp
 K_linked_regions_generalized_rec_SOURCES = K_linked_regions_generalized_rec.cc common_ind.hpp
+juvenile_migration_SOURCES = juvenile_migration.cc common_ind.hpp
 AM_CPPFLAGS = -Wall -W -I. $(am__append_2)
 AM_CXXFLAGS = $(am__append_1)
 @HAVE_LIBSEQ_RUNTIME_TRUE@@HAVE_SIMDATA_HPP_TRUE@AM_LIBS = -lsequence
@@ -368,6 +376,10 @@ diploid_ind$(EXEEXT): $(diploid_ind_OBJECTS) $(diploid_ind_DEPENDENCIES) $(EXTRA
 	@rm -f diploid_ind$(EXEEXT)
 	$(AM_V_CXXLD)$(CXXLINK) $(diploid_ind_OBJECTS) $(diploid_ind_LDADD) $(LIBS)
 
+juvenile_migration$(EXEEXT): $(juvenile_migration_OBJECTS) $(juvenile_migration_DEPENDENCIES) $(EXTRA_juvenile_migration_DEPENDENCIES) 
+	@rm -f juvenile_migration$(EXEEXT)
+	$(AM_V_CXXLD)$(CXXLINK) $(juvenile_migration_OBJECTS) $(juvenile_migration_LDADD) $(LIBS)
+
 mostlyclean-compile:
 	-rm -f *.$(OBJEXT)
 
@@ -379,6 +391,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/K_linked_regions_multilocus.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/diploid_fixed_sh_ind.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/diploid_ind.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/juvenile_migration.Po@am__quote@
 
 .cc.o:
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)depbase=`echo $@ | sed 's|[^/]*$$|$(DEPDIR)/&|;s|\.o$$||'`;\

--- a/examples/juvenile_migration.cc
+++ b/examples/juvenile_migration.cc
@@ -237,8 +237,7 @@ main(int argc, char **argv)
                 r.get(), pop.gametes, pop.diploids, pop.mutations, pop.mcounts,
                 N, mu_neutral + mu_del, mmodel,
                 // The function to generation recombination positions:
-                rec, fwdpp::multiplicative_diploid(1.), pop.neutral,
-                pop.selected);
+                rec, wfxn, pop.neutral, pop.selected);
             fwdpp::update_mutations(pop.mutations, pop.fixations,
                                     pop.fixation_times, pop.mut_lookup,
                                     pop.mcounts, generation, 2 * N);

--- a/examples/juvenile_migration.cc
+++ b/examples/juvenile_migration.cc
@@ -49,20 +49,22 @@ migrate_and_calc_fitness(const gsl_rng *r, singlepop_t &pop,
     for (unsigned i = 0; i < nmig12; ++i)
         {
             auto mig = static_cast<uint_t>(gsl_ran_flat(r, 0, N1));
-            if (migrants.find(mig) == migrants.end())
+            while (migrants.find(mig) != migrants.end())
                 {
-                    deme_labels[i] = !deme_labels[i];
-                    migrants.insert(mig);
+                    mig = static_cast<uint_t>(gsl_ran_flat(r, 0, N1));
                 }
+            deme_labels[i] = !deme_labels[i];
+            migrants.insert(mig);
         }
     for (unsigned i = 0; i < nmig21; ++i)
         {
             auto mig = static_cast<uint_t>(gsl_ran_flat(r, N1, N1 + N2));
-            if (migrants.find(mig) == migrants.end())
+            while (migrants.find(mig) != migrants.end())
                 {
-                    deme_labels[i] = !deme_labels[i];
-                    migrants.insert(mig);
+                    mig = static_cast<uint_t>(gsl_ran_flat(r, N1, N1 + N2));
                 }
+            deme_labels[i] = !deme_labels[i];
+            migrants.insert(mig);
         }
     for (std::size_t i = 0; i < deme_labels.size(); ++i)
         {

--- a/examples/juvenile_migration.cc
+++ b/examples/juvenile_migration.cc
@@ -1,0 +1,247 @@
+/*
+  \include juvenile_migration.cc
+ *  Juvenile migration.
+ *  Selection.
+ *  Constant pop size.
+*/
+#include <fwdpp/diploid.hh>
+#include <fwdpp/recbinder.hpp>
+#ifdef HAVE_LIBSEQUENCE
+#include <Sequence/SimData.hpp>
+#endif
+#include <numeric>
+#include <functional>
+#include <cassert>
+#include <iomanip>
+#include <fwdpp/sugar/popgenmut.hpp>
+#define SINGLEPOP_SIM
+// the type of mutation
+using mtype = fwdpp::popgenmut;
+#include <common_ind.hpp>
+#include <gsl/gsl_randist.h>
+using namespace fwdpp;
+
+struct parent_lookup_tables
+{
+    fwdpp_internal::gsl_ran_discrete_t_ptr lookup1, lookup2;
+    std::vector<std::size_t> parents1, parents2;
+};
+
+template <typename fitness_fxn>
+parent_lookup_tables
+migrate_and_calc_fitness(const gsl_rng *r, singlepop_t &pop,
+                         const fitness_fxn &wfxn, const uint_t N1,
+                         const uint_t N2, const double m12, const double m21)
+// Neither the most rigorous nor the most efficient:
+// 1. Ignores probability of back-migration.
+// 2. Allocates 4 vectors each generation.
+{
+    parent_lookup_tables rv;
+    std::vector<double> w1, w2;
+
+    unsigned nmig12 = gsl_ran_poisson(r, static_cast<double>(N1) * m12);
+    unsigned nmig21 = gsl_ran_poisson(r, static_cast<double>(N2) * m21);
+
+    std::vector<uint_t> deme_labels(N1, 0);
+    deme_labels.resize(N1 + N2, 1);
+    assert(deme_labels.size() == pop.diploids.size());
+    std::unordered_set<uint_t> migrants;
+    for (unsigned i = 0; i < nmig12; ++i)
+        {
+            auto mig = static_cast<uint_t>(gsl_ran_flat(r, 0, N1));
+            if (migrants.find(mig) == migrants.end())
+                {
+                    deme_labels[i] = !deme_labels[i];
+                    migrants.insert(mig);
+                }
+        }
+    for (unsigned i = 0; i < nmig21; ++i)
+        {
+            auto mig = static_cast<uint_t>(gsl_ran_flat(r, N1, N1 + N2));
+            if (migrants.find(mig) == migrants.end())
+                {
+                    deme_labels[i] = !deme_labels[i];
+                    migrants.insert(mig);
+                }
+        }
+    for (std::size_t i = 0; i < deme_labels.size(); ++i)
+        {
+            pop.gametes[pop.diploids[i].first].n
+                = pop.gametes[pop.diploids[i].second].n = 0;
+            if (deme_labels[i] == 0)
+                {
+                    rv.parents1.push_back(i);
+                    w1.push_back(
+                        wfxn(pop.diploids[i], pop.gametes, pop.mutations));
+                }
+            else
+                {
+                    rv.parents2.push_back(i);
+                    w2.push_back(
+                        wfxn(pop.diploids[i], pop.gametes, pop.mutations));
+                }
+        }
+    rv.lookup1.reset(gsl_ran_discrete_preproc(rv.parents1.size(), w1.data()));
+    rv.lookup2.reset(gsl_ran_discrete_preproc(rv.parents2.size(), w2.data()));
+    return rv;
+};
+
+template <typename fitness_fxn, typename rec_fxn, typename mut_fxn>
+void
+evolve_two_demes(const gsl_rng *r, singlepop_t &pop, const uint_t N1,
+                 const uint_t N2, const double m12, const double m21,
+                 const double mu, const fitness_fxn &wfxn,
+                 const rec_fxn &recfxn, const mut_fxn &mutfxn)
+{
+    auto mut_recycling_bin = fwdpp_internal::make_mut_queue(pop.mcounts);
+    auto gam_recycling_bin = fwdpp_internal::make_gamete_queue(pop.gametes);
+
+    auto lookups = migrate_and_calc_fitness(r, pop, wfxn, N1, N2, m12, m21);
+#ifndef NDEBUG
+    for (const auto &g : pop.gametes)
+        assert(!g.n);
+#endif
+    const auto parents(pop.diploids);
+
+    // Fill in the next generation!
+    for (uint_t i = 0; i < N1 + N2; ++i)
+        {
+            std::size_t p1 = std::numeric_limits<std::size_t>::max();
+            std::size_t p2 = std::numeric_limits<std::size_t>::max();
+            if (i < N1)
+                {
+                    p1 = lookups.parents1[gsl_ran_discrete(
+                        r, lookups.lookup1.get())];
+                    p2 = lookups.parents1[gsl_ran_discrete(
+                        r, lookups.lookup1.get())];
+                }
+            else
+                {
+                    p1 = lookups.parents2[gsl_ran_discrete(
+                        r, lookups.lookup2.get())];
+                    p2 = lookups.parents2[gsl_ran_discrete(
+                        r, lookups.lookup2.get())];
+                }
+            assert(p1 < parents.size());
+            assert(p2 < parents.size());
+            /*
+              These are the gametes from each parent.
+              This is a trivial assignment if keys.
+            */
+            auto p1g1 = parents[p1].first;
+            auto p1g2 = parents[p1].second;
+            auto p2g1 = parents[p2].first;
+            auto p2g2 = parents[p2].second;
+
+            if (gsl_rng_uniform(r) < 0.5)
+                std::swap(p1g1, p1g2);
+            if (gsl_rng_uniform(r) < 0.5)
+                std::swap(p2g1, p2g2);
+
+            mutate_recombine_update(r, pop.gametes, pop.mutations,
+                                    std::make_tuple(p1g1, p1g2, p2g1, p2g2),
+                                    recfxn, mutfxn, mu, gam_recycling_bin,
+                                    mut_recycling_bin, pop.diploids[i],
+                                    pop.neutral, pop.selected);
+        }
+    assert(check_sum(pop.gametes, 2 * (N1 + N2)));
+#ifndef NDEBUG
+    for (const auto &dip : pop.diploids)
+        {
+            assert(pop.gametes[dip.first].n > 0);
+            assert(pop.gametes[dip.first].n <= 2 * (N1 + N2));
+            assert(pop.gametes[dip.second].n > 0);
+            assert(pop.gametes[dip.second].n <= 2 * (N1 + N2));
+        }
+#endif
+    fwdpp_internal::process_gametes(pop.gametes, pop.mutations, pop.mcounts);
+
+    assert(pop.mcounts.size() == pop.mutations.size());
+#ifndef NDEBUG
+    for (const auto &mc : pop.mcounts)
+        {
+            assert(mc <= 2 * (N1 + N2));
+        }
+#endif
+    assert(
+        popdata_sane(pop.diploids, pop.gametes, pop.mutations, pop.mcounts));
+
+    fwdpp_internal::gamete_cleaner(pop.gametes, pop.mutations, pop.mcounts,
+                                   2 * (N1 + N2), std::true_type());
+}
+
+int
+main(int argc, char **argv)
+{
+    if (argc != 12)
+        {
+            std::cerr
+                << "Too few arguments.\n"
+                << "Usage: juvenile_migration N1 N1 m12 m21 theta_neutral "
+                   "theta_deleterious rho s h ngens "
+                   "seed\n";
+            exit(0);
+        }
+    int argument = 1;
+    const unsigned N1 = atoi(argv[argument++]);
+    const unsigned N2 = atoi(argv[argument++]);
+    const double m12 = atof(argv[argument++]);
+    const double m21 = atof(argv[argument++]);
+    const double theta_neutral = atof(argv[argument++]);
+    const double theta_del = atof(argv[argument++]);
+    const double rho = atof(argv[argument++]);
+    const double s = atof(argv[argument++]);
+    const double h = atof(argv[argument++]);
+    const unsigned ngens = atoi(argv[argument++]);
+    const unsigned seed = atoi(argv[argument++]);
+
+    const unsigned N = N1 + N2; // Total metapop size, for convenience
+    const double mu_neutral = theta_neutral / double(4 * N);
+    const double mu_del = theta_del / double(4 * N);
+    const double littler = rho / double(4 * N);
+
+    std::copy(argv, argv + argc,
+              std::ostream_iterator<char *>(std::cerr, " "));
+    std::cerr << '\n';
+
+    GSLrng r(seed);
+
+    // recombination map is uniform[0,1)
+    const auto rec
+        = fwdpp::recbinder(fwdpp::poisson_xover(littler, 0., 1.), r.get());
+
+    const double pselected = mu_del / (mu_del + mu_neutral);
+
+    auto wfxn = fwdpp::multiplicative_diploid(1.);
+    singlepop_t pop(N);
+    pop.mutations.reserve(
+        size_t(std::ceil(std::log(2 * N) * (theta_neutral + theta_del)
+                         + 0.667 * (theta_neutral + theta_del))));
+    unsigned generation = 0;
+    const auto mmodel = [&pop, &r, &generation, s, h,
+                         pselected](std::queue<std::size_t> &recbin,
+                                    singlepop_t::mcont_t &mutations) {
+        return fwdpp::infsites_popgenmut(
+            recbin, mutations, r.get(), pop.mut_lookup, generation, pselected,
+            [&r]() { return gsl_rng_uniform(r.get()); }, [s]() { return s; },
+            [h]() { return h; });
+    };
+
+    double wbar = 1;
+    for (generation = 0; generation < ngens; ++generation)
+        {
+            assert(fwdpp::check_sum(pop.gametes, 2 * (N1 + N2)));
+            evolve_two_demes(r.get(), pop, N1, N2, m12, m21,
+                             mu_neutral + mu_del, wfxn, rec, mmodel);
+            wbar = fwdpp::sample_diploid(
+                r.get(), pop.gametes, pop.diploids, pop.mutations, pop.mcounts,
+                N, mu_neutral + mu_del, mmodel,
+                // The function to generation recombination positions:
+                rec, fwdpp::multiplicative_diploid(1.), pop.neutral,
+                pop.selected);
+            fwdpp::update_mutations(pop.mutations, pop.fixations,
+                                    pop.fixation_times, pop.mut_lookup,
+                                    pop.mcounts, generation, 2 * N);
+            assert(fwdpp::check_sum(pop.gametes, 2 * N));
+        }
+}

--- a/examples/juvenile_migration.cc
+++ b/examples/juvenile_migration.cc
@@ -1,9 +1,66 @@
-/*
-  \include juvenile_migration.cc
+/*  \include juvenile_migration.cc
+ *
  *  Juvenile migration.
  *  Selection.
  *  Constant pop size.
-*/
+ *  Unequal migration rates.
+ *
+ * The goal is to show how to use a population
+ * object to handle details of population structure.
+ *
+ * The outline of the scheme is as follows:
+ *
+ * 1. Offspring are generated in sorted order by deme
+ * label.  In other words, deme 1 before deme 2.
+ *
+ * 2. Each generation, we migrate first.  Thus,
+ * we may start a generation with parents like this:
+ *
+ * Parent Deme
+ * 0    0
+ * 1    0
+ * 2    0
+ * 3    1
+ * 4    1
+ * 5    1
+ *
+ * After migration, we may end up with:
+ *
+ * Parent Deme
+ * 0    1*
+ * 1    0
+ * 2    0
+ * 3    1
+ * 4    0*
+ * 5    1
+ *
+ * An asterisk represent migrant individuals.
+ *
+ * We will generate efficient lookup tables to sample individuals
+ * proportional to their within-deme fitness, post-migration.
+ *
+ * These lookup tables will map to the indexes of the parents of each
+ * deme:
+ *
+ * Lookup 1:
+ *
+ * Index Parent
+ * 0    1
+ * 1    2
+ * 2    4
+ *
+ * Lookup 2:
+ * Index Parent
+ * 0    0
+ * 1    3
+ * 1    5
+ *
+ * The code is not safe for real-world use.  It doesn't handle the corner
+ * case of all of deme 1 migrating into deme 2, leaving deme 1 "extinct"
+ * in the next generation.  Such edge cases are clearly important, but
+ * the goal here it to show the book-keeping of parental fitnesses
+ * and the mapping back to deme labels.
+ */
 #include <fwdpp/diploid.hh>
 #include <fwdpp/recbinder.hpp>
 #ifdef HAVE_LIBSEQUENCE
@@ -12,7 +69,6 @@
 #include <numeric>
 #include <functional>
 #include <cassert>
-#include <iomanip>
 #include <fwdpp/sugar/popgenmut.hpp>
 #define SINGLEPOP_SIM
 // the type of mutation
@@ -22,8 +78,15 @@ using mtype = fwdpp::popgenmut;
 using namespace fwdpp;
 
 struct parent_lookup_tables
+// Our object for choosing parents each generation
 {
+    // These return indexes of parents from demes 1 and 2,
+    // resp, chosen in O(1) time proportional to
+    // relative fitness within each deme
     fwdpp_internal::gsl_ran_discrete_t_ptr lookup1, lookup2;
+    // These vectors map indexes returned from sampling
+    // lookup1 and lookup2 to diploids in the population
+    // object.
     std::vector<std::size_t> parents1, parents2;
 };
 
@@ -32,32 +95,53 @@ parent_lookup_tables
 migrate_and_calc_fitness(const gsl_rng *r, singlepop_t &pop,
                          const fitness_fxn &wfxn, const uint_t N1,
                          const uint_t N2, const double m12, const double m21)
+// This function will be called at the start of each generation.
+// The main goal is to return the lookup tables described above.
+// But, "while we're at it", it does some other stuff that
+// needs to be done at the start of each generation.
 // Neither the most rigorous nor the most efficient:
 // 1. Ignores probability of back-migration.
 // 2. Allocates 4 vectors each generation.
 {
     parent_lookup_tables rv;
+
+    // Temp containers for fitnesses in each deme,
+    // post-migration
     std::vector<double> w1, w2;
 
+    // Pick no. migrants 1 -> 2 and 2 -> 1.
     unsigned nmig12 = gsl_ran_poisson(r, static_cast<double>(N1) * m12);
     unsigned nmig21 = gsl_ran_poisson(r, static_cast<double>(N2) * m21);
 
+    // Fill a vector of N1 zeros and N2 ones:
     std::vector<uint_t> deme_labels(N1, 0);
     deme_labels.resize(N1 + N2, 1);
     assert(deme_labels.size() == pop.diploids.size());
+
+    // A lookup table to facilitate
+    // sampling migrants w/o replacement
     std::unordered_set<uint_t> migrants;
+
+    // Who is migrating 1 -> 2?
     for (unsigned i = 0; i < nmig12; ++i)
         {
+            // Sample an individual w/o replacement from deme 1:
             auto mig = static_cast<uint_t>(gsl_ran_flat(r, 0, N1));
             while (migrants.find(mig) != migrants.end())
                 {
                     mig = static_cast<uint_t>(gsl_ran_flat(r, 0, N1));
                 }
+            // Flip the deme label:
             deme_labels[i] = !deme_labels[i];
+
+            // Prevent sampling this individual again:
             migrants.insert(mig);
         }
+
+    // Exact same logic for migrants 2 -> 1
     for (unsigned i = 0; i < nmig21; ++i)
         {
+            // Mind your ranges for generating indexes:
             auto mig = static_cast<uint_t>(gsl_ran_flat(r, N1, N1 + N2));
             while (migrants.find(mig) != migrants.end())
                 {
@@ -66,8 +150,17 @@ migrate_and_calc_fitness(const gsl_rng *r, singlepop_t &pop,
             deme_labels[i] = !deme_labels[i];
             migrants.insert(mig);
         }
+
+    // Go over all parents, set gametes counts to zero,
+    // and put individual IDs and fitnesses into
+    // the right vectors:
     for (std::size_t i = 0; i < deme_labels.size(); ++i)
         {
+            // fwdpp requires that we zero out gamete
+            // counts each generation.  Since we're looping
+            // over diploids here, now is a good time to
+            // handle this task, which saves us from having to
+            // do another O(N1+N2) loop:
             pop.gametes[pop.diploids[i].first].n
                 = pop.gametes[pop.diploids[i].second].n = 0;
             if (deme_labels[i] == 0)
@@ -83,6 +176,8 @@ migrate_and_calc_fitness(const gsl_rng *r, singlepop_t &pop,
                         wfxn(pop.diploids[i], pop.gametes, pop.mutations));
                 }
         }
+
+    // Set up our lookup tables:
     rv.lookup1.reset(gsl_ran_discrete_preproc(rv.parents1.size(), w1.data()));
     rv.lookup2.reset(gsl_ran_discrete_preproc(rv.parents2.size(), w2.data()));
     return rv;
@@ -95,29 +190,36 @@ evolve_two_demes(const gsl_rng *r, singlepop_t &pop, const uint_t N1,
                  const double mu, const fitness_fxn &wfxn,
                  const rec_fxn &recfxn, const mut_fxn &mutfxn)
 {
+    // Handle mutation/gamete "recycling":
     auto mut_recycling_bin = fwdpp_internal::make_mut_queue(pop.mcounts);
     auto gam_recycling_bin = fwdpp_internal::make_gamete_queue(pop.gametes);
 
+    // Migration and build lookup tables:
     auto lookups = migrate_and_calc_fitness(r, pop, wfxn, N1, N2, m12, m21);
+
 #ifndef NDEBUG
     for (const auto &g : pop.gametes)
         assert(!g.n);
 #endif
+
+    // Copy parents
     const auto parents(pop.diploids);
 
     // Fill in the next generation!
+    // We generate the offspring for deme 1 first,
+    // and then for deme 2
     for (uint_t i = 0; i < N1 + N2; ++i)
         {
             std::size_t p1 = std::numeric_limits<std::size_t>::max();
             std::size_t p2 = std::numeric_limits<std::size_t>::max();
-            if (i < N1)
+            if (i < N1) // pick parents from pop 1
                 {
                     p1 = lookups.parents1[gsl_ran_discrete(
                         r, lookups.lookup1.get())];
                     p2 = lookups.parents1[gsl_ran_discrete(
                         r, lookups.lookup1.get())];
                 }
-            else
+            else // pick parents from pop 2
                 {
                     p1 = lookups.parents2[gsl_ran_discrete(
                         r, lookups.lookup2.get())];
@@ -126,15 +228,16 @@ evolve_two_demes(const gsl_rng *r, singlepop_t &pop, const uint_t N1,
                 }
             assert(p1 < parents.size());
             assert(p2 < parents.size());
+
             /*
               These are the gametes from each parent.
-              This is a trivial assignment if keys.
             */
             auto p1g1 = parents[p1].first;
             auto p1g2 = parents[p1].second;
             auto p2g1 = parents[p2].first;
             auto p2g2 = parents[p2].second;
 
+            // "Mendel"
             if (gsl_rng_uniform(r) < 0.5)
                 std::swap(p1g1, p1g2);
             if (gsl_rng_uniform(r) < 0.5)
@@ -156,6 +259,8 @@ evolve_two_demes(const gsl_rng *r, singlepop_t &pop, const uint_t N1,
             assert(pop.gametes[dip.second].n <= 2 * (N1 + N2));
         }
 #endif
+
+    // Update mutation counts
     fwdpp_internal::process_gametes(pop.gametes, pop.mutations, pop.mcounts);
 
     assert(pop.mcounts.size() == pop.mutations.size());
@@ -168,6 +273,7 @@ evolve_two_demes(const gsl_rng *r, singlepop_t &pop, const uint_t N1,
     assert(
         popdata_sane(pop.diploids, pop.gametes, pop.mutations, pop.mcounts));
 
+    // Prune fixations from gametes
     fwdpp_internal::gamete_cleaner(pop.gametes, pop.mutations, pop.mcounts,
                                    2 * (N1 + N2), std::true_type());
 }
@@ -233,6 +339,8 @@ main(int argc, char **argv)
     for (generation = 0; generation < ngens; ++generation)
         {
             assert(fwdpp::check_sum(pop.gametes, 2 * (N1 + N2)));
+
+            // Call our fancy new evolve function
             evolve_two_demes(r.get(), pop, N1, N2, m12, m21,
                              mu_neutral + mu_del, wfxn, rec, mmodel);
             wbar = fwdpp::sample_diploid(

--- a/fwdpp/extensions/regions.hpp
+++ b/fwdpp/extensions/regions.hpp
@@ -39,6 +39,8 @@ namespace fwdpp
          *
          *  See extensions_regionsTest.cc and
          *  K_linked_regions_extensions.cc for examples.
+         * 
+         *  \example K_linked_regions_extensions.cc
          */
         {
             static_assert(fwdpp::traits::is_mutation<
@@ -168,6 +170,8 @@ namespace fwdpp
         /*!
           Class allowing the simulation of discrete variation
           in recombination rates along a region.
+
+          \example K_linked_regions_extensions.cc
         */
         {
           private:

--- a/fwdpp/general_rec_variation.hpp
+++ b/fwdpp/general_rec_variation.hpp
@@ -121,6 +121,7 @@ namespace fwdpp
      * It holds a vector of functions that add recombination
      * breakpoints to a vector.  Examples of such functions
      * are fwdpp::poisson_interval and fwdpp::crossover_point.
+     * \example K_linked_regions_generalized_rec.cc
      */
     {
         std::vector<std::function<void(const gsl_rng *, std::vector<double>&)>> recmap;

--- a/fwdpp/sample_diploid.hpp
+++ b/fwdpp/sample_diploid.hpp
@@ -87,7 +87,6 @@ namespace fwdpp
       recombination, and sampling.  Mutations will be changed by mutation and
       sampling.
       \return The mean fitness of the parental generation
-      \example bneck_selection_ind.cc
     */
     template <typename gamete_type, typename gamete_cont_type_allocator,
               typename mutation_type, typename mutation_cont_type_allocator,

--- a/fwdpp/sample_diploid.hpp
+++ b/fwdpp/sample_diploid.hpp
@@ -34,7 +34,6 @@ namespace fwdpp
       sampling.
       \return The mean fitness of the parental generation
       \example diploid_ind.cc
-      \example pfix.cc
       \example diploid_fixed_sh_ind_lambda.cc
     */
     template <typename gamete_type, typename gamete_cont_type_allocator,

--- a/fwdpp/sample_diploid.hpp
+++ b/fwdpp/sample_diploid.hpp
@@ -34,7 +34,6 @@ namespace fwdpp
       sampling.
       \return The mean fitness of the parental generation
       \example diploid_ind.cc
-      \example diploid_fixed_sh_ind_lambda.cc
     */
     template <typename gamete_type, typename gamete_cont_type_allocator,
               typename mutation_type, typename mutation_cont_type_allocator,

--- a/fwdpp/sample_diploid.hpp
+++ b/fwdpp/sample_diploid.hpp
@@ -34,6 +34,7 @@ namespace fwdpp
       sampling.
       \return The mean fitness of the parental generation
       \example diploid_ind.cc
+      \example diploid_fixed_sh_ind.cc
     */
     template <typename gamete_type, typename gamete_cont_type_allocator,
               typename mutation_type, typename mutation_cont_type_allocator,

--- a/fwdpp/sugar/slocuspop.hpp
+++ b/fwdpp/sugar/slocuspop.hpp
@@ -11,6 +11,9 @@ namespace fwdpp
 {
     /*!
       \brief Single locus, single population object
+      \example juvenile_migration.cc
+      \example K_linked_regions_extensions.cc
+      \example K_linked_regions_generalized_rec.cc
       \ingroup sugar
     */
     template <typename mtype,


### PR DESCRIPTION
Adds an example of juvenile migration scheme.  Illustrates how `slocuspop` is fully-capable of handling structure.

Related to #81 about having better examples.