### PR TITLE
Add a debug namespace

### DIFF
--- a/doc/fwdpp.doxygen.in
+++ b/doc/fwdpp.doxygen.in
@@ -782,7 +782,7 @@ RECURSIVE              = NO
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                =
+EXCLUDE                = ../fwdpp/internal
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/examples/K_linked_regions_generalized_rec.cc
+++ b/examples/K_linked_regions_generalized_rec.cc
@@ -97,10 +97,11 @@ main(int argc, char **argv)
                                   pop.mutations, pop.mcounts, N, mu, mmodel,
                                   recmap, fwdpp::multiplicative_diploid(),
                                   pop.neutral, pop.selected);
-            assert(check_sum(pop.gametes, 2*pop.diploids.size()));
             fwdpp::update_mutations(pop.mutations, pop.fixations,
                                     pop.fixation_times, pop.mut_lookup,
                                     pop.mcounts, generation, 2 * N);
+            fwdpp::debug::validate_sum_gamete_counts(pop.gametes,2*N);
+            fwdpp::debug::validate_pop_data(pop);
         }
 #ifdef HAVE_LIBSEQUENCE
 #endif

--- a/examples/K_linked_regions_multilocus.cc
+++ b/examples/K_linked_regions_multilocus.cc
@@ -11,6 +11,7 @@
 #include <vector>
 #include <list>
 #include <sstream>
+#include <fwdpp/debug.hpp>
 // Use mutation model from sugar layer
 #include <fwdpp/sugar/popgenmut.hpp>
 #include <fwdpp/sampling_functions.hpp>
@@ -108,12 +109,12 @@ main(int argc, char **argv)
                 r.get(), pop.gametes, pop.diploids, pop.mutations, pop.mcounts,
                 N, mu.data(), mmodels, recpols, interlocus_rec,
                 no_selection_multi(), pop.neutral, pop.selected);
-            assert(check_sum(pop.gametes, K * 2 * pop.diploids.size()));
             fwdpp::update_mutations(pop.mutations, pop.fixations,
                                     pop.fixation_times, pop.mut_lookup,
                                     pop.mcounts, generation, 2 * N);
-            assert(popdata_sane_multilocus(pop.diploids, pop.gametes,
-                                           pop.mutations, pop.mcounts));
+            fwdpp::debug::validate_sum_gamete_counts(
+                pop.gametes, K * 2 * pop.diploids.size());
+            fwdpp::debug::validate_pop_data(pop);
 #ifndef NDEBUG
             /*
             Useful block for long-run testing.

--- a/examples/diploid_fixed_sh_ind.cc
+++ b/examples/diploid_fixed_sh_ind.cc
@@ -13,6 +13,7 @@
 #include <functional>
 #include <cassert>
 #include <iomanip>
+#include <fwdpp/debug.hpp>
 #include <fwdpp/sugar/popgenmut.hpp>
 #include <fwdpp/algorithm/compact_mutations.hpp>
 #define SINGLEPOP_SIM
@@ -80,7 +81,6 @@ main(int argc, char **argv)
             double wbar = 1;
             for (generation = 0; generation < ngens; ++generation)
                 {
-                    assert(fwdpp::check_sum(pop.gametes, 2 * N));
                     wbar = fwdpp::sample_diploid(
                         r.get(), pop.gametes, pop.diploids, pop.mutations,
                         pop.mcounts, N, mu_neutral + mu_del, mmodel,
@@ -92,23 +92,27 @@ main(int argc, char **argv)
                                             pop.mcounts, generation, 2 * N);
                     if (generation && generation % 100 == 0.0)
                         {
-							fwdpp::compact_mutations(pop);
+                            fwdpp::compact_mutations(pop);
                         }
-                    assert(fwdpp::check_sum(pop.gametes, 2 * N));
+                    fwdpp::debug::validate_sum_gamete_counts(pop.gametes,
+                                                             2 * N);
                 }
             // Take a sample of size samplesize1.  Two data blocks are
             // returned, one for neutral mutations, and one for selected
             std::vector<std::size_t> random_dips;
-            for(unsigned i=0;i<samplesize1;++i)
-            {
-                auto x = static_cast<std::size_t>(gsl_ran_flat(r.get(),0,N));
-                while(std::find(random_dips.begin(),random_dips.end(),x) != 
-                        random_dips.end())
+            for (unsigned i = 0; i < samplesize1; ++i)
                 {
-                x = static_cast<std::size_t>(gsl_ran_flat(r.get(),0,N));
+                    auto x = static_cast<std::size_t>(
+                        gsl_ran_flat(r.get(), 0, N));
+                    while (std::find(random_dips.begin(), random_dips.end(), x)
+                           != random_dips.end())
+                        {
+                            x = static_cast<std::size_t>(
+                                gsl_ran_flat(r.get(), 0, N));
+                        }
                 }
-            }
-            auto dm = fwdpp::sample_individuals(pop, random_dips, true, false, true);
+            auto dm = fwdpp::sample_individuals(pop, random_dips, true, false,
+                                                true);
 #ifdef HAVE_LIBSEQUENCE
 #endif
         }

--- a/examples/diploid_fixed_sh_ind.cc
+++ b/examples/diploid_fixed_sh_ind.cc
@@ -97,6 +97,14 @@ main(int argc, char **argv)
                     fwdpp::debug::validate_sum_gamete_counts(pop.gametes,
                                                              2 * N);
                 }
+            for(std::size_t i=0;i<pop.mcounts.size();++i)
+            {
+                if(pop.mcounts[i])
+                {
+                    std::cout<<pop.mutations[i].s<<' ' << pop.mcounts[i]<<'\n';
+
+                }
+            }
             // Take a sample of size samplesize1.  Two data blocks are
             // returned, one for neutral mutations, and one for selected
             std::vector<std::size_t> random_dips;

--- a/examples/diploid_ind.cc
+++ b/examples/diploid_ind.cc
@@ -24,7 +24,6 @@ using mtype = fwdpp::popgenmut;
 #define SINGLEPOP_SIM
 #include <common_ind.hpp>
 
-
 int
 main(int argc, char **argv)
 {
@@ -139,9 +138,11 @@ main(int argc, char **argv)
                                             pop.mcounts, generation, twoN);
                     if (generation && generation % 100 == 0.0)
                         {
-							fwdpp::compact_mutations(pop);
+                            fwdpp::compact_mutations(pop);
                         }
-                    assert(fwdpp::check_sum(pop.gametes, twoN));
+                    fwdpp::debug::validate_pop_data(pop);
+                    fwdpp::debug::validate_sum_gamete_counts(pop.gametes,
+                                                             twoN);
                     //for(std::size_t i=0;i<pop.mcounts.size();++i)
                     //{
                     //	if(pop.mcounts[i])
@@ -156,16 +157,19 @@ main(int argc, char **argv)
 
             // Take a sample of size samplesize1 from the population
             std::vector<std::size_t> random_dips;
-            for(unsigned i=0;i<samplesize1;++i)
-            {
-                auto x = static_cast<std::size_t>(gsl_ran_flat(r.get(),0,N));
-                while(std::find(random_dips.begin(),random_dips.end(),x) != 
-                        random_dips.end())
+            for (unsigned i = 0; i < samplesize1; ++i)
                 {
-                x = static_cast<std::size_t>(gsl_ran_flat(r.get(),0,N));
+                    auto x = static_cast<std::size_t>(
+                        gsl_ran_flat(r.get(), 0, N));
+                    while (std::find(random_dips.begin(), random_dips.end(), x)
+                           != random_dips.end())
+                        {
+                            x = static_cast<std::size_t>(
+                                gsl_ran_flat(r.get(), 0, N));
+                        }
                 }
-            }
-            auto dm = fwdpp::sample_individuals(pop, random_dips, true, false, true);
+            auto dm = fwdpp::sample_individuals(pop, random_dips, true, false,
+                                                true);
 // Write the sample date a to libsequence's Sequence::SimData and
 // print to screen
 #ifdef HAVE_LIBSEQUENCE

--- a/examples/juvenile_migration.cc
+++ b/examples/juvenile_migration.cc
@@ -70,6 +70,7 @@
 #include <functional>
 #include <cassert>
 #include <unordered_set>
+#include <fwdpp/debug.hpp>
 #include <fwdpp/sugar/popgenmut.hpp>
 #define SINGLEPOP_SIM
 // the type of mutation
@@ -239,7 +240,8 @@ evolve_two_demes(const gsl_rng *r, singlepop_t &pop, const uint_t N1,
                                     mut_recycling_bin, pop.diploids[i],
                                     pop.neutral, pop.selected);
         }
-    assert(check_sum(pop.gametes, 2 * (N1 + N2)));
+    fwdpp::debug::validate_sum_gamete_counts(pop.gametes,
+                                             2 * pop.diploids.size());
 #ifndef NDEBUG
     for (const auto &dip : pop.diploids)
         {
@@ -260,8 +262,7 @@ evolve_two_demes(const gsl_rng *r, singlepop_t &pop, const uint_t N1,
             assert(mc <= 2 * (N1 + N2));
         }
 #endif
-    assert(
-        popdata_sane(pop.diploids, pop.gametes, pop.mutations, pop.mcounts));
+    debug::validate_pop_data(pop);
 
     // Prune fixations from gametes
     fwdpp_internal::gamete_cleaner(pop.gametes, pop.mutations, pop.mcounts,
@@ -327,7 +328,8 @@ main(int argc, char **argv)
     double wbar = 1;
     for (generation = 0; generation < ngens; ++generation)
         {
-            assert(fwdpp::check_sum(pop.gametes, 2 * (N1 + N2)));
+            fwdpp::debug::validate_sum_gamete_counts(pop.gametes,
+                                                     2 * (N1 + N2));
 
             // Call our fancy new evolve function
             evolve_two_demes(r.get(), pop, N1, N2, m12, m21,
@@ -335,6 +337,6 @@ main(int argc, char **argv)
             fwdpp::update_mutations(pop.mutations, pop.fixations,
                                     pop.fixation_times, pop.mut_lookup,
                                     pop.mcounts, generation, 2 * N);
-            assert(fwdpp::check_sum(pop.gametes, 2 * N));
+            fwdpp::debug::validate_sum_gamete_counts(pop.gametes, 2 * N);
         }
 }

--- a/fwdpp/data_matrix.hpp
+++ b/fwdpp/data_matrix.hpp
@@ -1,7 +1,6 @@
 #ifndef FWDPP_DATA_MATRIX_HPP_
 #define FWDPP_DATA_MATRIX_HPP_
 
-#include <cassert>
 #include <numeric>
 #include <utility>
 #include <vector>

--- a/fwdpp/debug.hpp
+++ b/fwdpp/debug.hpp
@@ -61,6 +61,14 @@ namespace fwdpp
         {
             detail::validate_pop_data(pop);
         }
+
+        template <typename mutation_type>
+        void
+        check_mutation_neutrality(const mutation_type &mutation,
+                                  const bool expected_neutrality)
+        {
+            detail::check_mutation_neutrality(mutation, expected_neutrality);
+        }
     } // namespace debug
 } // namespace fwdpp
 

--- a/fwdpp/debug.hpp
+++ b/fwdpp/debug.hpp
@@ -149,6 +149,25 @@ namespace fwdpp
             }
         return true;
     }
-}
+
+    namespace debug
+    {
+        template <typename poptype, typename iterator>
+        void
+        validate_mutation_key_ranges(const poptype &p, const iterator beg,
+                                     const iterator end)
+        /*! Throw an exception if any mutation keys are >= p.mutations.size()
+         */
+        {
+            if (std::any_of(beg, end, [&p](const std::size_t m) {
+                    return m >= p.mutations.size();
+                }))
+                {
+                    throw std::runtime_error("FWDPP DEBUG: mutation key "
+                                             "out of range");
+                }
+        }
+    } // namespace debug
+} // namespace fwdpp
 
 #endif

