### PR TITLE
Refactor table_collection serialization

### DIFF
--- a/fwdpp/ts/serialization.hpp
+++ b/fwdpp/ts/serialization.hpp
@@ -224,22 +224,6 @@ namespace fwdpp
                                 tables.mutation_table.size()
                                     * sizeof(mutation_record));
                     }
-                //serialize_edge<TS_TABLES_VERSION> edge_writer;
-                //serialize_node<TS_TABLES_VERSION> node_writer;
-                //serialize_mutation_record<TS_TABLES_VERSION>
-                //    mutation_record_writer;
-                //for (auto& e : tables.edge_table)
-                //    {
-                //        edge_writer(o, e);
-                //    }
-                //for (auto& n : tables.node_table)
-                //    {
-                //        node_writer(o, n);
-                //    }
-                //for (auto& m : tables.mutation_table)
-                //    {
-                //        mutation_record_writer(o, m);
-                //    }
                 std::size_t num_preserved_samples
                     = tables.preserved_nodes.size();
                 sw(o, &num_preserved_samples);

--- a/fwdpp/ts/serialization.hpp
+++ b/fwdpp/ts/serialization.hpp
@@ -191,6 +191,8 @@ namespace fwdpp
 			 *
 			 *  This function always outputs to the format version
 			 *  specified by fwdpp::ts::io::TS_TABLES_VERSION.
+             *
+             *  \version 0.7.4 Tables are written in a single call
 			 */
             {
                 o << "fwdppts";
@@ -245,6 +247,8 @@ namespace fwdpp
 			 *
 			 *  \note The return value has its index vectors populated.
 			 *  See fwdpp::ts::table_collection::build_indexes
+             *
+             *  \version 0.7.4 Tables are read in a single call
 			 */
             {
                 //Reading data back in has to manage versions

--- a/fwdpp/ts/serialization.hpp
+++ b/fwdpp/ts/serialization.hpp
@@ -290,7 +290,6 @@ namespace fwdpp
                 sr(i, &num_mutations);
                 if (format == TS_TABLES_VERSION)
                     {
-                        std::cout << "V2\n";
                         tables.edge_table.resize(num_edges);
                         i.read(
                             reinterpret_cast<char*>(tables.edge_table.data()),
@@ -306,7 +305,6 @@ namespace fwdpp
                     }
                 else if (format == 1)
                     {
-                        std::cout << "V1\n";
                         deserialize_edge<TS_TABLES_VERSION> edge_reader;
                         deserialize_node<TS_TABLES_VERSION> node_reader;
                         deserialize_mutation_record<TS_TABLES_VERSION>

--- a/fwdpp/ts/serialization_version.hpp
+++ b/fwdpp/ts/serialization_version.hpp
@@ -11,7 +11,7 @@ namespace fwdpp
 			/*! \brief Current version number of binary formats
 			 *  \version 0.7.0 Added to library
 			 */
-            constexpr const std::uint32_t TS_TABLES_VERSION = 1;
+            constexpr const std::uint32_t TS_TABLES_VERSION = 2;
         }
     } // namespace ts
 } // namespace fwdpp

--- a/fwdpp/ts/serialization_version.hpp
+++ b/fwdpp/ts/serialization_version.hpp
@@ -10,6 +10,7 @@ namespace fwdpp
         {
 			/*! \brief Current version number of binary formats
 			 *  \version 0.7.0 Added to library
+             *  \version 0.7.4 Updated value to 2
 			 */
             constexpr const std::uint32_t TS_TABLES_VERSION = 2;
         }


### PR DESCRIPTION
The tables now get read/written via a single function call.  Output file sizes are slightly larger, but IO is faster.