### PR TITLE
Replace lookup table type

### DIFF
--- a/examples/custom_mutation.cc
+++ b/examples/custom_mutation.cc
@@ -31,9 +31,7 @@ struct TwoDmutation : public fwdpp::mutation_base
         : mutation_base(pos,
                         // Mutation is neutral i.f.f. all values in s_ == 0.
                         !std::any_of(std::begin(s_), std::end(s_),
-                                    [](const double t) {
-                                        return t != 0.;
-                                    }),
+                                     [](const double t) { return t != 0.; }),
                         label),
           s(std::move(s_)), h(std::move(h_)), g{ gen }
     {
@@ -118,16 +116,17 @@ infsites_TwoDmutation_additive(queue_t &recycling_bin, mcont_t &mutations,
         {
             pos = posmaker();
         }
-    lookup.insert(pos);
 
     if (gsl_rng_uniform(r) < pselected)
         {
             gsl_ran_bivariate_gaussian(r, sigma_x, sigma_y, rho, &s[0], &s[1]);
         }
 
-    return fwdpp::fwdpp_internal::recycle_mutation_helper(
+    auto idx = fwdpp::fwdpp_internal::recycle_mutation_helper(
         recycling_bin, mutations, std::move(s), std::move(h), pos, generation,
         x);
+    lookup.emplace(pos, idx);
+    return idx;
 }
 
 // For testing, we'll define a single-locus pop type in terms of the above.

--- a/examples/diploid_ind.cc
+++ b/examples/diploid_ind.cc
@@ -166,7 +166,6 @@ main(int argc, char **argv)
                     std::cout << "//\nsegsites: 0\n";
                 }
 #endif
-			std::cout<<pop.mutations.size()<<' '<<pop.gametes.size()<<' ' << pop.mut_lookup.size() << '\n';
         }
     return 0;
 }

--- a/examples/diploid_ind.cc
+++ b/examples/diploid_ind.cc
@@ -135,6 +135,16 @@ main(int argc, char **argv)
                                             pop.fixation_times, pop.mut_lookup,
                                             pop.mcounts, generation, twoN);
                     assert(fwdpp::check_sum(pop.gametes, twoN));
+					//for(std::size_t i=0;i<pop.mcounts.size();++i)
+					//{
+					//	if(pop.mcounts[i])
+					//	{
+					//		if(pop.mut_lookup.find(pop.mutations[i].pos)==pop.mut_lookup.end())
+					//		{
+					//			throw 1;
+					//		}
+					//	}
+					//}
                 }
 
             // Take a sample of size samplesize1 from the population
@@ -156,6 +166,7 @@ main(int argc, char **argv)
                     std::cout << "//\nsegsites: 0\n";
                 }
 #endif
+			std::cout<<pop.mutations.size()<<' '<<pop.gametes.size()<<' ' << pop.mut_lookup.size() << '\n';
         }
     return 0;
 }

--- a/examples/juvenile_migration.cc
+++ b/examples/juvenile_migration.cc
@@ -69,6 +69,7 @@
 #include <numeric>
 #include <functional>
 #include <cassert>
+#include <unordered_set>
 #include <fwdpp/sugar/popgenmut.hpp>
 #define SINGLEPOP_SIM
 // the type of mutation

--- a/fwdpp/io/detail/serialize_population.hpp
+++ b/fwdpp/io/detail/serialize_population.hpp
@@ -105,7 +105,8 @@ namespace fwdpp
                 for (unsigned i = 0; i < pop.mcounts.size(); ++i)
                     {
                         if (pop.mcounts[i])
-                            pop.mut_lookup.insert(pop.mutations[i].pos);
+                            pop.mut_lookup.emplace(pop.mutations[i].pos,
+                                                   static_cast<uint_t>(i));
                     }
             }
 
@@ -165,7 +166,8 @@ namespace fwdpp
                 for (unsigned i = 0; i < pop.mcounts.size(); ++i)
                     {
                         if (pop.mcounts[i])
-                            pop.mut_lookup.insert(pop.mutations[i].pos);
+                            pop.mut_lookup.emplace(pop.mutations[i].pos,
+                                                   static_cast<uint_t>(i));
                     }
             }
         }