--- a/fwdpp/debug.hpp
+++ b/fwdpp/debug.hpp
@@ -5,6 +5,7 @@
 #include <numeric>
 #include <fwdpp/forward_types.hpp>
 #include <fwdpp/type_traits.hpp>
+#include "internal/debug_details.hpp"
 
 namespace fwdpp
 {
@@ -152,20 +153,14 @@ namespace fwdpp
 
     namespace debug
     {
-        template <typename poptype, typename iterator>
+        template <typename mcont_t, typename iterator>
         void
-        validate_mutation_key_ranges(const poptype &p, const iterator beg,
-                                     const iterator end)
-        /*! Throw an exception if any mutation keys are >= p.mutations.size()
+        validate_mutation_key_ranges(const mcont_t &mutations,
+                                     const iterator beg, const iterator end)
+        /*! Throw an exception if any mutation keys are >= mutations.size()
          */
         {
-            if (std::any_of(beg, end, [&p](const std::size_t m) {
-                    return m >= p.mutations.size();
-                }))
-                {
-                    throw std::runtime_error("FWDPP DEBUG: mutation key "
-                                             "out of range");
-                }
+            detail::validate_mutation_key_ranges(mutations, beg, end);
         }
     } // namespace debug
 } // namespace fwdpp

--- a/fwdpp/debug.hpp
+++ b/fwdpp/debug.hpp
@@ -12,8 +12,9 @@ namespace fwdpp
     namespace debug
     {
         template <typename gcont_t>
-        void validate_sum_gamete_counts(const gcont_t &gametes,
-                                        const uint_t expected_sum)
+        void
+        validate_sum_gamete_counts(const gcont_t &gametes,
+                                   const uint_t expected_sum)
         {
             detail::validate_sum_gamete_counts(gametes, expected_sum);
         }
@@ -26,6 +27,13 @@ namespace fwdpp
          */
         {
             detail::validate_mutation_key_ranges(mutations, beg, end);
+        }
+
+        template <typename gamete_t>
+        void
+        gamete_is_extant(const gamete_t &gamete)
+        {
+            detail::gamete_is_extant(gamete);
         }
 
         template <typename gamete_t, typename mcont_t>

--- a/fwdpp/debug.hpp
+++ b/fwdpp/debug.hpp
@@ -9,150 +9,15 @@
 
 namespace fwdpp
 {
-
-    /*! \brief Returns true if the sum of counts in gametes equals twoN, false
-      otherwise
-      Returns true if the sum of counts in gametes equals twoN, false otherwise
-    */
-    template <typename gcont_t>
-    bool
-    check_sum(const gcont_t &gametes, const unsigned twoN)
-    {
-        static_assert(
-            typename traits::is_gamete<typename gcont_t::value_type>::type(),
-            "gcont_t::value_type must be a valid gamete type");
-        return (std::accumulate(gametes.cbegin(), gametes.cend(), 0u,
-                                [](unsigned &__u,
-                                   const typename gcont_t::value_type &__g) {
-                                    return __u + __g.n;
-                                })
-                == twoN);
-    }
-
-    /*! \brief Returns true if the sum of counts in gametes equals twoN, false
-      otherwise
-      Returns true if the sum of counts in gametes equals twoN, false otherwise
-    */
-    template <typename gcont_t>
-    bool
-    check_sum(const gcont_t *gametes, const unsigned twoN)
-    {
-        return check_sum(*gametes, twoN);
-    }
-
-    template <typename gamete_t, typename mcont_t>
-    bool
-    gamete_is_sorted_n(const gamete_t &g, const mcont_t &m)
-    /*!
-      \brief Check that neutral mutation keys are sorted according to mutation
-      position
-    */
-    {
-        return std::is_sorted(g.mutations.begin(), g.mutations.end(),
-                              [&m](const size_t i, const size_t j) {
-                                  return m[i].pos <= m[j].pos;
-                              });
-    }
-
-    template <typename gamete_t, typename mcont_t>
-    bool
-    gamete_is_sorted_s(const gamete_t &g, const mcont_t &m)
-    /*!
-      \brief Check that selected mutation keys are sorted according to mutation
-      position
-    */
-    {
-        return std::is_sorted(g.smutations.begin(), g.smutations.end(),
-                              [&m](const size_t i, const size_t j) {
-                                  return m[i].pos <= m[j].pos;
-                              });
-    }
-
-    template <typename gamete_t, typename mcont_t>
-    bool
-    gamete_data_sane(const gamete_t &g, const mcont_t &mutations,
-                     const std::vector<uint_t> &mutcounts)
-    /*
-      \brief Check that "neutral" and "non-neutral" mutations are where we
-      expect them to be.
-     */
-    {
-        for (const auto &i : g.mutations)
-            {
-                if (!mutcounts[i])
-                    return false;
-                if (!mutations[i].neutral)
-                    return false;
-                if (!(g.n <= mutcounts[i]))
-                    return false;
-            }
-        for (const auto &i : g.smutations)
-            {
-                if (!mutcounts[i])
-                    return false;
-                if (mutations[i].neutral)
-                    return false;
-                if (!(g.n <= mutcounts[i]))
-                    return false;
-            }
-        return true;
-    }
-
-    template <typename dipcont_t, typename gcont_t, typename mcont_t>
-    bool
-    popdata_sane(const dipcont_t &diploids, const gcont_t &gametes,
-                 const mcont_t &mutations,
-                 const std::vector<uint_t> &mutcounts)
-    /*
-      \brief Check that all diploids refer to extant gametes with sane data.
-     */
-    {
-        for (const auto &d : diploids)
-            {
-                if (!gametes[d.first].n)
-                    return false;
-                if (!gametes[d.second].n)
-                    return false;
-                if (!gamete_data_sane(gametes[d.first], mutations, mutcounts))
-                    return false;
-                if (!gamete_data_sane(gametes[d.second], mutations, mutcounts))
-                    return false;
-            }
-        return true;
-    }
-
-    template <typename dipcont_t, typename gcont_t, typename mcont_t>
-    bool
-    popdata_sane_multilocus(const dipcont_t &diploids, const gcont_t &gametes,
-                            const mcont_t &mutations,
-                            const std::vector<uint_t> &mutcounts)
-    /*
-      \brief Check that all diploids refer to extant gametes with sane data.
-      \note This is for the case where diploids are equivalent to
-      vector<pair<key,key>>
-     */
-    {
-        for (const auto &d : diploids)
-            {
-                for (const auto &locus : d)
-                    {
-                        if (!gametes[locus.first].n)
-                            return false;
-                        if (!gametes[locus.second].n)
-                            return false;
-                        if (!gamete_data_sane(gametes[locus.first], mutations,
-                                              mutcounts))
-                            return false;
-                        if (!gamete_data_sane(gametes[locus.second], mutations,
-                                              mutcounts))
-                            return false;
-                    }
-            }
-        return true;
-    }
-
     namespace debug
     {
+        template <typename gcont_t>
+        void validate_sum_gamete_counts(const gcont_t &gametes,
+                                        const uint_t expected_sum)
+        {
+            detail::validate_sum_gamete_counts(gametes, expected_sum);
+        }
+
         template <typename mcont_t, typename iterator>
         void
         validate_mutation_key_ranges(const mcont_t &mutations,
@@ -167,11 +32,26 @@ namespace fwdpp
         void
         gamete_is_sorted(const gamete_t &g, const mcont_t &mutations)
         /*!
-      \brief Check that neutral mutation keys are sorted according to mutation
-      position
-    */
+          \brief Check that neutral mutation keys are sorted according to mutation
+          position
+        */
         {
             detail::gamete_is_sorted(g, mutations);
+        }
+
+        template <typename gamete_t, typename mcont_t>
+        void
+        gamete_data_valid(const gamete_t &g, const mcont_t &mutations,
+                          const std::vector<uint_t> &mutcounts)
+        {
+            detail::gamete_data_valid(g, mutations, mutcounts);
+        }
+
+        template <typename poptype>
+        void
+        validate_pop_data(const poptype &pop)
+        {
+            detail::validate_pop_data(pop);
         }
     } // namespace debug
 } // namespace fwdpp

--- a/fwdpp/debug.hpp
+++ b/fwdpp/debug.hpp
@@ -7,6 +7,29 @@
 #include <fwdpp/type_traits.hpp>
 #include "internal/debug_details.hpp"
 
+/*! \namespace fwdpp::debug Debugging routines
+ * In general, the library does not throw exceptions
+ * during the execution of simulation-related algorithms.
+ * Rather, exception handling is limited to sanity-checking
+ * parameters inputs, etc., for object construction and other routines.
+ *
+ * However, it is sometimes useful to perform expensive checks on the
+ * data integrity of a simulated population.  The routines in
+ * fwdpp::debug allow you to do that without affecting the 
+ * performance of code compiled in "release" mode.
+ *
+ * Following the tradition of the C language, compiling with
+ * -DNDEBUG signals that a release-mode build is desired, 
+ * meaning that expensive runtime checks are disables.
+ * 
+ * If that symbol is not defined, then various runtime checks
+ * are enabled, and any failed checks with throw std::runtime_error.
+ * The message field of the error will begin with "FWDPP DEBUG:".
+ *
+ * Functions in namespace fwdpp::debug will be optimized out when
+ * code is compiled with -DNDEBUG, as they evaluate to empty functions.
+ */
+
 namespace fwdpp
 {
     namespace debug
@@ -15,6 +38,7 @@ namespace fwdpp
         void
         validate_sum_gamete_counts(const gcont_t &gametes,
                                    const uint_t expected_sum)
+        /// Throw exception if sum of all gamete counts != \a expected_sum
         {
             detail::validate_sum_gamete_counts(gametes, expected_sum);
         }
@@ -32,6 +56,7 @@ namespace fwdpp
         template <typename gamete_t>
         void
         gamete_is_extant(const gamete_t &gamete)
+        /// Throw exception of gamete.n == 0
         {
             detail::gamete_is_extant(gamete);
         }
@@ -51,6 +76,9 @@ namespace fwdpp
         void
         gamete_data_valid(const gamete_t &g, const mcont_t &mutations,
                           const std::vector<uint_t> &mutcounts)
+        /// Throw exception if gamete data are unsorted or if mutation
+        /// key storage is invalid.
+        /// \note Only call this if the gamete is extant!!!!
         {
             detail::gamete_data_valid(g, mutations, mutcounts);
         }
@@ -58,6 +86,9 @@ namespace fwdpp
         template <typename poptype>
         void
         validate_pop_data(const poptype &pop)
+        /// Throw exception if any in a series of checks on
+        /// the internal state of \a pop fail.
+        /// \note This is an expensive function!
         {
             detail::validate_pop_data(pop);
         }
@@ -66,6 +97,7 @@ namespace fwdpp
         void
         check_mutation_neutrality(const mutation_type &mutation,
                                   const bool expected_neutrality)
+        /// Throw exception if mutation.neutral != \a expected_neutrality
         {
             detail::check_mutation_neutrality(mutation, expected_neutrality);
         }

--- a/fwdpp/debug.hpp
+++ b/fwdpp/debug.hpp
@@ -162,6 +162,17 @@ namespace fwdpp
         {
             detail::validate_mutation_key_ranges(mutations, beg, end);
         }
+
+        template <typename gamete_t, typename mcont_t>
+        void
+        gamete_is_sorted(const gamete_t &g, const mcont_t &mutations)
+        /*!
+      \brief Check that neutral mutation keys are sorted according to mutation
+      position
+    */
+        {
+            detail::gamete_is_sorted(g, mutations);
+        }
     } // namespace debug
 } // namespace fwdpp
 

--- a/fwdpp/debug.hpp
+++ b/fwdpp/debug.hpp
@@ -1,5 +1,5 @@
-#ifndef __FWDPP_DEBUG_HPP__
-#define __FWDPP_DEBUG_HPP__
+#ifndef FWDPP_DEBUG_HPP
+#define FWDPP_DEBUG_HPP
 
 #include <algorithm>
 #include <numeric>

--- a/fwdpp/diploid.hh
+++ b/fwdpp/diploid.hh
@@ -13,7 +13,6 @@
 // namespace std
 #include <vector>
 #include <list>
-#include <cassert>
 #include <iterator>
 #include <ctime>
 #include <cmath>

--- a/fwdpp/extensions/regions.hpp
+++ b/fwdpp/extensions/regions.hpp
@@ -3,7 +3,6 @@
 #define __FWDPP_EXTENSIONS_REGIONS_HPP__
 
 #include <limits>
-#include <cassert>
 #include <stdexcept>
 #include <algorithm>
 #include <memory>

--- a/fwdpp/fitness_models.hpp
+++ b/fwdpp/fitness_models.hpp
@@ -189,6 +189,7 @@ namespace fwdpp
                 {
                     for (;
                          first2 != last2 && *first1 != *first2
+                         // TODO: change this test to <
                          && !(mutations[*first2].pos > mutations[*first1].pos);
                          ++first2)
                         // All mutations in this range are Aa

--- a/fwdpp/fitness_models.hpp
+++ b/fwdpp/fitness_models.hpp
@@ -6,7 +6,6 @@
 #include <fwdpp/type_traits.hpp>
 #include <cmath>
 #include <stdexcept>
-#include <cassert>
 #include <type_traits>
 #include <algorithm>
 #include <functional>
@@ -187,23 +186,19 @@ namespace fwdpp
                 }
             for (; first1 != last1; ++first1)
                 {
-                    for (;
-                         first2 != last2 && *first1 != *first2
-                         // TODO: change this test to <
-                         && !(mutations[*first2].pos > mutations[*first1].pos);
+                    for (; first2 != last2 && *first1 != *first2
+                           && mutations[*first2].pos < mutations[*first1].pos;
                          ++first2)
                         // All mutations in this range are Aa
                         {
-                            assert(mutations[*first2].pos
-                                   < mutations[*first1].pos);
                             fpol_het(w, mutations[*first2]);
                         }
-                    if (first2 < last2 && *first1 == *first2) // mutation with
-                        // index first1
-                        // is homozygous
+                    if (first2 < last2
+                        && (*first1 == *first2
+                            || mutations[*first1].pos
+                                   == mutations[*first2].pos))
+                        // mutation with index first1 is homozygous
                         {
-                            assert(mutations[*first2].pos
-                                   == mutations[*first1].pos);
                             fpol_hom(w, mutations[*first1]);
                             ++first2; // increment so that we don't re-process
                             // this site as a het next time 'round

--- a/fwdpp/internal/Makefile.am
+++ b/fwdpp/internal/Makefile.am
@@ -12,5 +12,6 @@ pkginclude_HEADERS=mutation_internal.hpp \
 	type_traits.hpp \
 	data_matrix_details.hpp \
 	sampling_functions_details.hpp \
+	debug_details.hpp \
 	void_t.hpp
 

--- a/fwdpp/internal/Makefile.in
+++ b/fwdpp/internal/Makefile.in
@@ -277,6 +277,7 @@ pkginclude_HEADERS = mutation_internal.hpp \
 	type_traits.hpp \
 	data_matrix_details.hpp \
 	sampling_functions_details.hpp \
+	debug_details.hpp \
 	void_t.hpp
 
 all: all-am

--- a/fwdpp/internal/debug_details.hpp
+++ b/fwdpp/internal/debug_details.hpp
@@ -1,8 +1,11 @@
 #ifndef FWDPP_INTERNAL_DEBUG_DETAILS_HPP
 #define FWDPP_INTERNAL_DEBUG_DETAILS_HPP
 
+#include <vector>
 #include <algorithm>
 #include <stdexcept>
+#include <fwdpp/forward_types.hpp>
+#include <fwdpp/sugar/poptypes/tags.hpp>
 
 namespace fwdpp
 {
@@ -11,6 +14,23 @@ namespace fwdpp
         namespace detail
         {
 #ifndef NDEBUG
+            template <typename gcont_t>
+            void
+            validate_sum_gamete_counts(const gcont_t &gametes,
+                                       const uint_t expected_sum)
+            {
+                uint_t s = 0;
+                for (auto &g : gametes)
+                    {
+                        s += g.n;
+                    }
+                if (s != expected_sum)
+                    {
+                        throw std::runtime_error(
+                            "unexpectd sum of gamete counts");
+                    }
+            }
+
             template <typename mcont_t, typename iterator>
             void
             validate_mutation_key_ranges(const mcont_t &mutations,
@@ -30,9 +50,9 @@ namespace fwdpp
             void
             gamete_is_sorted(const gamete_t &g, const mcont_t &m)
             /*!
-      \brief Check that neutral mutation keys are sorted according to mutation
-      position
-    */
+             * \brief Check that neutral mutation keys are sorted according to mutation
+             * position
+             */
             {
                 const auto comp = [&m](const size_t i, const size_t j) {
                     return m[i].pos <= m[j].pos;
@@ -51,7 +71,102 @@ namespace fwdpp
                             "selected mutation keys not sorted");
                     }
             }
+
+            template <typename key_container, typename mcont_t>
+            void
+            gamete_data_valid(const key_container &keys,
+                              const mcont_t &mutations,
+                              const std::vector<uint_t> &mutcounts,
+                              const bool expected_neutrality)
+            {
+                for (auto &k : keys)
+                    {
+                        if (!mutcounts[k])
+                            {
+                                throw std::runtime_error(
+                                    "extinct mutation in extant gamete");
+                            }
+                        if (mutations[k].neutral != expected_neutrality)
+                            {
+                                throw std::runtime_error(
+                                    "mutation neutrality field incorrect");
+                            }
+                    }
+            }
+
+            template <typename gamete_t, typename mcont_t>
+            void
+            gamete_data_valid(const gamete_t &g, const mcont_t &mutations,
+                              const std::vector<uint_t> &mutcounts)
+            /*
+      \brief Check that "neutral" and "non-neutral" mutations are where we
+      expect them to be.
+     */
+            {
+                detail::gamete_is_sorted(g, mutations);
+                detail::gamete_data_valid(g.mutations, mutations, mutcounts,
+                                          true);
+                detail::gamete_data_valid(g.smutations, mutations, mutcounts,
+                                          false);
+            }
+
+            template <typename diploid, typename gcont_t, typename mcont_t>
+            void
+            validate_pop_data_common(const diploid &dip,
+                                     const gcont_t &gametes,
+                                     const mcont_t &mutations,
+                                     const std::vector<uint_t> &mutcounts)
+            {
+                if (!gametes[dip.first].n || !gametes[dip.second].n)
+                    {
+                        throw std::runtime_error("gamete count is zero");
+                    }
+                gamete_is_sorted(gametes[dip.first], mutations);
+                gamete_is_sorted(gametes[dip.second], mutations);
+                gamete_data_valid(gametes[dip.first], mutations, mutcounts);
+                gamete_data_valid(gametes[dip.second], mutations, mutcounts);
+            }
+
+            template <typename poptype>
+            void
+            validate_pop_data(const poptype &pop, sugar::SINGLELOC_TAG)
+            {
+                for (const auto &d : pop.diploids)
+                    {
+                        validate_pop_data_common(d, pop.gametes, pop.mutations,
+                                                 pop.mcounts);
+                    }
+            }
+
+            template <typename poptype>
+            void
+            validate_pop_data(const poptype &pop, sugar::MULTILOC_TAG)
+            {
+                for (const auto &d : pop.diploids)
+                    {
+                        for (const auto &locus : d)
+                            {
+                                validate_pop_data_common(locus, pop.gametes,
+                                                         pop.mutations,
+                                                         pop.mcounts);
+                            }
+                    }
+            }
+
+            template <typename poptype>
+            void
+            validate_pop_data(const poptype &pop)
+            {
+                validate_pop_data(pop, typename poptype::popmodel_t());
+            }
 #else
+            template <typename gcont_t>
+            void
+            validate_sum_gamete_counts(const gcont_t & /*gametes*/,
+                                       const uint_t /*expected_sum*/)
+            {
+            }
+
             template <typename mcont_t, typename iterator>
             void
             validate_mutation_key_ranges(const mcont_t & /*mutations*/,
@@ -64,9 +179,23 @@ namespace fwdpp
             void
             gamete_is_sorted(const gamete_t &, const mcont_t &)
             /*!
-      \brief Check that neutral mutation keys are sorted according to mutation
-      position
-    */
+              \brief Check that neutral mutation keys are sorted according to mutation
+              position
+            */
+            {
+            }
+
+            template <typename gamete_t, typename mcont_t>
+            void
+            gamete_data_valid(const gamete_t & /*gamete*/,
+                              const mcont_t & /*mutations*/,
+                              const std::vector<uint_t> & /*mutcounts*/)
+            {
+            }
+
+            template <typename poptype>
+            void
+            validate_pop_data(const poptype & /*pop*/)
             {
             }
 #endif

--- a/fwdpp/internal/debug_details.hpp
+++ b/fwdpp/internal/debug_details.hpp
@@ -1,12 +1,39 @@
 #ifndef FWDPP_INTERNAL_DEBUG_DETAILS_HPP
 #define FWDPP_INTERNAL_DEBUG_DETAILS_HPP
 
+#include <algorithm>
+#include <stdexcept>
+
 namespace fwdpp
 {
     namespace debug
     {
         namespace detail
         {
+#ifndef NDEBUG
+            template <typename mcont_t, typename iterator>
+            void
+            validate_mutation_key_ranges(const mcont_t &mutations,
+                                         const iterator beg,
+                                         const iterator end)
+            {
+                if (std::any_of(beg, end, [&mutations](const std::size_t m) {
+                        return m >= mutations.size();
+                    }))
+                    {
+                        throw std::runtime_error("FWDPP DEBUG: mutation key "
+                                                 "out of range");
+                    }
+            }
+#else
+            template <typename mcont_t, typename iterator>
+            void
+            validate_mutation_key_ranges(const mcont_t& /*mutations*/,
+                                         const iterator /*beg*/,
+                                         const iterator /*end*/)
+            {
+            }
+#endif
         }
     }
 }

--- a/fwdpp/internal/debug_details.hpp
+++ b/fwdpp/internal/debug_details.hpp
@@ -52,7 +52,8 @@ namespace fwdpp
             {
                 if (!gamete.n)
                     {
-                        throw std::runtime_error("FWDPP DEBUG: unexpected extinct gamete");
+                        throw std::runtime_error(
+                            "FWDPP DEBUG: unexpected extinct gamete");
                     }
             }
 
@@ -94,12 +95,14 @@ namespace fwdpp
                         if (!mutcounts[k])
                             {
                                 throw std::runtime_error(
-                                    "FWDPP DEBUG: extinct mutation in extant gamete");
+                                    "FWDPP DEBUG: extinct mutation in extant "
+                                    "gamete");
                             }
                         if (mutations[k].neutral != expected_neutrality)
                             {
                                 throw std::runtime_error(
-                                    "FWDPP DEBUG: mutation neutrality field incorrect");
+                                    "FWDPP DEBUG: mutation neutrality field "
+                                    "incorrect");
                             }
                     }
             }
@@ -129,7 +132,8 @@ namespace fwdpp
             {
                 if (!gametes[dip.first].n || !gametes[dip.second].n)
                     {
-                        throw std::runtime_error("FWDPP DEBUG: gamete count is zero");
+                        throw std::runtime_error(
+                            "FWDPP DEBUG: gamete count is zero");
                     }
                 gamete_is_sorted(gametes[dip.first], mutations);
                 gamete_is_sorted(gametes[dip.second], mutations);
@@ -168,6 +172,19 @@ namespace fwdpp
             validate_pop_data(const poptype &pop)
             {
                 validate_pop_data(pop, typename poptype::popmodel_t());
+            }
+
+            template <typename mutation_type>
+            void
+            check_mutation_neutrality(const mutation_type &mutation,
+                                      const bool expected_neutrality)
+            {
+                if (mutation.neutral != expected_neutrality)
+                    {
+                        throw std::runtime_error(
+                            "FWDPP DEBUG: mutation neutrality field "
+                            "incorrect");
+                    }
             }
 #else
             template <typename gcont_t>
@@ -212,6 +229,13 @@ namespace fwdpp
             template <typename poptype>
             void
             validate_pop_data(const poptype & /*pop*/)
+            {
+            }
+
+            template <typename mutation_type>
+            void
+            check_mutation_neutrality(const mutation_type & /*mutation*/,
+                                      const bool /*expected_neutrality*/)
             {
             }
 #endif

--- a/fwdpp/internal/debug_details.hpp
+++ b/fwdpp/internal/debug_details.hpp
@@ -46,6 +46,16 @@ namespace fwdpp
                     }
             }
 
+            template <typename gamete_t>
+            void
+            gamete_is_extant(const gamete_t &gamete)
+            {
+                if (!gamete.n)
+                    {
+                        throw std::runtime_error("unexpected extinct gamete");
+                    }
+            }
+
             template <typename gamete_t, typename mcont_t>
             void
             gamete_is_sorted(const gamete_t &g, const mcont_t &m)
@@ -175,6 +185,12 @@ namespace fwdpp
             {
             }
 
+            template <typename gamete_t>
+            void
+            gamete_is_extant(const gamete_t & /*gamete*/)
+            {
+            }
+
             template <typename gamete_t, typename mcont_t>
             void
             gamete_is_sorted(const gamete_t &, const mcont_t &)
@@ -199,8 +215,8 @@ namespace fwdpp
             {
             }
 #endif
-        }
-    }
-}
+        } // namespace detail
+    }     // namespace debug
+} // namespace fwdpp
 
 #endif

