### PR TITLE
Improve behavior of fwdpp::ts::generate_data_matrix

### DIFF
--- a/examples/wfts.cc
+++ b/examples/wfts.cc
@@ -534,6 +534,23 @@ main(int argc, char **argv)
                                  "+ preserved nodes...";
                     matrix_runtime_test(tables, sc, pop.mutations, mc);
                     std::cout << "passed.\n";
+                    std::cout << "Matrix test with respect to most recent "
+                                 "ancient sampling time point...";
+                    sc.clear();
+                    std::copy_if(
+                        tables.preserved_nodes.begin(),
+                        tables.preserved_nodes.end(), std::back_inserter(sc),
+                        [&tables](const fwdpp::ts::TS_NODE_INT n) {
+                            return tables.node_table[n].time
+                                   == tables
+                                          .node_table[tables.preserved_nodes
+                                                          .back()]
+                                          .time;
+                        });
+                    mc.clear();
+                    fwdpp::ts::count_mutations(tables, pop.mutations, sc, mc);
+                    matrix_runtime_test(tables, sc, pop.mutations, mc);
+                    std::cout<<"passed\n";
                 }
         }
     if (!filename.empty())

--- a/fwdpp/ts/marginal_tree.hpp
+++ b/fwdpp/ts/marginal_tree.hpp
@@ -22,7 +22,9 @@ namespace fwdpp
         /// \version 0.7.0 Added to fwdpp
         /// \version 0.7.1 Constructors throw exceptions when sample lists contain the
         /// same node ID more than once. Changed from struct to class in order
-        /// to reuse some code in a private function.
+        /// to reuse some code in a private function. Initialization also 
+        /// tracks the total sample size, which is number of nonzero elements
+        /// in sample_index_map.
         {
           private:
             void
@@ -45,6 +47,7 @@ namespace fwdpp
                             }
                         lc[s] = 1;
                         sample_index_map[s] = i;
+                        ++sample_size;
                         left_sample[s] = right_sample[s] = sample_index_map[s];
                         i++;
                     }
@@ -56,6 +59,7 @@ namespace fwdpp
                 right_child, left_sample, right_sample, next_sample,
                 sample_index_map;
             double left, right;
+            TS_NODE_INT sample_size;
             marginal_tree(TS_NODE_INT nnodes,
                           const std::vector<TS_NODE_INT>& samples)
                 : parents(nnodes, TS_NULL_NODE), leaf_counts(nnodes, 0),
@@ -70,12 +74,13 @@ namespace fwdpp
                   sample_index_map(nnodes, TS_NULL_NODE),
                   left{ std::numeric_limits<double>::quiet_NaN() }, right{
                       std::numeric_limits<double>::quiet_NaN()
-                  }
+                  },sample_size(0)
             /// Constructor
             /// \todo Document
             {
                 init_samples(samples, leaf_counts);
             }
+
             marginal_tree(TS_NODE_INT nnodes,
                           const std::vector<TS_NODE_INT>& samples,
                           const std::vector<TS_NODE_INT>& preserved_nodes)
@@ -91,7 +96,7 @@ namespace fwdpp
                   sample_index_map(nnodes, TS_NULL_NODE),
                   left{ std::numeric_limits<double>::quiet_NaN() }, right{
                       std::numeric_limits<double>::quiet_NaN()
-                  }
+                  },sample_size(0)
             /// Constructor
             /// \todo Document
             {
@@ -110,7 +115,7 @@ namespace fwdpp
                   sample_index_map(nnodes, TS_NULL_NODE),
                   left{ std::numeric_limits<double>::quiet_NaN() }, right{
                       std::numeric_limits<double>::quiet_NaN()
-                  }
+                  },sample_size(0)
             /// Constructor
             /// \todo Document
             {


### PR DESCRIPTION
1. marginal_tree now keeps track of total number of samples
2. generate_data_matrix uses that number of samples in a marginal tree to not add fixations to matrices