--- a/fwdpp/sugar/mlocuspop.hpp
+++ b/fwdpp/sugar/mlocuspop.hpp
@@ -2,7 +2,7 @@
 #define __FWDPP_SUGAR_MULTILOC_HPP__
 
 #include <vector>
-#include <unordered_set>
+#include <unordered_map>
 #include <fwdpp/sugar/poptypes/mlocuspop.hpp>
 #include <fwdpp/fwd_functional.hpp>
 
@@ -17,9 +17,11 @@ namespace fwdpp
               typename diploid_t = std::pair<std::size_t, std::size_t>>
     using mlocuspop
         = sugar::mlocuspop<mtype, std::vector<mtype>, std::vector<gamete>,
-                          std::vector<std::vector<diploid_t>>,
-                          std::vector<mtype>, std::vector<uint_t>,
-                          std::unordered_set<double, std::hash<double>,
-                                             fwdpp::equal_eps>>;
+                           std::vector<std::vector<diploid_t>>,
+                           std::vector<mtype>, std::vector<uint_t>,
+						   // fwdpp 0.6.1 changed this from an unordered_set,
+						   // in order to address a rare bug. See GitHub
+						   // issue 130 for details.
+                           std::unordered_multimap<double, uint_t>>;
 }
 #endif

--- a/fwdpp/sugar/popgenmut.hpp
+++ b/fwdpp/sugar/popgenmut.hpp
@@ -107,11 +107,12 @@ namespace fwdpp
             {
                 pos = posmaker();
             }
-        lookup.insert(pos);
         bool selected = (gsl_rng_uniform(r) < pselected);
-        return fwdpp_internal::recycle_mutation_helper(
+        auto idx =  fwdpp_internal::recycle_mutation_helper(
             recycling_bin, mutations, pos, (selected) ? esize_maker() : 0.,
             (selected) ? hmaker() : 0., generation, x);
+		lookup.emplace(pos,idx);
+		return idx;
     }
 
     namespace io

--- a/fwdpp/sugar/poptypes/popbase.hpp
+++ b/fwdpp/sugar/poptypes/popbase.hpp
@@ -153,7 +153,8 @@ namespace fwdpp
                 typename gamete_t::mutation_container::size_type reserve_size
                 = 100)
                 : // No muts in the population
-                  mutations(mcont_t()), mcounts(mcount_t()),
+                  mutations(mcont_t()),
+                  mcounts(mcount_t()),
                   // The population contains a single gamete in 2N copies
                   gametes(gcont(1, gamete_t(2 * popsize))),
                   neutral(typename gamete_t::mutation_container()),
@@ -255,9 +256,10 @@ namespace fwdpp
             fixations.clear();
             fixation_times.clear();
             mcounts.clear();
-            for (auto &&m : mutations)
+            for (std::size_t i = 0; i < mutations.size(); ++i)
                 {
-                    mut_lookup.insert(m.pos);
+                    mut_lookup.emplace(mutations[i].pos,
+                                       static_cast<uint_t>(i));
                 }
             for (const auto &g : gametes)
                 {

--- a/fwdpp/sugar/slocuspop.hpp
+++ b/fwdpp/sugar/slocuspop.hpp
@@ -3,7 +3,7 @@
 
 #include <utility>
 #include <vector>
-#include <unordered_set>
+#include <unordered_map>
 #include <fwdpp/fwd_functional.hpp>
 #include <fwdpp/sugar/poptypes/slocuspop.hpp>
 
@@ -22,7 +22,9 @@ namespace fwdpp
         = sugar::slocuspop<mtype, std::vector<mtype>, std::vector<gamete>,
                            std::vector<diploid_t>, std::vector<mtype>,
                            std::vector<uint_t>,
-                           std::unordered_set<double, std::hash<double>,
-                                              fwdpp::equal_eps>>;
+						   // fwdpp 0.6.1 changed this from an unordered_set,
+						   // in order to address a rare bug. See GitHub
+						   // issue 130 for details.
+                           std::unordered_multimap<double, std::uint32_t>>;
 }
 #endif