--- a/fwdpp/internal/debug_details.hpp
+++ b/fwdpp/internal/debug_details.hpp
@@ -25,12 +25,48 @@ namespace fwdpp
                                                  "out of range");
                     }
             }
+
+            template <typename gamete_t, typename mcont_t>
+            void
+            gamete_is_sorted(const gamete_t &g, const mcont_t &m)
+            /*!
+      \brief Check that neutral mutation keys are sorted according to mutation
+      position
+    */
+            {
+                const auto comp = [&m](const size_t i, const size_t j) {
+                    return m[i].pos <= m[j].pos;
+                };
+
+                if (!std::is_sorted(g.mutations.begin(), g.mutations.end(),
+                                    comp))
+                    {
+                        throw std::runtime_error(
+                            "neutral mutation keys not sorted");
+                    }
+                if (!std::is_sorted(g.smutations.begin(), g.smutations.end(),
+                                    comp))
+                    {
+                        throw std::runtime_error(
+                            "selected mutation keys not sorted");
+                    }
+            }
 #else
             template <typename mcont_t, typename iterator>
             void
-            validate_mutation_key_ranges(const mcont_t& /*mutations*/,
+            validate_mutation_key_ranges(const mcont_t & /*mutations*/,
                                          const iterator /*beg*/,
                                          const iterator /*end*/)
+            {
+            }
+
+            template <typename gamete_t, typename mcont_t>
+            void
+            gamete_is_sorted(const gamete_t &, const mcont_t &)
+            /*!
+      \brief Check that neutral mutation keys are sorted according to mutation
+      position
+    */
             {
             }
 #endif

--- a/fwdpp/internal/debug_details.hpp
+++ b/fwdpp/internal/debug_details.hpp
@@ -1,0 +1,14 @@
+#ifndef FWDPP_INTERNAL_DEBUG_DETAILS_HPP
+#define FWDPP_INTERNAL_DEBUG_DETAILS_HPP
+
+namespace fwdpp
+{
+    namespace debug
+    {
+        namespace detail
+        {
+        }
+    }
+}
+
+#endif

--- a/fwdpp/internal/debug_details.hpp
+++ b/fwdpp/internal/debug_details.hpp
@@ -27,7 +27,7 @@ namespace fwdpp
                 if (s != expected_sum)
                     {
                         throw std::runtime_error(
-                            "unexpectd sum of gamete counts");
+                            "FWDPP DEBUG: unexpectd sum of gamete counts");
                     }
             }
 
