### PR TITLE
Fitness policy strong types

### DIFF
--- a/examples/K_linked_regions_extensions.cc
+++ b/examples/K_linked_regions_extensions.cc
@@ -66,8 +66,8 @@ struct additive_over_loci
                         return mutations[i].pos < val;
                     });
 
-                rv += fwdpp::multiplicative_diploid(2.0)(start1, stop1, start2,
-                                                         stop2, mutations)
+                rv += fwdpp::multiplicative_diploid(fwdpp::fitness(2.0))(
+                          start1, stop1, start2, stop2, mutations)
                       - 1.0;
             }
         return std::max(1.0 + rv, 0.0);

--- a/examples/K_linked_regions_generalized_rec.cc
+++ b/examples/K_linked_regions_generalized_rec.cc
@@ -93,14 +93,15 @@ main(int argc, char **argv)
     for (generation = 0; generation < ngens; ++generation)
         {
             // Iterate the population through 1 generation
-            fwdpp::sample_diploid(r.get(), pop.gametes, pop.diploids,
-                                  pop.mutations, pop.mcounts, N, mu, mmodel,
-                                  recmap, fwdpp::multiplicative_diploid(),
-                                  pop.neutral, pop.selected);
+            fwdpp::sample_diploid(
+                r.get(), pop.gametes, pop.diploids, pop.mutations, pop.mcounts,
+                N, mu, mmodel, recmap,
+                fwdpp::multiplicative_diploid(fwdpp::fitness(2.)), pop.neutral,
+                pop.selected);
             fwdpp::update_mutations(pop.mutations, pop.fixations,
                                     pop.fixation_times, pop.mut_lookup,
                                     pop.mcounts, generation, 2 * N);
-            fwdpp::debug::validate_sum_gamete_counts(pop.gametes,2*N);
+            fwdpp::debug::validate_sum_gamete_counts(pop.gametes, 2 * N);
             fwdpp::debug::validate_pop_data(pop);
         }
 #ifdef HAVE_LIBSEQUENCE

--- a/examples/diploid_fixed_sh_ind.cc
+++ b/examples/diploid_fixed_sh_ind.cc
@@ -85,8 +85,8 @@ main(int argc, char **argv)
                         r.get(), pop.gametes, pop.diploids, pop.mutations,
                         pop.mcounts, N, mu_neutral + mu_del, mmodel,
                         // The function to generation recombination positions:
-                        rec, fwdpp::multiplicative_diploid(1.), pop.neutral,
-                        pop.selected);
+                        rec, fwdpp::multiplicative_diploid(fwdpp::fitness(1.)),
+                        pop.neutral, pop.selected);
                     fwdpp::update_mutations(pop.mutations, pop.fixations,
                                             pop.fixation_times, pop.mut_lookup,
                                             pop.mcounts, generation, 2 * N);
@@ -97,14 +97,14 @@ main(int argc, char **argv)
                     fwdpp::debug::validate_sum_gamete_counts(pop.gametes,
                                                              2 * N);
                 }
-            for(std::size_t i=0;i<pop.mcounts.size();++i)
-            {
-                if(pop.mcounts[i])
+            for (std::size_t i = 0; i < pop.mcounts.size(); ++i)
                 {
-                    std::cout<<pop.mutations[i].s<<' ' << pop.mcounts[i]<<'\n';
-
+                    if (pop.mcounts[i])
+                        {
+                            std::cout << pop.mutations[i].s << ' '
+                                      << pop.mcounts[i] << '\n';
+                        }
                 }
-            }
             // Take a sample of size samplesize1.  Two data blocks are
             // returned, one for neutral mutations, and one for selected
             std::vector<std::size_t> random_dips;

--- a/examples/diploid_ind.cc
+++ b/examples/diploid_ind.cc
@@ -131,7 +131,7 @@ main(int argc, char **argv)
                           multiplicative
                           models are very common in population genetics
                         */