--- a/fwdpp/util.hpp
+++ b/fwdpp/util.hpp
@@ -78,6 +78,7 @@ namespace fwdpp
                                         mcounts[i] = 0;
                                         break;
                                     }
+                                ++itr.first;
                             }
                     }
             }

--- a/fwdpp/util.hpp
+++ b/fwdpp/util.hpp
@@ -36,8 +36,17 @@ namespace fwdpp
                 assert(mcounts[i] <= twoN);
                 if (mcounts[i] == twoN || !mcounts[i])
                     {
-                        lookup.erase(mutations[i].pos);
-                        mcounts[i] = 0;
+                        auto itr = lookup.equal_range(mutations[i].pos);
+                        while (itr.first != itr.second)
+                            {
+                                if (itr.first->second == i)
+                                    {
+                                        lookup.erase(itr.first);
+                                        mcounts[i] = 0;
+                                        break;
+                                    }
+                                ++itr.first;
+                            }
                     }
             }
     }
@@ -60,8 +69,16 @@ namespace fwdpp
             {
                 if (!mcounts[i])
                     {
-                        lookup.erase(mutations[i].pos);
-                        mcounts[i] = 0;
+                        auto itr = lookup.equal_range(mutations[i].pos);
+                        while (itr.first != itr.second)
+                            {
+                                if (itr.first->second == i)
+                                    {
+                                        lookup.erase(mutations[i].pos);
+                                        mcounts[i] = 0;
+                                        break;
+                                    }
+                            }
                     }
             }
     }
@@ -96,10 +113,33 @@ namespace fwdpp
                         fixation_times.push_back(generation);
                         mcounts[i] = 0; // set count to zero to mark mutation
                                         // as "recyclable"
-                        lookup.erase(mutations[i].pos);
+                        auto itr = lookup.equal_range(mutations[i].pos);
+                        while (itr.first != itr.second)
+                            {
+                                if (itr.first->second == i)
+                                    {
+                                        lookup.erase(itr.first);
+                                        break;
+                                    }
+                                ++itr.first;
+                            }
                     }
-                if (!mcounts[i])
-                    lookup.erase(mutations[i].pos);
+                else if (!mcounts[i])
+                    {
+                        auto itr = lookup.equal_range(mutations[i].pos);
+                        if (itr.first != lookup.end())
+                            {
+                                while (itr.first != itr.second)
+                                    {
+                                        if (itr.first->second == i)
+                                            {
+                                                lookup.erase(itr.first);
+                                                break;
+                                            }
+                                        ++itr.first;
+                                    }
+                            }
+                    }
             }
     }
 
@@ -122,7 +162,8 @@ namespace fwdpp
     {
         static_assert(
             typename traits::is_mutation<typename mcont_t::value_type>::type(),
-            "mutation_type must be derived from fwdpp::mutation_base");
+            "mutation_type must be derived from "
+            "fwdpp::mutation_base");
         assert(mcounts.size() == mutations.size());
         for (unsigned i = 0; i < mcounts.size(); ++i)
             {
@@ -133,11 +174,20 @@ namespace fwdpp
                         fixation_times.push_back(generation);
                         mcounts[i] = 0; // set count to zero to mark mutation
                                         // as "recyclable"
-                        lookup.erase(mutations[i].pos);
+                        auto itr = lookup.equal_range(mutations[i].pos);
+                        while (itr.first != itr.second)
+                            {
+                                if (itr.first->second == i)
+                                    {
+                                        lookup.erase(mutations[i].pos);
+                                        break;
+                                    }
+                                ++itr.first;
+                            }
                     }
                 else if (mcounts[i] == twoN) // Fixation is not neutral
                     {
-						// Guard against repeatedly recording fixation data
+                        // Guard against repeatedly recording fixation data
                         if (std::find(std::begin(fixations),
                                       std::end(fixations), mutations[i])
                             == std::end(fixations))
@@ -146,8 +196,19 @@ namespace fwdpp
                                 fixation_times.push_back(generation);
                             }
                     }