@@ -52,7 +52,7 @@ namespace fwdpp
             {
                 if (!gamete.n)
                     {
-                        throw std::runtime_error("unexpected extinct gamete");
+                        throw std::runtime_error("FWDPP DEBUG: unexpected extinct gamete");
                     }
             }
 
@@ -72,13 +72,13 @@ namespace fwdpp
                                     comp))
                     {
                         throw std::runtime_error(
-                            "neutral mutation keys not sorted");
+                            "FWDPP DEBUG: neutral mutation keys not sorted");
                     }
                 if (!std::is_sorted(g.smutations.begin(), g.smutations.end(),
                                     comp))
                     {
                         throw std::runtime_error(
-                            "selected mutation keys not sorted");
+                            "FWDPP DEBUG: selected mutation keys not sorted");
                     }
             }
 
@@ -94,12 +94,12 @@ namespace fwdpp
                         if (!mutcounts[k])
                             {
                                 throw std::runtime_error(
-                                    "extinct mutation in extant gamete");
+                                    "FWDPP DEBUG: extinct mutation in extant gamete");
                             }
                         if (mutations[k].neutral != expected_neutrality)
                             {
                                 throw std::runtime_error(
-                                    "mutation neutrality field incorrect");
+                                    "FWDPP DEBUG: mutation neutrality field incorrect");
                             }
                     }
             }
@@ -129,7 +129,7 @@ namespace fwdpp
             {
                 if (!gametes[dip.first].n || !gametes[dip.second].n)
                     {
-                        throw std::runtime_error("gamete count is zero");
+                        throw std::runtime_error("FWDPP DEBUG: gamete count is zero");
                     }
                 gamete_is_sorted(gametes[dip.first], mutations);
                 gamete_is_sorted(gametes[dip.second], mutations);

--- a/fwdpp/internal/debug_details.hpp
+++ b/fwdpp/internal/debug_details.hpp
@@ -7,18 +7,31 @@
 #include <fwdpp/forward_types.hpp>
 #include <fwdpp/sugar/poptypes/tags.hpp>
 
+/* We ignore unused variable warnings in this 
+ * file.  In release mode, the functions are empty,
+ * and will result in loads of unnecessary warnings
+ */
+#if defined(__clang__) && defined(__llvm__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
+
+
 namespace fwdpp
 {
     namespace debug
     {
         namespace detail
         {
-#ifndef NDEBUG
             template <typename gcont_t>
             void
             validate_sum_gamete_counts(const gcont_t &gametes,
                                        const uint_t expected_sum)
             {
+#ifndef NDEBUG
                 uint_t s = 0;
                 for (auto &g : gametes)
                     {
@@ -29,6 +42,7 @@ namespace fwdpp
                         throw std::runtime_error(
                             "FWDPP DEBUG: unexpectd sum of gamete counts");
                     }
+#endif
             }
 
             template <typename mcont_t, typename iterator>
@@ -37,6 +51,7 @@ namespace fwdpp
                                          const iterator beg,
                                          const iterator end)
             {
+#ifndef NDEBUG
                 if (std::any_of(beg, end, [&mutations](const std::size_t m) {
                         return m >= mutations.size();
                     }))
@@ -44,17 +59,20 @@ namespace fwdpp
                         throw std::runtime_error("FWDPP DEBUG: mutation key "
                                                  "out of range");
                     }
+#endif
             }
 
             template <typename gamete_t>
             void
             gamete_is_extant(const gamete_t &gamete)
             {
+#ifndef NDEBUG
                 if (!gamete.n)
                     {
                         throw std::runtime_error(
                             "FWDPP DEBUG: unexpected extinct gamete");
                     }
+#endif
             }
 
             template <typename gamete_t, typename mcont_t>
@@ -65,6 +83,7 @@ namespace fwdpp
              * position
              */
             {
+#ifndef NDEBUG
                 const auto comp = [&m](const size_t i, const size_t j) {
                     return m[i].pos <= m[j].pos;
                 };
@@ -81,6 +100,7 @@ namespace fwdpp
                         throw std::runtime_error(
                             "FWDPP DEBUG: selected mutation keys not sorted");
                     }
+#endif
             }
 
             template <typename key_container, typename mcont_t>
@@ -90,6 +110,7 @@ namespace fwdpp
                               const std::vector<uint_t> &mutcounts,
                               const bool expected_neutrality)
             {
+#ifndef NDEBUG
                 for (auto &k : keys)
                     {
                         if (!mutcounts[k])
@@ -105,6 +126,7 @@ namespace fwdpp
                                     "incorrect");
                             }
                     }
