### PR TITLE
Initial gamete counts

### DIFF
--- a/fwdpp/sugar/poptypes/mlocuspop.hpp
+++ b/fwdpp/sugar/poptypes/mlocuspop.hpp
@@ -84,8 +84,8 @@ namespace fwdpp
                 typename popbase_t::gamete_t::mutation_container::size_type
                     reserve_size
                 = 100)
-                : popbase_t(__nloci * __N, reserve_size), N(__N),
-                  diploids(__N, diploid_t(__nloci, {0,0})),
+                : popbase_t(__nloci * 2 * __N, reserve_size), N(__N),
+                  diploids(__N, diploid_t(__nloci, { 0, 0 })),
                   locus_boundaries(locus_boundaries_)
             {
             }
@@ -121,7 +121,7 @@ namespace fwdpp
                 popbase_t::clear_containers();
             }
         };
-    }
-}
+    } // namespace sugar
+} // namespace fwdpp
 
 #endif

--- a/fwdpp/sugar/poptypes/popbase.hpp
+++ b/fwdpp/sugar/poptypes/popbase.hpp
@@ -149,14 +149,13 @@ namespace fwdpp
 
             //! Constructor
             explicit popbase(
-                const uint_t &popsize,
+                const uint_t &initial_gamete_count,
                 typename gamete_t::mutation_container::size_type reserve_size
                 = 100)
                 : // No muts in the population
                   mutations(mcont_t()),
                   mcounts(mcount_t()),
-                  // The population contains a single gamete in 2N copies
-                  gametes(gcont(1, gamete_t(2 * popsize))),
+                  gametes(gcont(1, gamete_t(initial_gamete_count))),
                   neutral(typename gamete_t::mutation_container()),
                   selected(typename gamete_t::mutation_container()),
                   mut_lookup(lookup_table_type()), fixations(mvector()),
@@ -165,7 +164,7 @@ namespace fwdpp
                 // This is a good number for reserving,
                 // allowing for extra allocations when recycling is doing its
                 // thing
-                gametes.reserve(4 * popsize);
+                gametes.reserve(2 * initial_gamete_count);
                 // Reserve memory
                 neutral.reserve(reserve_size);
                 selected.reserve(reserve_size);

--- a/fwdpp/sugar/poptypes/slocuspop.hpp
+++ b/fwdpp/sugar/poptypes/slocuspop.hpp
@@ -74,7 +74,7 @@ namespace fwdpp
                 typename popbase_t::gamete_t::mutation_container::size_type
                     reserve_size
                 = 100)
-                : popbase_t(popsize, reserve_size), N(popsize),
+                : popbase_t(2 * popsize, reserve_size), N(popsize),
                   // All N diploids contain the only gamete in the pop
                   diploids(dipvector_t(popsize, diploid_t(0, 0)))
             {
@@ -108,6 +108,6 @@ namespace fwdpp
                 popbase_t::clear_containers();
             }
         };
-    }
-}
+    } // namespace sugar
+} // namespace fwdpp
 #endif


### PR DESCRIPTION
This PR makes the initialization of gamete counts in fwdpp::popbase independent of ploidy. See #131.