-                if (!mcounts[i])
-                    lookup.erase(mutations[i].pos);
+                else if (!mcounts[i])
+                    {
+                        auto itr = lookup.equal_range(mutations[i].pos);
+                        while (itr.first != itr.second)
+                            {
+                                if (itr.first->second == i)
+                                    {
+                                        lookup.erase(mutations[i].pos);
+                                        break;
+                                    }
+                                ++itr.first;
+                            }
+                    }
             }
     }
 }

--- a/testsuite/fixtures/fwdpp_fixtures.hpp
+++ b/testsuite/fixtures/fwdpp_fixtures.hpp
@@ -9,7 +9,7 @@
 
 #include <vector>
 #include <utility>
-#include <unordered_set>
+#include <unordered_map>
 #include <fwdpp/fwd_functional.hpp>
 #include <fwdpp/forward_types.hpp>
 #include <gsl/gsl_rng.h>
@@ -27,7 +27,7 @@ using mcont_t = std::vector<mtype>;
 using gcont_t = std::vector<fwdpp::gamete>;
 using dipvector_t = std::vector<std::pair<std::size_t, std::size_t>>;
 using lookup_table_t
-    = std::unordered_set<double, std::hash<double>, fwdpp::equal_eps>;
+    = std::unordered_multimap<double, fwdpp::uint_t>;
 using mcounts_t = std::vector<fwdpp::uint_t>;
 
 struct standard_empty_single_deme_fixture