+#endif
             }
 
             template <typename gamete_t, typename mcont_t>
@@ -116,11 +138,13 @@ namespace fwdpp
       expect them to be.
      */
             {
+#ifndef NDEBUG
                 detail::gamete_is_sorted(g, mutations);
                 detail::gamete_data_valid(g.mutations, mutations, mutcounts,
                                           true);
                 detail::gamete_data_valid(g.smutations, mutations, mutcounts,
                                           false);
+#endif
             }
 
             template <typename diploid, typename gcont_t, typename mcont_t>
@@ -130,6 +154,7 @@ namespace fwdpp
                                      const mcont_t &mutations,
                                      const std::vector<uint_t> &mutcounts)
             {
+#ifndef NDEBUG
                 if (!gametes[dip.first].n || !gametes[dip.second].n)
                     {
                         throw std::runtime_error(
@@ -139,23 +164,27 @@ namespace fwdpp
                 gamete_is_sorted(gametes[dip.second], mutations);
                 gamete_data_valid(gametes[dip.first], mutations, mutcounts);
                 gamete_data_valid(gametes[dip.second], mutations, mutcounts);
+#endif
             }
 
             template <typename poptype>
             void
             validate_pop_data(const poptype &pop, sugar::SINGLELOC_TAG)
             {
+#ifndef NDEBUG
                 for (const auto &d : pop.diploids)
                     {
                         validate_pop_data_common(d, pop.gametes, pop.mutations,
                                                  pop.mcounts);
                     }
+#endif
             }
 
             template <typename poptype>
             void
             validate_pop_data(const poptype &pop, sugar::MULTILOC_TAG)
             {
+#ifndef NDEBUG
                 for (const auto &d : pop.diploids)
                     {
                         for (const auto &locus : d)
@@ -165,13 +194,16 @@ namespace fwdpp
                                                          pop.mcounts);
                             }
                     }
+#endif
             }
 
             template <typename poptype>
             void
             validate_pop_data(const poptype &pop)
             {
+#ifndef NDEBUG
                 validate_pop_data(pop, typename poptype::popmodel_t());
+#endif
             }
 
             template <typename mutation_type>
@@ -179,68 +211,23 @@ namespace fwdpp
             check_mutation_neutrality(const mutation_type &mutation,
                                       const bool expected_neutrality)
             {
+#ifndef NDEBUG
                 if (mutation.neutral != expected_neutrality)
                     {
                         throw std::runtime_error(
                             "FWDPP DEBUG: mutation neutrality field "
                             "incorrect");
                     }
-            }
-#else
-            template <typename gcont_t>
-            void
-            validate_sum_gamete_counts(const gcont_t & /*gametes*/,
-                                       const uint_t /*expected_sum*/)
-            {
-            }
-
-            template <typename mcont_t, typename iterator>
-            void
-            validate_mutation_key_ranges(const mcont_t & /*mutations*/,
-                                         const iterator /*beg*/,
-                                         const iterator /*end*/)
-            {
-            }
-
-            template <typename gamete_t>
-            void
-            gamete_is_extant(const gamete_t & /*gamete*/)
-            {
-            }
-
-            template <typename gamete_t, typename mcont_t>
-            void
-            gamete_is_sorted(const gamete_t &, const mcont_t &)
-            /*!
-              \brief Check that neutral mutation keys are sorted according to mutation
-              position
-            */
-            {
-            }
-
-            template <typename gamete_t, typename mcont_t>
-            void
-            gamete_data_valid(const gamete_t & /*gamete*/,
-                              const mcont_t & /*mutations*/,
-                              const std::vector<uint_t> & /*mutcounts*/)
-            {
-            }
-
-            template <typename poptype>
-            void
-            validate_pop_data(const poptype & /*pop*/)
-            {
-            }
-
-            template <typename mutation_type>
-            void
-            check_mutation_neutrality(const mutation_type & /*mutation*/,
-                                      const bool /*expected_neutrality*/)
-            {
-            }
 #endif
+            }
         } // namespace detail
     }     // namespace debug
 } // namespace fwdpp
+
+#if defined(__clang__) && defined(__llvm__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/fwdpp/internal/mutation_internal.hpp
+++ b/fwdpp/internal/mutation_internal.hpp
@@ -2,7 +2,7 @@
 #define __FWDPP_INTERNAL_MUTATION_HPP__
 
 #include <algorithm>
-#include <cassert>
+
 namespace fwdpp
 {
     namespace fwdpp_internal

--- a/fwdpp/internal/rec_gamete_updater.hpp
+++ b/fwdpp/internal/rec_gamete_updater.hpp
@@ -1,9 +1,9 @@
-#ifndef __FWDPP_INTERNAL_REC_GAMETE_UPDATER_HPP__
-#define __FWDPP_INTERNAL_REC_GAMETE_UPDATER_HPP__
+#ifndef FWDPP_INTERNAL_REC_GAMETE_UPDATER_HPP
+#define FWDPP_INTERNAL_REC_GAMETE_UPDATER_HPP
 
 #include <algorithm>
 #include <functional>
-#include <cassert>
+
 namespace fwdpp
 {
     namespace fwdpp_internal

--- a/fwdpp/internal/recombination_common.hpp
+++ b/fwdpp/internal/recombination_common.hpp
@@ -45,9 +45,7 @@ namespace fwdpp
                     std::swap(itr_e, jtr_e);
                     std::swap(itr_s_e, jtr_s_e);
                 }
-
-            assert(gamete_is_sorted_n(gametes[ibeg], mutations));
-            assert(gamete_is_sorted_s(gametes[ibeg], mutations));
+			debug::gamete_is_sorted(gametes[ibeg], mutations);
         }
     }
 }

--- a/fwdpp/io/detail/serialize_population.hpp
+++ b/fwdpp/io/detail/serialize_population.hpp
@@ -1,6 +1,8 @@
 #ifndef FWDPP_IO_SERIALIZE_POPULATION_DETAIL_HPP__
 #define FWDPP_IO_SERIALIZE_POPULATION_DETAIL_HPP__
 
+#include <cstdint>
+#include <stdexcept>
 #include <fwdpp/io/scalar_serialization.hpp>
 #include <fwdpp/io/mutation.hpp>
 #include <fwdpp/io/gamete.hpp>
@@ -133,7 +135,13 @@ namespace fwdpp
                     dipreader;
                 for (auto &dip : pop.diploids)
                     {
-                        assert(dip.size() == nloci);
+                        if (dip.size() != nloci)
+                            {
+                                throw std::runtime_error(
+                                    "serialization error: diploid has "
+                                    "unexpected number of loci");
+                            }
+
                         for (auto &genotype : dip)
                             {
                                 dipreader(buffer, genotype);
@@ -170,7 +178,7 @@ namespace fwdpp
                                                    static_cast<uint_t>(i));
                     }
             }
-        }
-    }
-}
+        } // namespace detail
+    }     // namespace io
+} // namespace fwdpp
 #endif

--- a/fwdpp/mutate_recombine.hpp
+++ b/fwdpp/mutate_recombine.hpp
@@ -14,6 +14,7 @@
 #include <tuple>
 #include <gsl/gsl_rng.h>
 #include <gsl/gsl_randist.h>
+#include <fwdpp/debug.hpp>
 #include <fwdpp/type_traits.hpp>
 #include <fwdpp/forward_types.hpp>
 #include <fwdpp/internal/mutation_internal.hpp>
@@ -66,7 +67,7 @@ namespace fwdpp
                          const recombination_policy &rec_pol)
     /// Generate vector of recombination breakpoints
     ///
-	/// \param diploid A single-locus diploid.
+    /// \param diploid A single-locus diploid.
     /// \param g1 Index of gamete 1
     /// \param g2 Index of gamete 2
     /// \param gametes Vector of gametes
@@ -107,7 +108,7 @@ namespace fwdpp
     /// \param recycling_bin The queue for recycling mutations
     /// \param r A random number generator
     /// \param mu The total mutation rate
-	/// \param dip A single-locus diploid
+    /// \param dip A single-locus diploid
     /// \param gametes Vector of gametes
     /// \param mutations Vector of mutations
     /// \param g index of gamete to mutate
@@ -320,7 +321,7 @@ namespace fwdpp
     /// \param parental_gametes Tuple of gamete keys for each parent
     /// \param rec_pol Policy to generate recombination breakpoints
     /// \param mmodel Policy to generate new mutations
-	/// \param mu Total mutation rate (per gamete).
+    /// \param mu Total mutation rate (per gamete).
     /// \param gamete_recycling_bin FIFO queue for gamete recycling
     /// \param mutation_recycling_bin FIFO queue for mutation recycling
     /// \param dip The offspring
@@ -375,9 +376,11 @@ namespace fwdpp
         dip.first = mutate_recombine(new_mutations, breakpoints, p1g1, p1g2,
                                      gametes, mutations, gamete_recycling_bin,
                                      neutral, selected);
+        debug::gamete_is_sorted(gametes[dip.first], mutations);
         dip.second = mutate_recombine(new_mutations2, breakpoints2, p2g1, p2g2,
                                       gametes, mutations, gamete_recycling_bin,
                                       neutral, selected);
+        debug::gamete_is_sorted(gametes[dip.second], mutations);
         gametes[dip.first].n++;
         gametes[dip.second].n++;
 

--- a/fwdpp/mutate_recombine.hpp
+++ b/fwdpp/mutate_recombine.hpp
@@ -10,7 +10,6 @@
 
 #include <vector>
 #include <algorithm>
-#include <cassert>
 #include <tuple>
 #include <gsl/gsl_rng.h>
 #include <gsl/gsl_randist.h>
@@ -166,7 +165,7 @@ namespace fwdpp
             selected.reserve(std::max(gametes[g1].smutations.size(),
                                       gametes[g2].smutations.size()));
         }
-    }
+    } // namespace fwdpp_internal
 
     template <typename gcont_t, typename mcont_t, typename queue_type>
     uint_t
@@ -290,7 +289,13 @@ namespace fwdpp
                         ++i;
                     }
             }
-        assert(next_mutation == new_mutations.cend());
+#ifndef NDEBUG
+        if (next_mutation != new_mutations.cend())
+            {
+                throw std::runtime_error(
+                    "FWDPP DEBUG: fatal error during mutation/recombination");
+            }
+#endif
         return fwdpp_internal::recycle_gamete(gametes, gamete_recycling_bin,
                                               neutral, selected);
     }