-                        fwdpp::multiplicative_diploid(), pop.neutral,
+                        fwdpp::multiplicative_diploid(fwdpp::fitness(2.)), pop.neutral,
                         pop.selected);
                     fwdpp::update_mutations(pop.mutations, pop.fixations,
                                             pop.fixation_times, pop.mut_lookup,

--- a/examples/juvenile_migration.cc
+++ b/examples/juvenile_migration.cc
@@ -311,14 +311,15 @@ main(int argc, char **argv)
 
     const double pselected = mu_del / (mu_del + mu_neutral);
 
-    auto wfxn = fwdpp::multiplicative_diploid(1.);
+    auto wfxn = fwdpp::multiplicative_diploid(fwdpp::fitness(1.));
     singlepop_t pop(N);
     pop.mutations.reserve(
         size_t(std::ceil(std::log(2 * N) * (theta_neutral + theta_del)
                          + 0.667 * (theta_neutral + theta_del))));
     unsigned generation = 0;
-    const auto mmodel = [&pop, &r, &generation, s, h, pselected](
-        std::queue<std::size_t> &recbin, singlepop_t::mcont_t &mutations) {
+    const auto mmodel = [&pop, &r, &generation, s, h,
+                         pselected](std::queue<std::size_t> &recbin,
+                                    singlepop_t::mcont_t &mutations) {
         return fwdpp::infsites_popgenmut(
             recbin, mutations, r.get(), pop.mut_lookup, generation, pselected,
             [&r]() { return gsl_rng_uniform(r.get()); }, [s]() { return s; },

--- a/examples/spatialts.cc
+++ b/examples/spatialts.cc
@@ -232,7 +232,7 @@ main(int argc, char **argv)
     std::vector<std::size_t> possible_mates;
     std::vector<double> possible_mate_fitness;
     std::vector<double> cumw;
-    auto ff = fwdpp::multiplicative_diploid(2.0);
+    auto ff = fwdpp::multiplicative_diploid(fwdpp::fitness(2.0));
     for (; generation <= 10 * N; ++generation)
         {
             //Clear out offspring coordinates
@@ -295,8 +295,8 @@ main(int argc, char **argv)
             if (generation % gcint == 0.0)
                 {
                     auto rv = simplify_tables(
-                        pop, generation, pop.mcounts_from_preserved_nodes, tables,
-                        simplifier, tables.num_nodes() - 2 * N, 2 * N);
+                        pop, generation, pop.mcounts_from_preserved_nodes,
+                        tables, simplifier, tables.num_nodes() - 2 * N, 2 * N);
                     mutation_recycling_bin = fwdpp::ts::make_mut_queue(
                         pop.mcounts, pop.mcounts_from_preserved_nodes);
                     simplified = true;
@@ -371,9 +371,9 @@ main(int argc, char **argv)
         }
     if (!simplified)
         {
-            auto rv = simplify_tables(pop, generation, pop.mcounts_from_preserved_nodes,
-                                         tables, simplifier,
-                                         tables.num_nodes() - 2 * N, 2 * N);
+            auto rv = simplify_tables(
+                pop, generation, pop.mcounts_from_preserved_nodes, tables,
+                simplifier, tables.num_nodes() - 2 * N, 2 * N);
             confirm_mutation_counts(pop, tables);
             // When tracking ancient samples, the node ids of those samples change.
             // Thus, we need to remap our metadata upon simplification
@@ -427,7 +427,8 @@ main(int argc, char **argv)
         {
             if (pop.mutations[i].neutral)
                 {
-                    if (!pop.mcounts[i] && !pop.mcounts_from_preserved_nodes[i])
+                    if (!pop.mcounts[i]
+                        && !pop.mcounts_from_preserved_nodes[i])
                         {
                             throw std::runtime_error(
                                 "invalid final mutation count");

--- a/examples/wfts.cc
+++ b/examples/wfts.cc
@@ -315,7 +315,7 @@ main(int argc, char **argv)
     // meaning that we can record a correct fitness
     // value as ancient sample metadata.  This is a logic
     // issue that is easy to goof.
-    auto ff = fwdpp::multiplicative_diploid(scaling);
+    auto ff = fwdpp::multiplicative_diploid(fwdpp::fitness(scaling));
     auto lookup = calculate_fitnesses(pop, fitnesses, ff);
     for (; generation <= 10 * N; ++generation)
         {
@@ -334,8 +334,8 @@ main(int argc, char **argv)
             if (generation % gcint == 0.0)
                 {
                     auto rv = simplify_tables(
-                        pop, generation, pop.mcounts_from_preserved_nodes, tables,
-                        simplifier, tables.num_nodes() - 2 * N, 2 * N,
+                        pop, generation, pop.mcounts_from_preserved_nodes,
+                        tables, simplifier, tables.num_nodes() - 2 * N, 2 * N,
                         preserve_fixations);
                     if (!preserve_fixations)
                         {
@@ -452,9 +452,9 @@ main(int argc, char **argv)
                 {
                     std::vector<std::int32_t> samples(2 * N);
                     std::iota(samples.begin(), samples.end(), 0);
-                    fwdpp::ts::count_mutations(tables, pop.mutations, samples,
-                                               pop.mcounts,
-                                               pop.mcounts_from_preserved_nodes);
+                    fwdpp::ts::count_mutations(
+                        tables, pop.mutations, samples, pop.mcounts,
+                        pop.mcounts_from_preserved_nodes);
                 }
             confirm_mutation_counts(pop, tables);
             // When tracking ancient samples, the node ids of those samples change.
@@ -509,7 +509,8 @@ main(int argc, char **argv)
         {
             if (pop.mutations[i].neutral)
                 {
-                    if (!pop.mcounts[i] && !pop.mcounts_from_preserved_nodes[i])
+                    if (!pop.mcounts[i]
+                        && !pop.mcounts_from_preserved_nodes[i])
                         {
                             throw std::runtime_error(
                                 "invalid final mutation count");

--- a/fwdpp/Makefile.am
+++ b/fwdpp/Makefile.am
@@ -19,7 +19,8 @@ pkginclude_HEADERS=debug.hpp \
 	version.hpp \
 	mutate_recombine.hpp \
 	data_matrix.hpp \
-	recbinder.hpp
+	recbinder.hpp \
+	named_type.hpp
 
 
 

--- a/fwdpp/Makefile.in
+++ b/fwdpp/Makefile.in
@@ -326,7 +326,8 @@ pkginclude_HEADERS = debug.hpp \
 	version.hpp \
 	mutate_recombine.hpp \
 	data_matrix.hpp \
-	recbinder.hpp
+	recbinder.hpp \
+	named_type.hpp
 
 all: all-recursive
 

--- a/fwdpp/named_type.hpp
+++ b/fwdpp/named_type.hpp
@@ -1,0 +1,41 @@
+#ifndef FWDPP_NAMED_TYPE_HPP_
+#define FWDPP_NAMED_TYPE_HPP_
+
+#include <type_traits>
+#include <utility>
+
+namespace fwdpp
+{
+    namespace strong_types
+    {
+        template <typename T, typename parameter_name> struct named_type
+        {
+          private:
+            T value_;
+
+          public:
+            explicit named_type(const T& value) : value_(value) {}
+            template <typename T_>
+            explicit named_type(
+                T_&& value,
+                typename std::enable_if<!std::is_reference<T_>::value>::value)
+                : value_(std::move(value))
+            {
+            }
+
+            T&
+            get()
+            {
+                return value_;
+            }
+
+            const T&
+            get() const
+            {
+                return value_;
+            }
+        };
+    } // namespace strong_types
+} // namespace fwdpp
+
+#endif

--- a/testsuite/fixtures/sugar_fixtures.hpp
+++ b/testsuite/fixtures/sugar_fixtures.hpp
@@ -88,8 +88,8 @@ class mlocuspop_popgenmut_fixture
         std::vector<fwdpp::extensions::discrete_rec_model> vdrm_;
         for (unsigned i = 0; i < 4; ++i)
             {
-                std::vector<fwdpp::extensions::discrete_rec_model::
-                                function_type>
+                std::vector<
+                    fwdpp::extensions::discrete_rec_model::function_type>
                     f;
                 std::vector<double> w{ 1., 10., 1. };
                 f.push_back([&r, i](std::vector<double> &b) {
@@ -128,16 +128,18 @@ class mlocuspop_popgenmut_fixture
         {
             using dip_t = poptype::dipvector_t::value_type::value_type;
             return std::max(
-                0.,
-                1. + std::accumulate(diploid.begin(), diploid.end(), 0.,
-                                     [&gametes, &mutations](const double d,
-                                                            const dip_t &dip) {
-                                         return d + fwdpp::additive_diploid()(
-                                                        gametes[dip.first],
-                                                        gametes[dip.second],
-                                                        mutations)
-                                                - 1.;
-                                     }));
+                0., 1.
+                        + std::accumulate(
+                              diploid.begin(), diploid.end(), 0.,
+                              [&gametes, &mutations](const double d,
+                                                     const dip_t &dip) {
+                                  return d
+                                         + fwdpp::additive_diploid(
+                                               fwdpp::fitness(1.))(
+                                               gametes[dip.first],
+                                               gametes[dip.second], mutations)
+                                         - 1.;
+                              }));
         }
     };
     poptype pop;

--- a/testsuite/unit/siteDepFitnessTest.cc
+++ b/testsuite/unit/siteDepFitnessTest.cc
@@ -157,7 +157,10 @@ BOOST_AUTO_TEST_CASE(simple_additive_1)
 
     gcont_t g{ g1, g2 };
 
-    double w = fwdpp::additive_diploid(fwdpp::fitness(1.))(g[0], g[1], mutations);
+    auto wfxn = fwdpp::additive_diploid(fwdpp::fitness(1.));
+    BOOST_REQUIRE_EQUAL(wfxn.gvalue_is_trait.get(), false);
+    BOOST_REQUIRE_EQUAL(wfxn.gvalue_is_fitness.get(), true);
+    double w = wfxn(g[0], g[1], mutations);
     BOOST_CHECK_EQUAL(w, 1.2);
 }
 
@@ -175,7 +178,10 @@ BOOST_AUTO_TEST_CASE(simple_additive_trait)
 
     gcont_t g{ g1, g2 };
 
-    double w = fwdpp::additive_diploid(fwdpp::trait(1.))(g[0], g[1], mutations);
+    auto wfxn = fwdpp::additive_diploid(fwdpp::trait(1.));
+    BOOST_REQUIRE_EQUAL(wfxn.gvalue_is_trait.get(), true);
+    BOOST_REQUIRE_EQUAL(wfxn.gvalue_is_fitness.get(), false);
+    auto w = wfxn(g[0], g[1], mutations);
     BOOST_CHECK_EQUAL(w, -0.1);
 }
 

--- a/testsuite/unit/siteDepFitnessTest.cc
+++ b/testsuite/unit/siteDepFitnessTest.cc
@@ -57,9 +57,8 @@ BOOST_AUTO_TEST_CASE(simple_multiplicative_trait)
     BOOST_CHECK_EQUAL(g1.smutations.size(), 1);
 
     gcont_t g{ g1, g2 };
-    double w = fwdpp::multiplicative_diploid(
-        1., fwdpp::multiplicative_diploid::policy::mtrait)(g[0], g[1],
-                                                           mutations);
+    double w = fwdpp::multiplicative_diploid(fwdpp::trait(1.))(g[0], g[1],
+                                                               mutations);
 
     BOOST_CHECK_CLOSE(w, -0.05, 1e-8);
 }
@@ -158,7 +157,7 @@ BOOST_AUTO_TEST_CASE(simple_additive_1)
 
     gcont_t g{ g1, g2 };
 
-    double w = fwdpp::additive_diploid()(g[0], g[1], mutations);
+    double w = fwdpp::additive_diploid(fwdpp::fitness(1.))(g[0], g[1], mutations);
     BOOST_CHECK_EQUAL(w, 1.2);
 }
 
@@ -176,8 +175,7 @@ BOOST_AUTO_TEST_CASE(simple_additive_trait)
 
     gcont_t g{ g1, g2 };
 
-    double w = fwdpp::additive_diploid(
-        1., fwdpp::additive_diploid::policy::atrait)(g[0], g[1], mutations);
+    double w = fwdpp::additive_diploid(fwdpp::trait(1.))(g[0], g[1], mutations);
     BOOST_CHECK_EQUAL(w, -0.1);
 }
 
@@ -211,12 +209,13 @@ BOOST_AUTO_TEST_CASE(reassign_test_1)
 
         // assign a fitness model with default scaling = 1.
         fitness_model_t dipfit
-            = std::bind(fwdpp::multiplicative_diploid(), std::placeholders::_1,
-                        std::placeholders::_2, std::placeholders::_3);
+            = std::bind(fwdpp::multiplicative_diploid(fwdpp::fitness(1.)),
+                        std::placeholders::_1, std::placeholders::_2,
+                        std::placeholders::_3);
 
         auto a = dipfit(dipvector_t::value_type{ 0, 0 }, gametes, mutations);
         // Now, reassign it with scaling = 2.
-        dipfit = fwdpp::multiplicative_diploid(2.);
+        dipfit = fwdpp::multiplicative_diploid(fwdpp::fitness(2.));
         auto b = dipfit(dipvector_t::value_type{ 0, 0 }, gametes, mutations);
 
         BOOST_CHECK_CLOSE(a - 1.0, 0.5 * (b - 1.0), 1e-6);
@@ -227,10 +226,10 @@ BOOST_AUTO_TEST_CASE(reassign_test_1)
         // Now the additive model
 
         // assign a fitness model with default scaling = 1.
-        fitness_model_t dipfit = fwdpp::additive_diploid();
+        fitness_model_t dipfit = fwdpp::additive_diploid(fwdpp::fitness(1.));
         auto a = dipfit(dipvector_t::value_type{ 0, 0 }, gametes, mutations);
         // Now, reassign it with scaling = 2.
-        dipfit = fwdpp::additive_diploid(2.);
+        dipfit = fwdpp::additive_diploid(fwdpp::fitness(2.));
         auto b = dipfit(dipvector_t::value_type{ 0, 0 }, gametes, mutations);
         BOOST_CHECK_CLOSE(a - 1.0, 0.5 * (b - 1.0), 1e-6);
     }
@@ -241,10 +240,11 @@ BOOST_AUTO_TEST_CASE(reassign_test_1)
         // that wants to decide which model to use based on parameters
         // passed in by a user.
 
-        fitness_model_t dipfit = fwdpp::multiplicative_diploid();
+        fitness_model_t dipfit
+            = fwdpp::multiplicative_diploid(fwdpp::fitness(1.));
         auto a = dipfit(dipvector_t::value_type{ 0, 0 }, gametes, mutations);
         // Now, reassign it to addtive model with scaling = 2.
-        dipfit = fwdpp::additive_diploid(2.0);
+        dipfit = fwdpp::additive_diploid(fwdpp::fitness(2.0));
         auto b = dipfit(dipvector_t::value_type{ 0, 0 }, gametes, mutations);
         // With only 1 mutation in play, additive & multiplicative will give
         // same result:
@@ -275,11 +275,12 @@ BOOST_AUTO_TEST_CASE(reassign_test_2)
         // Multiplicative model first
 
         // assign a fitness model with default scaling = 1.
-        fitness_model_t dipfit = fwdpp::multiplicative_diploid();
+        fitness_model_t dipfit
+            = fwdpp::multiplicative_diploid(fwdpp::fitness(1.));
         auto a = dipfit(cdiploids[0], gametes, mutations);
 
         // Now, reassign it with scaling = 2.
-        dipfit = fwdpp::multiplicative_diploid(2.);
+        dipfit = fwdpp::multiplicative_diploid(fwdpp::fitness(2.));
         auto b = dipfit(cdiploids[0], gametes, mutations);
         BOOST_CHECK_CLOSE(a - 1.0, 0.5 * (b - 1.0), 1e-6);
     }
@@ -289,10 +290,10 @@ BOOST_AUTO_TEST_CASE(reassign_test_2)
         // Now the additive model
 
         // assign a fitness model with default scaling = 1.
-        fitness_model_t dipfit = fwdpp::additive_diploid();
+        fitness_model_t dipfit = fwdpp::additive_diploid(fwdpp::fitness(1.));
         auto a = dipfit(cdiploids[0], gametes, mutations);
         // Now, reassign it with scaling = 2.
-        dipfit = fwdpp::additive_diploid(2.);
+        dipfit = fwdpp::additive_diploid(fwdpp::fitness(2.));
         auto b = dipfit(cdiploids[0], gametes, mutations);
         BOOST_CHECK_CLOSE(a - 1.0, 0.5 * (b - 1.0), 1e-6);
     }
@@ -303,10 +304,11 @@ BOOST_AUTO_TEST_CASE(reassign_test_2)
         // that wants to decide which model to use based on parameters
         // passed in by a user.
 
-        fitness_model_t dipfit = fwdpp::multiplicative_diploid();
+        fitness_model_t dipfit
+            = fwdpp::multiplicative_diploid(fwdpp::fitness(1.));
         auto a = dipfit(cdiploids[0], gametes, mutations);
         // Now, reassign it to addtive model with scaling = 2.
-        dipfit = fwdpp::additive_diploid(2.);
+        dipfit = fwdpp::additive_diploid(fwdpp::fitness(2.));
         auto b = dipfit(cdiploids[0], gametes, mutations);
         BOOST_CHECK_CLOSE(a - 1.0, 0.5 * (b - 1.0), 1e-6);
     }

--- a/testsuite/unit/type_traitsTest.cc
+++ b/testsuite/unit/type_traitsTest.cc
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(is_mmodel_diploid_test)
 
 BOOST_AUTO_TEST_CASE(is_standard_fitness_model_test)
 {
-    auto fp = fwdpp::multiplicative_diploid(2.);
+    auto fp = fwdpp::multiplicative_diploid(fwdpp::fitness(2.));
     auto v = std::is_convertible<
         decltype(fp),
         fwdpp::traits::fitness_fxn_t<dipvector_t, gcont_t, mcont_t>>::value;

--- a/testsuite/util/quick_evolve_sugar.hpp
+++ b/testsuite/util/quick_evolve_sugar.hpp
@@ -32,8 +32,8 @@ simulate_slocuspop(slocuspop_object_t &pop, const unsigned simlen = 10,
     fwdpp::GSLrng_t<fwdpp::GSL_RNG_TAUS2> rng(0u);
     unsigned generation = 0;
     const auto mmodel = [&pop, &rng, &generation](
-        std::queue<std::size_t> &recbin,
-        typename slocuspop_object_t::mcont_t &mutations) {
+                            std::queue<std::size_t> &recbin,
+                            typename slocuspop_object_t::mcont_t &mutations) {
         return fwdpp::infsites_popgenmut(
             recbin, mutations, rng.get(), pop.mut_lookup, generation, 0.5,
             [&rng]() { return gsl_rng_uniform(rng.get()); },
@@ -46,7 +46,8 @@ simulate_slocuspop(slocuspop_object_t &pop, const unsigned simlen = 10,
                 pop.mcounts, pop.N, popsize, 0.005, mmodel,
                 fwdpp::recbinder(fwdpp::poisson_xover(0.005, 0., 1.),
                                  rng.get()),
-                fwdpp::multiplicative_diploid(2.), pop.neutral, pop.selected);
+                fwdpp::multiplicative_diploid(fwdpp::fitness(2.)), pop.neutral,
+                pop.selected);
             if (!std::isfinite(wbar))
                 {
                     throw std::runtime_error("fitness not finite");
@@ -71,8 +72,8 @@ simulate_slocuspop(slocuspop_object_t &pop, const rng_type &rng,
     unsigned g = generation;
 
     const auto mmodel = [&pop, &rng, &generation](
-        std::queue<std::size_t> &recbin,
-        typename slocuspop_object_t::mcont_t &mutations) {
+                            std::queue<std::size_t> &recbin,
+                            typename slocuspop_object_t::mcont_t &mutations) {
         return fwdpp::infsites_popgenmut(
             recbin, mutations, rng.get(), pop.mut_lookup, generation, 0.5,
             [&rng]() { return gsl_rng_uniform(rng.get()); },
@@ -111,15 +112,17 @@ struct multilocus_additive
         using dip_t = mlocuspop_popgenmut_fixture::poptype::dipvector_t::
             value_type::value_type;
         return std::max(
-            0., 1. + std::accumulate(diploid.begin(), diploid.end(), 0.,
-                                     [&gametes, &mutations](const double d,
-                                                            const dip_t &dip) {
-                                         return d + fwdpp::additive_diploid()(
-                                                        gametes[dip.first],
-                                                        gametes[dip.second],
-                                                        mutations)
-                                                - 1.;
-                                     }));
+            0., 1.
+                    + std::accumulate(
+                          diploid.begin(), diploid.end(), 0.,
+                          [&gametes, &mutations](const double d,
+                                                 const dip_t &dip) {
+                              return d
+                                     + fwdpp::additive_diploid(fwdpp::fitness(
+                                           1.))(gametes[dip.first],
+                                                gametes[dip.second], mutations)
+                                     - 1.;
+                          }));
     }
 };
 


### PR DESCRIPTION
Adds `fwdpp::strong_types::named_type` and uses that type to refactor how `multiplicative_diploid` and `additive_diploid` are constructed. See #144 for background.

Breaks existing API.