--- a/testsuite/unit/utilTest.cc
+++ b/testsuite/unit/utilTest.cc
@@ -22,11 +22,15 @@ BOOST_FIXTURE_TEST_CASE(only_recycle_extinct_mutations,
 {
     // This is a neutral mutation
     mutations.emplace_back(0.1, 0);
-    mut_lookup.insert(0.1);
+    mut_lookup.emplace(0.1, 0);
     mcounts.emplace_back(1);
     mutations.emplace_back(0.2, 0);
-    mut_lookup.insert(0.2);
+    mut_lookup.emplace(0.2, 1);
     mcounts.emplace_back(0);
+    for (auto& i : mut_lookup)
+        {
+            BOOST_REQUIRE_EQUAL(i.first, mutations[i.second].pos);
+        }
     fwdpp::update_mutations(mutations, mut_lookup, mcounts);
     BOOST_REQUIRE_EQUAL(mcounts[0], 1);
     BOOST_REQUIRE_EQUAL(mcounts[1], 0);
@@ -41,7 +45,11 @@ BOOST_FIXTURE_TEST_CASE(test_recycle_all_fixations,
     fwdpp::uint_t N = 1000;
     // This is a neutral mutation
     mutations.emplace_back(0.1, 0);
-    mut_lookup.insert(0.1);
+    mut_lookup.emplace(0.1, 0);
+    for (auto& i : mut_lookup)
+        {
+            BOOST_REQUIRE_EQUAL(i.first, mutations[i.second].pos);
+        }
     mcounts.emplace_back(2 * N);
     fwdpp::update_mutations(mutations, mut_lookup, mcounts, 2 * N);
     BOOST_REQUIRE_EQUAL(mcounts[0], 0);
@@ -57,7 +65,11 @@ BOOST_FIXTURE_TEST_CASE(
     fwdpp::uint_t N = 1000;
     // This is a neutral mutation
     mutations.emplace_back(0.1, 0);
-    mut_lookup.insert(0.1);
+    mut_lookup.emplace(0.1, 0);
+    for (auto& i : mut_lookup)
+        {
+            BOOST_REQUIRE_EQUAL(i.first, mutations[i.second].pos);
+        }
     mcounts.emplace_back(2 * N);
     // use generation = 2
     fwdpp::update_mutations(mutations, fixations, fixation_times, mut_lookup,
@@ -75,11 +87,15 @@ BOOST_FIXTURE_TEST_CASE(only_recycle_neutral_fixations,
     fwdpp::uint_t N = 1000;
     // This is a neutral mutation
     mutations.emplace_back(0.1, 0);
-    mut_lookup.insert(0.1);
+    mut_lookup.emplace(0.1, 0);
     mcounts.emplace_back(2 * N);
     // This is NOT a neutral mutation
     mutations.emplace_back(0.2, -1.0);
-    mut_lookup.insert(0.2);
+    mut_lookup.emplace(0.2, 1);
+    for (auto& i : mut_lookup)
+        {
+            BOOST_REQUIRE_EQUAL(i.first, mutations[i.second].pos);
+        }
     mcounts.emplace_back(2 * N);
     // use generation = 2
     fwdpp::update_mutations_n(mutations, fixations, fixation_times, mut_lookup,
@@ -94,9 +110,9 @@ BOOST_FIXTURE_TEST_CASE(only_recycle_neutral_fixations,
     // use generation = 3
     fwdpp::update_mutations_n(mutations, fixations, fixation_times, mut_lookup,
                               mcounts, 3, 2 * N);
-	// This will not change the data b/c
-	// the neutral variant is already flagged to recycle
-	// and the selected one is already entered into fixations.
+    // This will not change the data b/c
+    // the neutral variant is already flagged to recycle
+    // and the selected one is already entered into fixations.
     BOOST_REQUIRE_EQUAL(mcounts[0], 0);
     BOOST_REQUIRE_EQUAL(mcounts[1], 2 * N);
     BOOST_REQUIRE_EQUAL(mutations.size(), 2);
@@ -104,6 +120,150 @@ BOOST_FIXTURE_TEST_CASE(only_recycle_neutral_fixations,
     BOOST_REQUIRE_EQUAL(fixation_times.size(), 2);
     BOOST_REQUIRE_EQUAL(fixation_times[0], 2);
     BOOST_REQUIRE_EQUAL(fixation_times[1], 2);
+}
+
+// The following unit tests are checks for GitHub issue #130
+// This issue involves the situation where an extinct mutation
+// has the same position as an extant mutation.  Through fwdpp
+// 0.6.0, this cause the extant mutation's position to
+// be removed from the lookup table, which is a book-keeping bug.
+// However, I ran a ton of sims and never found a difference due
+// to the bug vs the fixed version (fwdpp 0.6.1).  The reason
+// is that, for the bug to have an effect, a series of rare events
+// must happen multiple times.
+
+BOOST_FIXTURE_TEST_CASE(issue_130_slocuspop_test_update_mutations,
+                        standard_empty_single_deme_fixture)
+{
+    fwdpp::uint_t N = 1000;
+    // This is a neutral mutation
+    mutations.emplace_back(0.1, 0);
+    mut_lookup.emplace(0.1, 0);
+    mcounts.emplace_back(2 * N);
+    // This is NOT a neutral mutation
+    mutations.emplace_back(0.2, -1.0);
+    mut_lookup.emplace(0.2, 1);
+    mcounts.push_back(1); //a singleton
+
+    // This is an exctinct variant at 0.2
+    mutations.emplace_back(0.2, 0.0);
+    mcounts.push_back(0);
+    for (auto& i : mut_lookup)
+        {
+            BOOST_REQUIRE_EQUAL(i.first, mutations[i.second].pos);
+        }
+
+    fwdpp::update_mutations(mutations, fixations, fixation_times, mut_lookup,
+                            mcounts, 0, 2 * N);
+    for (std::size_t i = 0; i < mcounts.size(); ++i)
+        {
+            if (mcounts[i] > 0)
+                {
+                    BOOST_CHECK_EQUAL(mut_lookup.find(mutations[i].pos)
+                                          != mut_lookup.end(),
+                                      true);
+                }
+        }
+}
+
+BOOST_FIXTURE_TEST_CASE(issue_130_slocuspop_test_update_mutations_extinct_only,
+                        standard_empty_single_deme_fixture)
+{
+    fwdpp::uint_t N = 1000;
+    // This is a neutral mutation
+    mutations.emplace_back(0.1, 0);
+    mut_lookup.emplace(0.1, 0);
+    mcounts.emplace_back(2 * N);
+    // This is NOT a neutral mutation
+    mutations.emplace_back(0.2, -1.0);
+    mut_lookup.emplace(0.2, 1);
+    mcounts.push_back(1); //a singleton
+
+    // This is an exctinct variant at 0.2
+    mutations.emplace_back(0.2, 0.0);
+    mcounts.push_back(0);
+    for (auto& i : mut_lookup)
+        {
+            BOOST_REQUIRE_EQUAL(i.first, mutations[i.second].pos);
+        }
+
+    fwdpp::update_mutations(mutations, mut_lookup, mcounts);
+    for (std::size_t i = 0; i < mcounts.size(); ++i)
+        {
+            if (mcounts[i] > 0)
+                {
+                    BOOST_CHECK_EQUAL(mut_lookup.find(mutations[i].pos)
+                                          != mut_lookup.end(),
+                                      true);
+                }
+        }
+}
+BOOST_FIXTURE_TEST_CASE(
+    issue_130_slocuspop_test_update_mutations_do_not_record_fixations,
+    standard_empty_single_deme_fixture)
+{
+    fwdpp::uint_t N = 1000;
+    // This is a neutral mutation
+    mutations.emplace_back(0.1, 0);
+    mut_lookup.emplace(0.1, 0);
+    mcounts.emplace_back(2 * N);
+    // This is NOT a neutral mutation
+    mutations.emplace_back(0.2, -1.0);
+    mut_lookup.emplace(0.2, 1);
+    mcounts.push_back(1); //a singleton
+
+    // This is an exctinct variant at 0.2
+    mutations.emplace_back(0.2, 0.0);
+    mcounts.push_back(0);
+    for (auto& i : mut_lookup)
+        {
+            BOOST_REQUIRE_EQUAL(i.first, mutations[i.second].pos);
+        }
+
+    fwdpp::update_mutations(mutations, mut_lookup, mcounts, 2 * N);
+    for (std::size_t i = 0; i < mcounts.size(); ++i)
+        {
+            if (mcounts[i] > 0)
+                {
+                    BOOST_CHECK_EQUAL(mut_lookup.find(mutations[i].pos)
+                                          != mut_lookup.end(),
+                                      true);
+                }
+        }
+}
+
+BOOST_FIXTURE_TEST_CASE(issue_130_slocuspop_test_update_mutations_n,
+                        standard_empty_single_deme_fixture)
+{
+    fwdpp::uint_t N = 1000;
+    // This is a neutral mutation
+    mutations.emplace_back(0.1, 0);
+    mut_lookup.emplace(0.1, 0);
+    mcounts.emplace_back(2 * N);
+    // This is NOT a neutral mutation
+    mutations.emplace_back(0.2, -1.0);
+    mut_lookup.emplace(0.2, 1);
+    mcounts.push_back(1); //a singleton
+
+    // This is an exctinct variant at 0.2
+    mutations.emplace_back(0.2, 0.0);
+    mcounts.push_back(0);
+    for (auto& i : mut_lookup)
+        {
+            BOOST_REQUIRE_EQUAL(i.first, mutations[i.second].pos);
+        }
+
+    fwdpp::update_mutations_n(mutations, fixations, fixation_times, mut_lookup,
+                              mcounts, 0, 2 * N);
+    for (std::size_t i = 0; i < mcounts.size(); ++i)
+        {
+            if (mcounts[i] > 0)
+                {
+                    BOOST_CHECK_EQUAL(mut_lookup.find(mutations[i].pos)
+                                          != mut_lookup.end(),
+                                      true);
+                }
+        }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR fixes #130 by replacing the mutation position lookup table type with `std::unordered_multimap`.  A nice side-effect is that this new type helps with recurrent mutation models.