@@ -384,14 +389,14 @@ namespace fwdpp
         gametes[dip.first].n++;
         gametes[dip.second].n++;
 
-        assert(gametes[dip.first].n);
-        assert(gametes[dip.second].n);
+        debug::gamete_is_extant(gametes[dip.first]);
+        debug::gamete_is_extant(gametes[dip.second]);
 
         auto nrec = (!breakpoints.empty()) ? breakpoints.size() - 1 : 0;
         auto nrec2 = (!breakpoints2.empty()) ? breakpoints2.size() - 1 : 0;
         return std::make_tuple(nrec, nrec2, new_mutations.size(),
                                new_mutations2.size());
     }
-}
+} // namespace fwdpp
 
 #endif

--- a/fwdpp/sample_diploid.hpp
+++ b/fwdpp/sample_diploid.hpp
@@ -1,5 +1,5 @@
-#ifndef __FWDPP_SAMPLE_DIPLOID_HPP__
-#define __FWDPP_SAMPLE_DIPLOID_HPP__
+#ifndef FWDPP_SAMPLE_DIPLOID_HPP
+#define FWDPP_SAMPLE_DIPLOID_HPP
 
 #include <utility>
 #include <vector>

--- a/fwdpp/sample_diploid.tcc
+++ b/fwdpp/sample_diploid.tcc
@@ -6,8 +6,8 @@
   \brief Definitions of functions for evolving populations of diploids.
 */
 
-#ifndef __FWDPP_SAMPLE_DIPLOID_TCC__
-#define __FWDPP_SAMPLE_DIPLOID_TCC__
+#ifndef FWDPP_SAMPLE_DIPLOID_TCC
+#define FWDPP_SAMPLE_DIPLOID_TCC
 
 #include <fwdpp/debug.hpp>
 #include <fwdpp/mutate_recombine.hpp>

--- a/fwdpp/sample_diploid.tcc
+++ b/fwdpp/sample_diploid.tcc
@@ -8,7 +8,8 @@
 
 #ifndef FWDPP_SAMPLE_DIPLOID_TCC
 #define FWDPP_SAMPLE_DIPLOID_TCC
-
+   
+#include <cassert>
 #include <fwdpp/debug.hpp>
 #include <fwdpp/mutate_recombine.hpp>
 #include <fwdpp/internal/recycling.hpp>
@@ -92,9 +93,19 @@ namespace fwdpp
         */
 
         // test preconditions in debugging mode
-        assert(mcounts.size() == mutations.size());
-        assert(N_curr == diploids.size());
-        assert(mcounts.size() == mutations.size());
+#ifndef NDEBUG
+        if (mcounts.size() != mutations.size())
+            {
+                throw std::runtime_error(
+                    "FWDPP DEBUG: mutation container size must equal "
+                    "mutation count container size");
+            }
+        if (N_curr != diploids.size())
+            {
+                throw std::runtime_error(
+                    "FWDPP DEBUG: N_curr != diploids.size()");
+            }
+#endif
 
         /*
           The mutation and gamete containers contain both extinct and extant
@@ -152,7 +163,13 @@ namespace fwdpp
         wbar /= double(diploids.size());
 #ifndef NDEBUG
         for (const auto &g : gametes)
-            assert(!g.n);
+            {
+                if (g.n > 0)
+                    {
+                        throw std::runtime_error(
+                            "FWDPP DEBUG: not all gamete counts equal zero");
+                    }
+            }
 #endif
 
         /*
@@ -174,7 +191,6 @@ namespace fwdpp
             {
                 diploids.resize(N_next);
             }
-        assert(diploids.size() == N_next);
 
         // Fill in the next generation!
         for (auto &dip : diploids)
@@ -186,8 +202,6 @@ namespace fwdpp
                 auto p2 = (f == 1. || (f > 0. && gsl_rng_uniform(r) < f))
                               ? p1
                               : gsl_ran_discrete(r, lookup.get());
-                assert(p1 < parents.size());
-                assert(p2 < parents.size());
                 /*
                   These are the gametes from each parent.
                   This is a trivial assignment if keys.
@@ -252,11 +266,10 @@ namespace fwdpp
           The implementation is in fwdpp/internal/sample_diploid_helpers.hpp
          */
         fwdpp_internal::process_gametes(gametes, mutations, mcounts);
-        assert(mcounts.size() == mutations.size());
 #ifndef NDEBUG
         for (const auto &mc : mcounts)
             {
-                assert(mc <= 2 * N_next);
+                if(mc > 2*N_next){throw std::runtime_error("mutation size too large");}
             }
 #endif
 
@@ -288,26 +301,26 @@ namespace fwdpp
 
     // Multi-locus API
     // single deme, N changing
-    template <
-        typename diploid_geno_t, typename gamete_type,
-        typename gamete_cont_type_allocator, typename mutation_type,
-        typename mutation_cont_type_allocator,
-        typename diploid_vector_type_allocator,
-        typename locus_vector_type_allocator,
-        typename diploid_fitness_function, typename mutation_model_container,
-        typename recombination_policy_container,
-        template <typename, typename> class gamete_cont_type,
-        template <typename, typename> class mutation_cont_type,
-        template <typename, typename> class diploid_vector_type,
-        template <typename, typename> class locus_vector_type,
-        typename mutation_removal_policy>
+    template <typename diploid_geno_t, typename gamete_type,
+              typename gamete_cont_type_allocator, typename mutation_type,
+              typename mutation_cont_type_allocator,
+              typename diploid_vector_type_allocator,
+              typename locus_vector_type_allocator,
+              typename diploid_fitness_function,
+              typename mutation_model_container,
+              typename recombination_policy_container,
+              template <typename, typename> class gamete_cont_type,
+              template <typename, typename> class mutation_cont_type,
+              template <typename, typename> class diploid_vector_type,
+              template <typename, typename> class locus_vector_type,
+              typename mutation_removal_policy>
     double
     sample_diploid(
         const gsl_rng *r,
         gamete_cont_type<gamete_type, gamete_cont_type_allocator> &gametes,
-        diploid_vector_type<locus_vector_type<diploid_geno_t,
-                                              locus_vector_type_allocator>,
-                            diploid_vector_type_allocator> &diploids,
+        diploid_vector_type<
+            locus_vector_type<diploid_geno_t, locus_vector_type_allocator>,
+            diploid_vector_type_allocator> &diploids,
         mutation_cont_type<mutation_type, mutation_cont_type_allocator>
             &mutations,
         std::vector<uint_t> &mcounts, const uint_t &N_curr,
@@ -320,8 +333,19 @@ namespace fwdpp
         typename gamete_type::mutation_container &selected, const double &f,
         const mutation_removal_policy &mp)
     {
-        assert(mcounts.size() == mutations.size());
-        assert(diploids.size() == N_curr);
+#ifndef NDEBUG
+        if (mcounts.size() != mutations.size())
+            {
+                throw std::runtime_error(
+                    "FWDPP DEBUG: mutation container size must equal "
+                    "mutation count container size");
+            }
+        if (N_curr != diploids.size())
+            {
+                throw std::runtime_error(
+                    "FWDPP DEBUG: N_curr != diploids.size()");
+            }
+#endif
         // Vector of parental fitnesses
         std::vector<double> fitnesses(N_curr);
         double wbar = 0.;
@@ -352,7 +376,13 @@ namespace fwdpp
           If so, this assertion will fail.
         */
         for (const auto &g : gametes)
-            assert(!g.n);
+            {
+                if (g.n > 0)
+                    {
+                        throw std::runtime_error("FWDPP DEBUG: not all gamete "
+                                                 "counts were set to zero");
+                    }
+            }
 #endif
 
         fwdpp_internal::gsl_ran_discrete_t_ptr lookup(
@@ -368,16 +398,13 @@ namespace fwdpp
                 diploids.resize(N_next);
             }
 
-        assert(diploids.size() == N_next);
 
         for (auto &dip : diploids)
             {
                 auto p1 = gsl_ran_discrete(r, lookup.get());
-                assert(p1 < N_curr);
                 auto p2 = (f == 1. || (f > 0. && gsl_rng_uniform(r) < f))
                               ? p1
                               : gsl_ran_discrete(r, lookup.get());
-                assert(p2 < N_curr);
                 dip = fwdpp_internal::multilocus_rec_mut(
                     r, parents[p1], parents[p2], mut_recycling_bin,
                     gamete_recycling_bin, rec_policies, interlocus_rec,
@@ -392,26 +419,26 @@ namespace fwdpp
     }
 
     // single deme, constant N
-    template <
-        typename diploid_geno_t, typename gamete_type,
-        typename gamete_cont_type_allocator, typename mutation_type,
-        typename mutation_cont_type_allocator,
-        typename diploid_vector_type_allocator,
-        typename locus_vector_type_allocator,
-        typename diploid_fitness_function, typename mutation_model_container,
-        typename recombination_policy_container,
-        template <typename, typename> class gamete_cont_type,
-        template <typename, typename> class mutation_cont_type,
-        template <typename, typename> class diploid_vector_type,
-        template <typename, typename> class locus_vector_type,
-        typename mutation_removal_policy>
+    template <typename diploid_geno_t, typename gamete_type,
+              typename gamete_cont_type_allocator, typename mutation_type,
+              typename mutation_cont_type_allocator,
+              typename diploid_vector_type_allocator,
+              typename locus_vector_type_allocator,
+              typename diploid_fitness_function,
+              typename mutation_model_container,
+              typename recombination_policy_container,
+              template <typename, typename> class gamete_cont_type,
+              template <typename, typename> class mutation_cont_type,
+              template <typename, typename> class diploid_vector_type,
+              template <typename, typename> class locus_vector_type,
+              typename mutation_removal_policy>
     double
     sample_diploid(
         const gsl_rng *r,
         gamete_cont_type<gamete_type, gamete_cont_type_allocator> &gametes,
-        diploid_vector_type<locus_vector_type<diploid_geno_t,
-                                              locus_vector_type_allocator>,
-                            diploid_vector_type_allocator> &diploids,
+        diploid_vector_type<
+            locus_vector_type<diploid_geno_t, locus_vector_type_allocator>,
+            diploid_vector_type_allocator> &diploids,
         mutation_cont_type<mutation_type, mutation_cont_type_allocator>
             &mutations,
         std::vector<uint_t> &mcounts, const uint_t &N, const double *mu,
@@ -427,6 +454,6 @@ namespace fwdpp
                               mu, mmodel, rec_policies, interlocus_rec, ff,
                               neutral, selected, f, mp);
     }
-}
+} // namespace fwdpp
 
 #endif

--- a/fwdpp/sample_diploid.tcc
+++ b/fwdpp/sample_diploid.tcc
@@ -92,7 +92,6 @@ namespace fwdpp
         */
 
         // test preconditions in debugging mode
-        assert(popdata_sane(diploids, gametes, mutations, mcounts));
         assert(mcounts.size() == mutations.size());
         assert(N_curr == diploids.size());
         assert(mcounts.size() == mutations.size());
