### PR TITLE
Simplification return value

### DIFF
--- a/doc/md/RELEASE_NOTES.md
+++ b/doc/md/RELEASE_NOTES.md
@@ -3,6 +3,14 @@ For a list of planned features, etc., see the issues list on [GitHub](https://gi
 Issues that are tagged 'performance' or 'enhancement' reflect future plans for the library. I will probably not put
 milestones (target version numbers for these features to go live) because that is not realistic given how I work.
 
+## 0.7.3
+
+* The return value of fwdpp::ts::table_simplifier::simplify has been changed to include a list of indexes to mutations
+  that are preserved by simplification.  This return value may be passed to a new overload of fwdpp::ts::make_mut_queue
+  that avoids tree traversal entirely.  This new overload can result in big speedups for simulations where ancestral
+  samples are being recorded.  However, it only applies for simulations where it is "ok" to keep fixations around.
+  [PR 167](https://github.com/molpopgen/fwdpp/pull/167)
+
 ## 0.7.2
 
 * Resolve a serialization and comparison issue with fwdpp::ts::table_collection [PR 165](https://github.com/molpopgen/fwdpp/pull/165).

--- a/examples/simplify_tables.hpp
+++ b/examples/simplify_tables.hpp
@@ -22,17 +22,17 @@ simplify_tables(poptype &pop, const fwdpp::uint_t generation,
     tables.sort_tables(pop.mutations);
     std::vector<std::int32_t> samples(num_samples);
     std::iota(samples.begin(), samples.end(), first_sample_node);
-    auto idmap_removed_variants
+    auto rv
         = simplifier.simplify(tables, samples, pop.mutations);
     tables.build_indexes();
     for (auto &s : samples)
         {
-            s = idmap_removed_variants.first[s];
+            s = rv.first[s];
         }
 #ifndef NDEBUG
     for (auto &s : tables.preserved_nodes)
         {
-            assert(idmap_removed_variants.first[s] != 1);
+            assert(rv.first[s] != 1);
         }
 #endif
     fwdpp::ts::count_mutations(tables, pop.mutations, samples, pop.mcounts,
@@ -44,10 +44,6 @@ simplify_tables(poptype &pop, const fwdpp::uint_t generation,
             return pop.mcounts[mr.key] == 2 * pop.diploids.size()
                    && mcounts_from_preserved_nodes[mr.key] == 0;
         });
-    for (auto i = itr; i < tables.mutation_table.end(); ++i)
-        {
-            idmap_removed_variants.second.push_back(i->key);
-        }
     tables.mutation_table.erase(itr, tables.mutation_table.end());
     fwdpp::ts::remove_fixations_from_gametes(
         pop.gametes, pop.mutations, pop.mcounts, mcounts_from_preserved_nodes,
@@ -57,6 +53,6 @@ simplify_tables(poptype &pop, const fwdpp::uint_t generation,
         pop, mcounts_from_preserved_nodes, 2 * pop.diploids.size(), generation,
         std::false_type(), std::false_type());
     confirm_mutation_counts(pop, tables);
-    return idmap_removed_variants;
+    return rv;
 }
 #endif

--- a/examples/simplify_tables.hpp
+++ b/examples/simplify_tables.hpp
@@ -17,13 +17,13 @@ simplify_tables(poptype &pop, const fwdpp::uint_t generation,
                 fwdpp::ts::table_collection &tables,
                 fwdpp::ts::table_simplifier &simplifier,
                 const fwdpp::ts::TS_NODE_INT first_sample_node,
-                const std::size_t num_samples)
+                const std::size_t num_samples,
+                const bool preserve_fixations = false)
 {
     tables.sort_tables(pop.mutations);
     std::vector<std::int32_t> samples(num_samples);
     std::iota(samples.begin(), samples.end(), first_sample_node);
-    auto rv
-        = simplifier.simplify(tables, samples, pop.mutations);
+    auto rv = simplifier.simplify(tables, samples, pop.mutations);
     tables.build_indexes();
     for (auto &s : samples)
         {
@@ -35,24 +35,28 @@ simplify_tables(poptype &pop, const fwdpp::uint_t generation,
             assert(rv.first[s] != 1);
         }
 #endif
-    fwdpp::ts::count_mutations(tables, pop.mutations, samples, pop.mcounts,
-                               mcounts_from_preserved_nodes);
-    auto itr = std::remove_if(
-        tables.mutation_table.begin(), tables.mutation_table.end(),
-        [&pop,
-         &mcounts_from_preserved_nodes](const fwdpp::ts::mutation_record &mr) {
-            return pop.mcounts[mr.key] == 2 * pop.diploids.size()
-                   && mcounts_from_preserved_nodes[mr.key] == 0;
-        });
-    tables.mutation_table.erase(itr, tables.mutation_table.end());
-    fwdpp::ts::remove_fixations_from_gametes(
-        pop.gametes, pop.mutations, pop.mcounts, mcounts_from_preserved_nodes,
-        2 * pop.diploids.size(), false);
+    if (!preserve_fixations)
+        {
+            fwdpp::ts::count_mutations(tables, pop.mutations, samples,
+                                       pop.mcounts,
+                                       mcounts_from_preserved_nodes);
+            auto itr = std::remove_if(
+                tables.mutation_table.begin(), tables.mutation_table.end(),
+                [&pop, &mcounts_from_preserved_nodes](
+                    const fwdpp::ts::mutation_record &mr) {
+                    return pop.mcounts[mr.key] == 2 * pop.diploids.size()
+                           && mcounts_from_preserved_nodes[mr.key] == 0;
+                });
+            tables.mutation_table.erase(itr, tables.mutation_table.end());
+            fwdpp::ts::remove_fixations_from_gametes(
+                pop.gametes, pop.mutations, pop.mcounts,
+                mcounts_from_preserved_nodes, 2 * pop.diploids.size(), false);
 
-    fwdpp::ts::flag_mutations_for_recycling(
-        pop, mcounts_from_preserved_nodes, 2 * pop.diploids.size(), generation,
-        std::false_type(), std::false_type());
-    confirm_mutation_counts(pop, tables);
+            fwdpp::ts::flag_mutations_for_recycling(
+                pop, mcounts_from_preserved_nodes, 2 * pop.diploids.size(),
+                generation, std::false_type(), std::false_type());
+            confirm_mutation_counts(pop, tables);
+        }
     return rv;
 }
 #endif

--- a/examples/simplify_tables.hpp
+++ b/examples/simplify_tables.hpp
@@ -11,7 +11,7 @@
 #include "confirm_mutation_counts.hpp"
 
 template <typename poptype>
-std::vector<fwdpp::ts::TS_NODE_INT>
+std::pair<std::vector<fwdpp::ts::TS_NODE_INT>, std::vector<std::size_t>>
 simplify_tables(poptype &pop, const fwdpp::uint_t generation,
                 std::vector<fwdpp::uint_t> &mcounts_from_preserved_nodes,
                 fwdpp::ts::table_collection &tables,
@@ -22,16 +22,17 @@ simplify_tables(poptype &pop, const fwdpp::uint_t generation,
     tables.sort_tables(pop.mutations);
     std::vector<std::int32_t> samples(num_samples);
     std::iota(samples.begin(), samples.end(), first_sample_node);
-    auto idmap = simplifier.simplify(tables, samples, pop.mutations);
+    auto idmap_removed_variants
+        = simplifier.simplify(tables, samples, pop.mutations);
     tables.build_indexes();
     for (auto &s : samples)
         {
-            s = idmap[s];
+            s = idmap_removed_variants.first[s];
         }
 #ifndef NDEBUG
     for (auto &s : tables.preserved_nodes)
         {
-            assert(idmap[s] != 1);
+            assert(idmap_removed_variants.first[s] != 1);
         }
 #endif
     fwdpp::ts::count_mutations(tables, pop.mutations, samples, pop.mcounts,
@@ -53,6 +54,6 @@ simplify_tables(poptype &pop, const fwdpp::uint_t generation,
         pop, mcounts_from_preserved_nodes, 2 * pop.diploids.size(), generation,
         std::false_type(), std::false_type());
     confirm_mutation_counts(pop, tables);
-    return idmap;
+    return idmap_removed_variants;
 }
 #endif

--- a/examples/simplify_tables.hpp
+++ b/examples/simplify_tables.hpp
@@ -37,15 +37,18 @@ simplify_tables(poptype &pop, const fwdpp::uint_t generation,
 #endif
     fwdpp::ts::count_mutations(tables, pop.mutations, samples, pop.mcounts,
                                mcounts_from_preserved_nodes);
-    tables.mutation_table.erase(
-        std::remove_if(
-            tables.mutation_table.begin(), tables.mutation_table.end(),
-            [&pop, &mcounts_from_preserved_nodes](
-                const fwdpp::ts::mutation_record &mr) {
-                return pop.mcounts[mr.key] == 2 * pop.diploids.size()
-                       && mcounts_from_preserved_nodes[mr.key] == 0;
-            }),
-        tables.mutation_table.end());
+    auto itr = std::remove_if(
+        tables.mutation_table.begin(), tables.mutation_table.end(),
+        [&pop,
+         &mcounts_from_preserved_nodes](const fwdpp::ts::mutation_record &mr) {
+            return pop.mcounts[mr.key] == 2 * pop.diploids.size()
+                   && mcounts_from_preserved_nodes[mr.key] == 0;
+        });
+    for (auto i = itr; i < tables.mutation_table.end(); ++i)
+        {
+            idmap_removed_variants.second.push_back(i->key);
+        }
+    tables.mutation_table.erase(itr, tables.mutation_table.end());
     fwdpp::ts::remove_fixations_from_gametes(
         pop.gametes, pop.mutations, pop.mcounts, mcounts_from_preserved_nodes,
         2 * pop.diploids.size(), false);

--- a/examples/spatialts.cc
+++ b/examples/spatialts.cc
@@ -295,7 +295,7 @@ main(int argc, char **argv)
 
             if (generation % gcint == 0.0)
                 {
-                    auto idmap = simplify_tables(
+                    auto rv = simplify_tables(
                         pop, generation, mcounts_from_preserved_nodes, tables,
                         simplifier, tables.num_nodes() - 2 * N, 2 * N);
                     mutation_recycling_bin = fwdpp::ts::make_mut_queue(
@@ -309,8 +309,8 @@ main(int argc, char **argv)
                     // Thus, we need to remap our metadata upon simplification
                     for (auto &md : ancient_sample_metadata)
                         {
-                            md.n1 = idmap[md.n1];
-                            md.n2 = idmap[md.n2];
+                            md.n1 = rv.first[md.n1];
+                            md.n2 = rv.first[md.n2];
                             assert(md.n1 != fwdpp::ts::TS_NULL_NODE);
                             assert(md.n2 != fwdpp::ts::TS_NULL_NODE);
                         }
@@ -372,7 +372,7 @@ main(int argc, char **argv)
         }
     if (!simplified)
         {
-            auto idmap = simplify_tables(pop, generation, mcounts_from_preserved_nodes,
+            auto rv = simplify_tables(pop, generation, mcounts_from_preserved_nodes,
                                          tables, simplifier,
                                          tables.num_nodes() - 2 * N, 2 * N);
             confirm_mutation_counts(pop, tables);
@@ -380,8 +380,8 @@ main(int argc, char **argv)
             // Thus, we need to remap our metadata upon simplification
             for (auto &md : ancient_sample_metadata)
                 {
-                    md.n1 = idmap[md.n1];
-                    md.n2 = idmap[md.n2];
+                    md.n1 = rv.first[md.n1];
+                    md.n2 = rv.first[md.n2];
                     assert(md.n1 != fwdpp::ts::TS_NULL_NODE);
                     assert(md.n2 != fwdpp::ts::TS_NULL_NODE);
                 }

--- a/examples/wfts.cc
+++ b/examples/wfts.cc
@@ -345,17 +345,8 @@ main(int argc, char **argv)
                         }
                     else
                         {
-                            std::sort(rv.second.begin(), rv.second.end());
-                            std::vector<std::size_t> mindexes(
-                                pop.mutations.size());
-                            std::deque<std::size_t> diff;
-                            std::iota(mindexes.begin(), mindexes.end(), 0);
-                            std::set_difference(
-                                mindexes.begin(), mindexes.end(),
-                                rv.second.begin(), rv.second.end(),
-                                std::back_inserter(diff));
-                            std::queue<std::size_t> tqueue(std::move(diff));
-                            mutation_recycling_bin.swap(tqueue);
+                            mutation_recycling_bin = fwdpp::ts::make_mut_queue(
+                                rv.second, pop.mutations.size());
                         }
                     simplified = true;
                     next_index = tables.num_nodes();

--- a/examples/wfts.cc
+++ b/examples/wfts.cc
@@ -332,7 +332,7 @@ main(int argc, char **argv)
             lookup = calculate_fitnesses(pop, fitnesses, ff);
             if (generation % gcint == 0.0)
                 {
-                    auto idmap = simplify_tables(
+                    auto rv = simplify_tables(
                         pop, generation, mcounts_from_preserved_nodes, tables,
                         simplifier, tables.num_nodes() - 2 * N, 2 * N);
                     mutation_recycling_bin = fwdpp::ts::make_mut_queue(
@@ -346,8 +346,8 @@ main(int argc, char **argv)
                     // Thus, we need to remap our metadata upon simplification
                     for (auto &md : ancient_sample_metadata)
                         {
-                            md.n1 = idmap[md.n1];
-                            md.n2 = idmap[md.n2];
+                            md.n1 = rv.first[md.n1];
+                            md.n2 = rv.first[md.n2];
                             assert(md.n1 != fwdpp::ts::TS_NULL_NODE);
                             assert(md.n2 != fwdpp::ts::TS_NULL_NODE);
                         }
@@ -435,7 +435,7 @@ main(int argc, char **argv)
         }
     if (!simplified)
         {
-            auto idmap = simplify_tables(pop, generation, mcounts_from_preserved_nodes,
+            auto rv = simplify_tables(pop, generation, mcounts_from_preserved_nodes,
                                          tables, simplifier,
                                          tables.num_nodes() - 2 * N, 2 * N);
             confirm_mutation_counts(pop, tables);
@@ -443,8 +443,8 @@ main(int argc, char **argv)
             // Thus, we need to remap our metadata upon simplification
             for (auto &md : ancient_sample_metadata)
                 {
-                    md.n1 = idmap[md.n1];
-                    md.n2 = idmap[md.n2];
+                    md.n1 = rv.first[md.n1];
+                    md.n2 = rv.first[md.n2];
                     assert(md.n1 != fwdpp::ts::TS_NULL_NODE);
                     assert(md.n2 != fwdpp::ts::TS_NULL_NODE);
                 }

--- a/fwdpp/ts/table_simplifier.hpp
+++ b/fwdpp/ts/table_simplifier.hpp
@@ -450,15 +450,15 @@ namespace fwdpp
 
                 // Any mutations with null node values do not have
                 // ancestry and may be removed.
-                std::vector<std::size_t> removed_variants;
+                std::vector<std::size_t> preserved_variants;
                 auto itr = std::remove_if(mt.begin(), mt.end(),
                                           [](const mutation_record& mr) {
                                               return mr.node == TS_NULL_NODE;
                                           });
-                removed_variants.reserve(std::distance(itr, mt.end()));
-                for (auto i = itr; i != mt.end(); ++i)
+                preserved_variants.reserve(std::distance(itr, mt.end()));
+                for (auto i = mt.begin(); i != itr; ++i)
                     {
-                        removed_variants.push_back(i->key);
+                        preserved_variants.push_back(i->key);
                     }
 
                 mt.erase(itr, mt.end());
@@ -469,7 +469,7 @@ namespace fwdpp
                                           return mutations[a.key].pos
                                                  < mutations[b.key].pos;
                                       }));
-                return removed_variants;
+                return preserved_variants;
             }
 
             void
@@ -523,7 +523,8 @@ namespace fwdpp
             /// \param mutations A container of mutations
             /// \version 0.7.1 Throw exception if a sample is recorded twice
             /// \version 0.7.3 Return value is now a pair containing the
-            /// node ID map and a vector of keys to mutations "simplified out"
+            /// node ID map and a vector of keys to mutations preserved in
+            /// mutation tables
             {
                 Ancestry.resize(tables.node_table.size());
 
@@ -586,12 +587,12 @@ namespace fwdpp
                 // TODO: allow for exception instead of assert
                 assert(tables.edges_are_sorted());
                 tables.update_offset();
-                auto removed_variants
+                auto preserved_variants
                     = simplify_mutations(mutations, tables.mutation_table);
 
                 cleanup();
                 std::pair<std::vector<TS_NODE_INT>, std::vector<std::size_t>>
-                    rv(std::move(idmap), std::move(removed_variants));
+                    rv(std::move(idmap), std::move(preserved_variants));
                 return rv;
             }
         };

--- a/fwdpp/ts/table_simplifier.hpp
+++ b/fwdpp/ts/table_simplifier.hpp
@@ -391,7 +391,7 @@ namespace fwdpp
             }
 
             template <typename mcont_t>
-            void
+            std::vector<std::size_t>
             simplify_mutations(const mcont_t& mutations,
                                mutation_key_vector& mt) const
             // Remove all mutations that do not map to nodes
@@ -450,11 +450,18 @@ namespace fwdpp
 
                 // Any mutations with null node values do not have
                 // ancestry and may be removed.
-                mt.erase(std::remove_if(mt.begin(), mt.end(),
-                                        [](const mutation_record& mr) {
-                                            return mr.node == TS_NULL_NODE;
-                                        }),
-                         mt.end());
+                std::vector<std::size_t> removed_variants;
+                auto itr = std::remove_if(mt.begin(), mt.end(),
+                                          [](const mutation_record& mr) {
+                                              return mr.node == TS_NULL_NODE;
+                                          });
+                removed_variants.reserve(std::distance(itr, mt.end()));
+                for (auto i = itr; i != mt.end(); ++i)
+                    {
+                        removed_variants.push_back(i->key);
+                    }
+
+                mt.erase(itr, mt.end());
                 //TODO: replace assert with exception
                 assert(std::is_sorted(mt.begin(), mt.end(),
                                       [&mutations](const mutation_record& a,
@@ -462,6 +469,7 @@ namespace fwdpp
                                           return mutations[a.key].pos
                                                  < mutations[b.key].pos;
                                       }));
+                return removed_variants;
             }
 
             void
@@ -474,10 +482,11 @@ namespace fwdpp
                     {
                         // See GitHub issue 158
                         // for background
-                        if(idmap[s] != TS_NULL_NODE)
-                        {
-                            throw std::invalid_argument("invalid sample list");
-                        }
+                        if (idmap[s] != TS_NULL_NODE)
+                            {
+                                throw std::invalid_argument(
+                                    "invalid sample list");
+                            }
                         new_node_table.emplace_back(
                             node{ tables.node_table[s].population,
                                   tables.node_table[s].time });
@@ -502,7 +511,7 @@ namespace fwdpp
             }
 
             template <typename mutation_container>
-            std::vector<TS_NODE_INT>
+            std::pair<std::vector<TS_NODE_INT>, std::vector<std::size_t>>
             simplify(table_collection& tables,
                      const std::vector<TS_NODE_INT>& samples,
                      const mutation_container& mutations)
@@ -513,6 +522,8 @@ namespace fwdpp
             /// \param samples A list of sample (node) ids.
             /// \param mutations A container of mutations
             /// \version 0.7.1 Throw exception if a sample is recorded twice
+            /// \version 0.7.3 Return value is now a pair containing the
+            /// node ID map and a vector of keys to mutations "simplified out"
             {
                 Ancestry.resize(tables.node_table.size());
 
@@ -575,10 +586,13 @@ namespace fwdpp
                 // TODO: allow for exception instead of assert
                 assert(tables.edges_are_sorted());
                 tables.update_offset();
-                simplify_mutations(mutations, tables.mutation_table);
+                auto removed_variants
+                    = simplify_mutations(mutations, tables.mutation_table);
 
                 cleanup();
-                return idmap;
+                std::pair<std::vector<TS_NODE_INT>, std::vector<std::size_t>>
+                    rv(std::move(idmap), std::move(removed_variants));
+                return rv;
             }
         };
     } // namespace ts


### PR DESCRIPTION
This PR is a WIP to see if the ideas in #163 are helpful.

There is a logic error in the issue as described.  The number of indexes of mutations that are "simplified out" is not the same as the length of a recycling queue.  The correct procedure is something like:

1. generate a list of mutation indexes that *are* preserved after simplification
2. generate a list of all possible mutation indexes
3. The recycling queue is the set difference of these two lists.