@@ -214,7 +213,6 @@ namespace fwdpp
                     mu, gam_recycling_bin, mut_recycling_bin, dip, neutral,
                     selected);
             }
-        assert(check_sum(gametes, 2 * N_next));
 #ifndef NDEBUG
         for (const auto &dip : diploids)
             {
@@ -261,7 +259,6 @@ namespace fwdpp
                 assert(mc <= 2 * N_next);
             }
 #endif
-        assert(popdata_sane(diploids, gametes, mutations, mcounts));
 
         /*
           The last thing to do is handle fixations.  In many contexts, we
@@ -323,7 +320,6 @@ namespace fwdpp
         typename gamete_type::mutation_container &selected, const double &f,
         const mutation_removal_policy &mp)
     {
-        assert(popdata_sane_multilocus(diploids, gametes, mutations, mcounts));
         assert(mcounts.size() == mutations.size());
         assert(diploids.size() == N_curr);
         // Vector of parental fitnesses
@@ -392,7 +388,6 @@ namespace fwdpp
         fwdpp_internal::process_gametes(gametes, mutations, mcounts);
         fwdpp_internal::gamete_cleaner(gametes, mutations, mcounts, 2 * N_next,
                                        mp, std::true_type());
-        assert(popdata_sane_multilocus(diploids, gametes, mutations, mcounts));
         return wbar;
     }
 

--- a/fwdpp/sampling_functions.hpp
+++ b/fwdpp/sampling_functions.hpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <utility>
 #include <string>
-#include <cassert>
 #include <type_traits>
 #include <gsl/gsl_rng.h>
 #include <gsl/gsl_randist.h>

--- a/fwdpp/sugar/GSLrng_t.hpp
+++ b/fwdpp/sugar/GSLrng_t.hpp
@@ -5,7 +5,6 @@
 #ifndef __FWDPP_SUGAR_GSLRNG_T_HPP__
 #define __FWDPP_SUGAR_GSLRNG_T_HPP__
 
-#include <cassert>
 #include <stdexcept>
 //#include <cstdio>// FOR SOME POSIX ONLY FUNCTIONS!
 #include <fwdpp/sugar/gsl/tags.hpp>

--- a/fwdpp/sugar/add_mutation.hpp
+++ b/fwdpp/sugar/add_mutation.hpp
@@ -15,10 +15,7 @@
 #include <unordered_map>
 #include <fwdpp/internal/recycling.hpp>
 #include <fwdpp/sugar/poptypes/tags.hpp>
-
-#ifndef NDEBUG
 #include <fwdpp/debug.hpp>
-#endif
 
 namespace fwdpp
 {
@@ -116,10 +113,8 @@ namespace fwdpp
 
                             if (p.mutations[mindex].neutral)
                                 {
-#ifndef NDEBUG
                                     debug::validate_mutation_key_ranges(
-                                        p, n.begin(), n.end());
-#endif
+                                        p.mutations, n.begin(), n.end());
                                     n.insert(std::upper_bound(n.begin(),
                                                               n.end(), pos,
                                                               inserter),
@@ -127,10 +122,8 @@ namespace fwdpp
                                 }
                             else
                                 {
-#ifndef NDEBUG
                                     debug::validate_mutation_key_ranges(
-                                        p, s.begin(), s.end());
-#endif
+                                        p.mutations, s.begin(), s.end());
                                     s.insert(std::upper_bound(s.begin(),
                                                               s.end(), pos,
                                                               inserter),
@@ -162,9 +155,9 @@ namespace fwdpp
         template <typename poptype, typename = std::enable_if<std::is_same<
                                         typename poptype::popmodel_t,
                                         fwdpp::sugar::SINGLELOC_TAG>::value>>
-        std::unordered_map<
-            std::size_t,
-            std::vector<typename poptype::diploid_t::first_type *>>
+        std::unordered_map<std::size_t,
+                           std::vector<
+                               typename poptype::diploid_t::first_type *>>
         collect_gametes(poptype &p, const std::vector<std::size_t> &indlist,
                         const std::vector<short> &clist)
         /*!
@@ -175,9 +168,9 @@ namespace fwdpp
           new gametes created.
         */
         {
-            std::unordered_map<
-                std::size_t,
-                std::vector<typename poptype::diploid_t::first_type *>>
+            std::unordered_map<std::size_t,
+                               std::vector<
+                                   typename poptype::diploid_t::first_type *>>
                 gams;
             for (std::size_t i = 0; i < indlist.size(); ++i)
                 {
@@ -198,9 +191,9 @@ namespace fwdpp
         template <typename poptype, typename = std::enable_if<std::is_same<
                                         typename poptype::popmodel_t,
                                         fwdpp::sugar::MULTILOC_TAG>::value>>
-        std::unordered_map<
-            std::size_t,
-            std::vector<typename poptype::diploid_t::value_type::first_type *>>
+        std::unordered_map<std::size_t,
+                           std::vector<typename poptype::diploid_t::
+                                           value_type::first_type *>>
         collect_gametes(poptype &p, const std::size_t locus,
                         const std::vector<std::size_t> &indlist,
                         const std::vector<short> &clist)
@@ -212,10 +205,9 @@ namespace fwdpp
           new gametes created.
         */
         {
-            std::unordered_map<
-                std::size_t,
-                std::vector<
-                    typename poptype::diploid_t::value_type::first_type *>>
+            std::unordered_map<std::size_t,
+                               std::vector<typename poptype::diploid_t::
+                                               value_type::first_type *>>
                 gams;
             for (std::size_t ind = 0; ind < indlist.size(); ++ind)
                 {

--- a/fwdpp/sugar/add_mutation.hpp
+++ b/fwdpp/sugar/add_mutation.hpp
@@ -117,7 +117,7 @@ namespace fwdpp
                             if (p.mutations[mindex].neutral)
                                 {
 #ifndef NDEBUG
-                                    debug::validate_mutation_ranges(
+                                    debug::validate_mutation_key_ranges(
                                         p, n.begin(), n.end());
 #endif
                                     n.insert(std::upper_bound(n.begin(),

--- a/fwdpp/sugar/change_neutral.hpp
+++ b/fwdpp/sugar/change_neutral.hpp
@@ -7,7 +7,6 @@
 #define FWDPP_SUGAR_CHANGE_NEUTRAL_HPP
 
 #include <algorithm>
-#include <cassert>
 #include <exception>
 #include <fwdpp/debug.hpp>
 

--- a/fwdpp/sugar/change_neutral.hpp
+++ b/fwdpp/sugar/change_neutral.hpp
@@ -102,7 +102,7 @@ namespace fwdpp
                                     p.mutations, pos, mindex, g.smutations,
                                     g.mutations);
                             }
-                        assert(gamete_data_sane(g, p.mutations, p.mcounts));
+                        debug::gamete_data_valid(g,p.mutations,p.mcounts);
                     }
             }
     }

--- a/fwdpp/util.hpp
+++ b/fwdpp/util.hpp
@@ -10,8 +10,8 @@
 #include <map>
 #include <type_traits>
 #include <algorithm>
+#include <stdexcept>
 #include <functional>
-#include <cassert>
 #include <gsl/gsl_rng.h>
 #include <gsl/gsl_randist.h>
 
@@ -30,10 +30,22 @@ namespace fwdpp
         static_assert(
             typename traits::is_mutation<typename mcont_t::value_type>::type(),
             "mutation_type must be derived from fwdpp::mutation_base");
-        assert(mcounts.size() == mutations.size());
+#ifndef NDEBUG
+        if (mcounts.size() != mutations.size())
+            {
+                throw std::runtime_error(
+                    "mutation counts size must equal mutation container size");
+            }
+#endif
         for (std::size_t i = 0; i < mcounts.size(); ++i)
             {
-                assert(mcounts[i] <= twoN);
+#ifndef NDEBUG
+                if (mcounts[i] > twoN)
+                    {
+                        throw std::runtime_error(
+                            "mutation count out of range");
+                    }
+#endif
                 if (mcounts[i] == twoN || !mcounts[i])
                     {
                         auto itr = lookup.equal_range(mutations[i].pos);
@@ -104,10 +116,22 @@ namespace fwdpp
         static_assert(
             typename traits::is_mutation<typename mcont_t::value_type>::type(),
             "mutation_type must be derived from fwdpp::mutation_base");
-        assert(mcounts.size() == mutations.size());
+#ifndef NDEBUG
+        if (mcounts.size() != mutations.size())
+            {
+                throw std::runtime_error(
+                    "mutation counts size must equal mutation container size");
+            }
+#endif
         for (unsigned i = 0; i < mcounts.size(); ++i)
             {
-                assert(mcounts[i] <= twoN);
+#ifndef NDEBUG
+                if (mcounts[i] > twoN)
+                    {
+                        throw std::runtime_error(
+                            "mutation count out of range");
+                    }
+#endif
                 if (mcounts[i] == twoN)
                     {
                         fixations.push_back(mutations[i]);
@@ -165,10 +189,22 @@ namespace fwdpp
             typename traits::is_mutation<typename mcont_t::value_type>::type(),
             "mutation_type must be derived from "
             "fwdpp::mutation_base");
-        assert(mcounts.size() == mutations.size());
+#ifndef NDEBUG
+        if (mcounts.size() != mutations.size())
+            {
+                throw std::runtime_error(
+                    "mutation counts size must equal mutation container size");
+            }
+#endif
         for (unsigned i = 0; i < mcounts.size(); ++i)
             {
-                assert(mcounts[i] <= twoN);
+#ifndef NDEBUG
+                if (mcounts[i] > twoN)
+                    {
+                        throw std::runtime_error(
+                            "mutation count out of range");
+                    }
+#endif
                 if (mutations[i].neutral && mcounts[i] == twoN)
                     {
                         fixations.push_back(mutations[i]);
@@ -212,5 +248,5 @@ namespace fwdpp
                     }
             }
     }
-}
+} // namespace fwdpp
 #endif /* _UTIL_HPP_ */

--- a/fwdpp/util.hpp
+++ b/fwdpp/util.hpp
@@ -34,7 +34,7 @@ namespace fwdpp
         if (mcounts.size() != mutations.size())
             {
                 throw std::runtime_error(
-                    "mutation counts size must equal mutation container size");
+                    "FWDPP DEBUG: mutation counts size must equal mutation container size");
             }
 #endif
         for (std::size_t i = 0; i < mcounts.size(); ++i)
@@ -43,7 +43,7 @@ namespace fwdpp
                 if (mcounts[i] > twoN)
                     {
                         throw std::runtime_error(
-                            "mutation count out of range");
+                            "FWDPP DEBUG: mutation count out of range");
                     }
 #endif
                 if (mcounts[i] == twoN || !mcounts[i])
@@ -120,7 +120,7 @@ namespace fwdpp
         if (mcounts.size() != mutations.size())
             {
                 throw std::runtime_error(
-                    "mutation counts size must equal mutation container size");
+                    "FWDPP DEBUG: mutation counts size must equal mutation container size");
             }
 #endif
         for (unsigned i = 0; i < mcounts.size(); ++i)
@@ -129,7 +129,7 @@ namespace fwdpp
                 if (mcounts[i] > twoN)
                     {
                         throw std::runtime_error(
-                            "mutation count out of range");
+                            "FWDPP DEBUG: mutation count out of range");
                     }
 #endif
                 if (mcounts[i] == twoN)
@@ -193,7 +193,7 @@ namespace fwdpp
         if (mcounts.size() != mutations.size())
             {
                 throw std::runtime_error(
-                    "mutation counts size must equal mutation container size");
+                    "FWDPP DEBUG: mutation counts size must equal mutation container size");
             }
 #endif
         for (unsigned i = 0; i < mcounts.size(); ++i)
@@ -202,7 +202,7 @@ namespace fwdpp
                 if (mcounts[i] > twoN)
                     {
                         throw std::runtime_error(
-                            "mutation count out of range");
+                            "FWDPP DEBUG: mutation count out of range");
                     }
 #endif
                 if (mutations[i].neutral && mcounts[i] == twoN)

--- a/testsuite/unit/gamete_cleanerTest.cc
+++ b/testsuite/unit/gamete_cleanerTest.cc
@@ -6,12 +6,14 @@
 #include <config.h>
 #include <boost/test/unit_test.hpp>
 #include <fwdpp/diploid.hh>
+#include <fwdpp/debug.hpp>
 #include "../fixtures/fwdpp_fixtures.hpp"
 
 BOOST_FIXTURE_TEST_SUITE(gamete_cleanerTest,
                          standard_empty_single_deme_fixture)
 
 BOOST_AUTO_TEST_CASE(test_remove_all)
+// TODO: Refactor this test to use a pop type
 {
     diploids.resize(1000, std::make_pair(0, 0));
     mutations.emplace_back(mtype(0, 0, 0));
@@ -23,15 +25,19 @@ BOOST_AUTO_TEST_CASE(test_remove_all)
     gametes[0].n = 1999;
     gametes.push_back(gcont_t::value_type(1));
     gametes[1].mutations.push_back(1);
-    BOOST_REQUIRE_EQUAL(fwdpp::check_sum(gametes, 2000), true);
-    BOOST_REQUIRE_EQUAL(
-        fwdpp::popdata_sane(diploids, gametes, mutations, mcounts), true);
+    int s = 0;
+    for (auto& g : gametes)
+        {
+            s += g.n;
+        }
+    BOOST_REQUIRE_EQUAL(s, 2000);
     fwdpp::fwdpp_internal::gamete_cleaner(gametes, mutations, mcounts, 2000,
                                           std::true_type());
     BOOST_REQUIRE_EQUAL(gametes[0].mutations.size(), 0);
 }
 
 BOOST_AUTO_TEST_CASE(test_remove_nothing)
+// TODO: Refactor this test to use a pop type
 {
     diploids.resize(1000, std::make_pair(0, 0));
     mutations.emplace_back(mtype(0, 0, 0));
@@ -43,15 +49,19 @@ BOOST_AUTO_TEST_CASE(test_remove_nothing)
     gametes[0].n = 1999;
     gametes.push_back(gcont_t::value_type(1));
     gametes[1].mutations.push_back(1);
-    BOOST_REQUIRE_EQUAL(fwdpp::check_sum(gametes, 2000), true);
-    BOOST_REQUIRE_EQUAL(
-        fwdpp::popdata_sane(diploids, gametes, mutations, mcounts), true);
+    int s = 0;
+    for (auto& g : gametes)
+        {
+            s += g.n;
+        }
+    BOOST_REQUIRE_EQUAL(s, 2000);
     fwdpp::fwdpp_internal::gamete_cleaner(gametes, mutations, mcounts, 2000,
                                           fwdpp::remove_nothing());
     BOOST_REQUIRE_EQUAL(gametes[0].mutations.size(), 1);
 }
 
 BOOST_AUTO_TEST_CASE(test_remove_neutral)
+// TODO: Refactor this test to use a pop type
 {
     diploids.resize(1000, std::make_pair(0, 0));
     mutations.emplace_back(mtype(0, 0, 0));
@@ -64,9 +74,12 @@ BOOST_AUTO_TEST_CASE(test_remove_neutral)
     gametes[0].n = 2000;
     BOOST_REQUIRE_EQUAL(gametes[0].mutations.size(), 1);
     BOOST_REQUIRE_EQUAL(gametes[0].smutations.size(), 1);
-    BOOST_REQUIRE_EQUAL(fwdpp::check_sum(gametes, 2000), true);
-    BOOST_REQUIRE_EQUAL(
-        fwdpp::popdata_sane(diploids, gametes, mutations, mcounts), true);
+    int s = 0;
+    for (auto& g : gametes)
+        {
+            s += g.n;
+        }
+    BOOST_REQUIRE_EQUAL(s, 2000);
     fwdpp::fwdpp_internal::gamete_cleaner(gametes, mutations, mcounts, 2000,
                                           fwdpp::remove_neutral());
     BOOST_REQUIRE_EQUAL(gametes[0].mutations.size(), 0);

--- a/testsuite/unit/sugar_add_mutationTest.cc
+++ b/testsuite/unit/sugar_add_mutationTest.cc
@@ -34,7 +34,8 @@ BOOST_AUTO_TEST_CASE(test_add_mutation)
                         { 0, 1, 0, 2, 2, 0 },
                         // Parameters to pass on to create a new mutation
                         0.1, -0.1, 1, 0);
-    BOOST_REQUIRE_EQUAL(fwdpp::check_sum(pop.gametes, 2000), true);
+    BOOST_REQUIRE_NO_THROW(
+        fwdpp::debug::validate_sum_gamete_counts(pop.gametes, 2000));
     BOOST_REQUIRE_EQUAL(pop.gametes.size(), 2);
     BOOST_REQUIRE_EQUAL(pop.mutations.size(), 1);
     BOOST_REQUIRE_EQUAL(pop.mcounts.size(), 1);
@@ -79,7 +80,8 @@ BOOST_AUTO_TEST_CASE(test_add_mutation_from_object)
                         { 0, 1, 0, 2, 2, 0 },
                         // move it right into place:
                         std::move(m));
-    BOOST_REQUIRE_EQUAL(fwdpp::check_sum(pop.gametes, 2000), true);
+    BOOST_REQUIRE_NO_THROW(
+        fwdpp::debug::validate_sum_gamete_counts(pop.gametes, 2000));
     BOOST_REQUIRE_EQUAL(pop.gametes.size(), 2);
     BOOST_REQUIRE_EQUAL(pop.mutations.size(), 1);
     BOOST_REQUIRE_EQUAL(pop.mcounts.size(), 1);
@@ -208,7 +210,8 @@ BOOST_AUTO_TEST_CASE(test_add_mutation_mlocuspop)
                         { 0, 1, 0, 2, 2, 0 },
                         // params for new mutation
                         0.1, -0.1, 1, 0);
-    BOOST_REQUIRE_EQUAL(fwdpp::check_sum(pop.gametes, 8000), true);
+    BOOST_REQUIRE_NO_THROW(
+        fwdpp::debug::validate_sum_gamete_counts(pop.gametes, 8000));
     BOOST_REQUIRE_EQUAL(pop.gametes.size(), 2);
     BOOST_REQUIRE_EQUAL(pop.mutations.size(), 1);
     BOOST_REQUIRE_EQUAL(pop.mcounts.size(), 1);

--- a/testsuite/unit/sugar_change_neutralTest.cc
+++ b/testsuite/unit/sugar_change_neutralTest.cc
@@ -28,7 +28,8 @@ BOOST_AUTO_TEST_CASE(test_change_neutral_slocuspop)
                         { 0, 1, 0, 2, 2, 0 },
                         // Parameters to pass on to create a new mutation
                         0.1, -0.1, 1, 0);
-    BOOST_REQUIRE_EQUAL(fwdpp::check_sum(pop.gametes, 2000), true);
+    BOOST_REQUIRE_NO_THROW(
+        fwdpp::debug::validate_sum_gamete_counts(pop.gametes, 2000));
     BOOST_REQUIRE_EQUAL(pop.gametes.size(), 2);
     BOOST_REQUIRE_EQUAL(pop.mutations.size(), 1);
     BOOST_REQUIRE_EQUAL(pop.mcounts.size(), 1);

--- a/testsuite/util/quick_evolve_sugar.hpp
+++ b/testsuite/util/quick_evolve_sugar.hpp
@@ -8,6 +8,7 @@
 
 #include <exception>
 #include <cmath>
+#include <fwdpp/debug.hpp>
 #include <fwdpp/poisson_xover.hpp>
 #include <fwdpp/recbinder.hpp>
 #include <fwdpp/fitness_models.hpp>
@@ -81,8 +82,7 @@ simulate_slocuspop(slocuspop_object_t &pop, const rng_type &rng,
         {
             double wbar = fwdpp::sample_diploid(
                 rng.get(), pop.gametes, pop.diploids, pop.mutations,
-                pop.mcounts, 1000, 0.005,
-				mmodel,
+                pop.mcounts, 1000, 0.005, mmodel,
                 fwdpp::recbinder(fwdpp::poisson_xover(0.005, 0., 1.),
                                  rng.get()),
                 fwdpp::multiplicative_diploid(2.), pop.neutral, pop.selected);
@@ -111,15 +111,15 @@ struct multilocus_additive
         using dip_t = mlocuspop_popgenmut_fixture::poptype::dipvector_t::
             value_type::value_type;
         return std::max(
-            0.,
-            1. + std::accumulate(
-                     diploid.begin(), diploid.end(), 0.,
-                     [&gametes, &mutations](const double d, const dip_t &dip) {
-                         return d + fwdpp::additive_diploid()(
-                                        gametes[dip.first],
-                                        gametes[dip.second], mutations)
-                                - 1.;
-                     }));
+            0., 1. + std::accumulate(diploid.begin(), diploid.end(), 0.,
+                                     [&gametes, &mutations](const double d,
+                                                            const dip_t &dip) {
+                                         return d + fwdpp::additive_diploid()(
+                                                        gametes[dip.first],
+                                                        gametes[dip.second],
+                                                        mutations)
+                                                - 1.;
+                                     }));
     }
 };
 
@@ -150,7 +150,7 @@ simulate_mlocuspop(poptype &pop, const rng_type &rng,
                 {
                     throw std::runtime_error("fitness not finite");
                 }
-            assert(check_sum(pop.gametes, 8000));
+            fwdpp::debug::validate_sum_gamete_counts(pop.gametes, 8000);
             fwdpp::update_mutations(pop.mutations, pop.fixations,
                                     pop.fixation_times, pop.mut_lookup,
                                     pop.mcounts, generation, 2000);


### PR DESCRIPTION
This PR:

* Add namespace `fwdpp::debug`, which is based on exceptions rather than `assert`.
* Replaces existing `assert` calls with exception handling wrapped in preprocessor code.

The result will be that `-DNDEBUG` renders functions in `fwdpp::debug` empty and that #146 will be resolved.