### PR TITLE
Add fwdpp::ts::samples_iterator.

### DIFF
--- a/examples/tree_sequence_examples_common.cc
+++ b/examples/tree_sequence_examples_common.cc
@@ -59,8 +59,8 @@ options::options()
     : N{}, gcint(100), theta(), rho(), mean(0.), shape(1.), mu(),
       scoeff(std::numeric_limits<double>::max()), dominance(1.), scaling(2.),
       seed(42), ancient_sampling_interval(-1), ancient_sample_size(-1),
-      nsam(0), leaf_test(false), matrix_test(false),
-      preserve_fixations(false), filename(), sfsfilename()
+      nsam(0), leaf_test(false), matrix_test(false), preserve_fixations(false),
+      filename(), sfsfilename()
 {
 }
 
@@ -193,8 +193,9 @@ void
 expensive_leaf_test(const fwdpp::ts::table_collection &tables,
                     const std::vector<fwdpp::ts::TS_NODE_INT> &sample_list)
 {
-    fwdpp::ts::tree_visitor mti(tables, sample_list);
-    while (mti(std::true_type(), std::true_type()))
+    fwdpp::ts::tree_visitor mti(tables, sample_list,
+                                fwdpp::ts::update_samples_list(true));
+    while (mti())
         {
             auto &tree = mti.tree();
             for (auto i : sample_list)
@@ -349,7 +350,6 @@ execute_matrix_test(const options &o, const single_locus_poptype &pop,
     execute_matrix_test_detail(o, pop, tables, samples);
 }
 
-
 void
 execute_serialization_test(const options &o,
                            const fwdpp::ts::table_collection &tables)
@@ -380,8 +380,8 @@ write_sfs(const options &o, const fwdpp::GSLrng_mt &rng,
             gsl_ran_choose(rng.get(), small_sample.data(), small_sample.size(),
                            s.data(), s.size(), sizeof(fwdpp::ts::TS_NODE_INT));
             std::iota(small_sample.begin(), small_sample.end(), 0);
-            auto dm = fwdpp::ts::generate_data_matrix(tables, small_sample,
-                                                      mutations, true, false, true);
+            auto dm = fwdpp::ts::generate_data_matrix(
+                tables, small_sample, mutations, true, false, true);
             auto rs = fwdpp::row_sums(dm);
             std::vector<int> sfs(small_sample.size() - 1);
             for (auto i : rs.first)

--- a/fwdpp/ts/count_mutations.hpp
+++ b/fwdpp/ts/count_mutations.hpp
@@ -28,8 +28,8 @@ namespace fwdpp
 
             auto mtable_itr = tables.mutation_table.begin();
             auto mtable_end = tables.mutation_table.end();
-            tree_visitor mti(tables, samples);
-            while (mti(std::true_type(), std::false_type()))
+            tree_visitor mti(tables, samples, update_samples_list(false));
+            while (mti())
                 {
                     auto& tree = mti.tree();
                     while (mtable_itr < mtable_end
@@ -70,9 +70,9 @@ namespace fwdpp
 
             auto mtable_itr = tables.mutation_table.begin();
             auto mtable_end = tables.mutation_table.end();
-            tree_visitor mti(tables, samples,
-                                       tables.preserved_nodes);
-            while (mti(std::true_type(), std::false_type()))
+            tree_visitor mti(tables, samples, tables.preserved_nodes,
+                             update_samples_list(false));
+            while (mti())
                 {
                     auto& tree = mti.tree();
                     while (mtable_itr < mtable_end

--- a/fwdpp/ts/detail/advance_marginal_tree_policies.hpp
+++ b/fwdpp/ts/detail/advance_marginal_tree_policies.hpp
@@ -13,22 +13,9 @@ namespace fwdpp
         namespace detail
         {
             inline void
-            outgoing_leaf_counts(marginal_tree&, const std::int32_t,
-                                 const std::int32_t, const std::false_type)
-            {
-            }
-
-            inline void
-            incoming_leaf_counts(marginal_tree&, const std::int32_t,
-                                 const std::int32_t, const std::false_type)
-            {
-            }
-
-            inline void
             outgoing_leaf_counts(marginal_tree& marginal,
                                  const std::int32_t parent,
-                                 const std::int32_t child,
-                                 const std::true_type)
+                                 const std::int32_t child)
             {
                 auto p = parent;
                 auto lc = marginal.leaf_counts[child];
@@ -46,8 +33,7 @@ namespace fwdpp
             inline void
             incoming_leaf_counts(marginal_tree& marginal,
                                  const std::int32_t parent,
-                                 const std::int32_t child,
-                                 const std::true_type)
+                                 const std::int32_t child)
             {
                 auto p = parent;
                 auto lc = marginal.leaf_counts[child];
@@ -62,7 +48,7 @@ namespace fwdpp
 
             inline void
             update_samples_list(marginal_tree& marginal,
-                                const std::int32_t node, const std::true_type)
+                                const std::int32_t node)
             {
                 const auto& parents = marginal.parents;
                 const auto& sample_map = marginal.sample_index_map;
@@ -103,12 +89,6 @@ namespace fwdpp
                                     }
                             }
                     }
-            }
-
-            inline void
-            update_samples_list(marginal_tree&, const std::int32_t,
-                                const std::false_type)
-            {
             }
         } // namespace detail
     }     // namespace ts

--- a/fwdpp/ts/detail/advance_marginal_tree_policies.hpp
+++ b/fwdpp/ts/detail/advance_marginal_tree_policies.hpp
@@ -61,8 +61,8 @@ namespace fwdpp
             }
 
             inline void
-            update_sample_list(marginal_tree& marginal,
-                               const std::int32_t node, const std::true_type)
+            update_samples_list(marginal_tree& marginal,
+                                const std::int32_t node, const std::true_type)
             {
                 const auto& parents = marginal.parents;
                 const auto& sample_map = marginal.sample_index_map;
@@ -106,8 +106,8 @@ namespace fwdpp
             }
 
             inline void
-            update_sample_list(marginal_tree&, const std::int32_t,
-                               const std::false_type)
+            update_samples_list(marginal_tree&, const std::int32_t,
+                                const std::false_type)
             {
             }
         } // namespace detail

--- a/fwdpp/ts/generate_data_matrix.hpp
+++ b/fwdpp/ts/generate_data_matrix.hpp
@@ -33,10 +33,10 @@ namespace fwdpp
                 }
             auto mut = tables.mutation_table.cbegin();
             const auto mut_end = tables.mutation_table.cend();
-            tree_visitor tv(tables, samples);
+            tree_visitor tv(tables, samples, update_samples_list(true));
             std::vector<std::int8_t> genotypes(samples.size(), 0);
             data_matrix rv(samples.size());
-            while (tv(std::true_type(), std::true_type()))
+            while (tv())
                 {
                     // Advance the mutation table records until we are
                     // in the current tree

--- a/fwdpp/ts/marginal_tree.hpp
+++ b/fwdpp/ts/marginal_tree.hpp
@@ -54,6 +54,7 @@ namespace fwdpp
             std::size_t num_nodes;
             std::vector<std::int32_t> sample_groups;
             std::vector<TS_NODE_INT> samples_list;
+            bool advancing_sample_list_;
 
             std::vector<std::int32_t>
             fill_sample_groups(const std::vector<TS_NODE_INT>& samples)
@@ -178,11 +179,13 @@ namespace fwdpp
             TS_NODE_INT left_root;
 
             template <typename SAMPLES>
-            marginal_tree(TS_NODE_INT nnodes, SAMPLES&& samples)
+            marginal_tree(TS_NODE_INT nnodes, SAMPLES&& samples,
+                          bool advancing_sample_list)
                 : num_nodes(nnodes),
                   sample_groups(fill_sample_groups(samples)),
                   samples_list(
                       forward_input_samples(std::forward<SAMPLES>(samples))),
+                  advancing_sample_list_(advancing_sample_list),
                   parents(nnodes, TS_NULL_NODE), leaf_counts(nnodes, 0),
                   preserved_leaf_counts(nnodes, 0),
                   left_sib(nnodes, TS_NULL_NODE),
@@ -219,12 +222,14 @@ namespace fwdpp
 
             template <typename SAMPLES>
             marginal_tree(TS_NODE_INT nnodes, SAMPLES&& samples,
-                          SAMPLES&& preserved_nodes)
+                          SAMPLES&& preserved_nodes,
+                          bool advancing_sample_list)
                 : num_nodes(nnodes),
                   sample_groups(fill_sample_groups(samples, preserved_nodes)),
                   samples_list(forward_input_samples(
                       std::forward<SAMPLES>(samples),
                       std::forward<SAMPLES>(preserved_nodes))),
+                  advancing_sample_list_(advancing_sample_list),
                   parents(nnodes, TS_NULL_NODE), leaf_counts(nnodes, 0),
                   preserved_leaf_counts(nnodes, 0),
                   left_sib(nnodes, TS_NULL_NODE),
@@ -261,8 +266,9 @@ namespace fwdpp
 
             marginal_tree(TS_NODE_INT nnodes)
                 : num_nodes(nnodes), sample_groups{}, samples_list{},
-                  parents(nnodes, TS_NULL_NODE), leaf_counts{},
-                  preserved_leaf_counts{}, left_sib(nnodes, TS_NULL_NODE),
+                  advancing_sample_list_(false), parents(nnodes, TS_NULL_NODE),
+                  leaf_counts{}, preserved_leaf_counts{},
+                  left_sib(nnodes, TS_NULL_NODE),
                   right_sib(nnodes, TS_NULL_NODE),
                   left_child(nnodes, TS_NULL_NODE),
                   right_child(nnodes, TS_NULL_NODE),
@@ -327,6 +333,12 @@ namespace fwdpp
                         throw std::invalid_argument("invalid node id");
                     }
                 return sample_groups[u];
+            }
+
+            inline bool
+            advancing_sample_list() const
+            {
+                return advancing_sample_list_;
             }
         };
     } // namespace ts

--- a/fwdpp/ts/marginal_tree.hpp
+++ b/fwdpp/ts/marginal_tree.hpp
@@ -340,6 +340,13 @@ namespace fwdpp
             {
                 return advancing_sample_list_;
             }
+
+            inline std::size_t
+            size() const
+            /// Return the length of the internal vectors.
+            {
+                return num_nodes;
+            }
         };
     } // namespace ts
 } // namespace fwdpp

--- a/fwdpp/ts/marginal_tree.hpp
+++ b/fwdpp/ts/marginal_tree.hpp
@@ -347,6 +347,14 @@ namespace fwdpp
             {
                 return num_nodes;
             }
+
+            inline TS_NODE_INT
+            sample_index_to_node(TS_NODE_INT u) const
+            /// If u is a sample index, return the associated 
+            /// node id.
+            {
+                return samples_list[u];
+            }
         };
     } // namespace ts
 } // namespace fwdpp

--- a/fwdpp/ts/marginal_tree_functions.hpp
+++ b/fwdpp/ts/marginal_tree_functions.hpp
@@ -4,5 +4,6 @@
 #include "marginal_tree_functions/roots.hpp"
 #include "marginal_tree_functions/children.hpp"
 #include "marginal_tree_functions/nodes.hpp"
+#include "marginal_tree_functions/samples.hpp"
 
 #endif

--- a/fwdpp/ts/marginal_tree_functions/Makefile.am
+++ b/fwdpp/ts/marginal_tree_functions/Makefile.am
@@ -3,6 +3,7 @@ pkgincludedir=$(prefix)/include/fwdpp/ts/marginal_tree_functions
 pkginclude_HEADERS= roots.hpp \
 					children.hpp \
 					nodes.hpp \
+					samples.hpp \
 					statistics.hpp \
 					node_traversal_order.hpp \
 					node_traversal_preorder.hpp

--- a/fwdpp/ts/marginal_tree_functions/Makefile.in
+++ b/fwdpp/ts/marginal_tree_functions/Makefile.in
@@ -268,6 +268,7 @@ top_srcdir = @top_srcdir@
 pkginclude_HEADERS = roots.hpp \
 					children.hpp \
 					nodes.hpp \
+					samples.hpp \
 					statistics.hpp \
 					node_traversal_order.hpp \
 					node_traversal_preorder.hpp

--- a/fwdpp/ts/marginal_tree_functions/samples.hpp
+++ b/fwdpp/ts/marginal_tree_functions/samples.hpp
@@ -2,12 +2,21 @@
 #define FWDPP_TS_MARGINAL_TREE_FUNCTIONS_SAMPLES_HPP__
 
 #include <stdexcept>
+#include <fwdpp/named_type.hpp>
 #include "../marginal_tree.hpp"
 
 namespace fwdpp
 {
     namespace ts
     {
+        struct convert_sample_index_to_nodes_t
+        {
+        };
+
+        /// Policy affecting behavior of samples_iterator
+        using convert_sample_index_to_nodes
+            = strong_types::named_type<bool, convert_sample_index_to_nodes_t>;
+
         class samples_iterator
         /// \brief Faciliate traversal of the samples descending from a node
         /// \headerfile fwdpp/ts/marginal_tree_functions/samples.hpp
@@ -50,9 +59,10 @@ namespace fwdpp
 
           public:
             samples_iterator(const marginal_tree &m, TS_NODE_INT u,
-                             bool convert)
+                             convert_sample_index_to_nodes convert)
                 : t(init_marginal(m)), current_sample{ init_left_sample(u) },
-                  right_sample(init_right_sample(u)), convert_to_nodes(convert)
+                  right_sample(init_right_sample(u)),
+                  convert_to_nodes(convert.get())
             /// \param m A marginal_tree
             /// \param u A node index
             {
@@ -110,7 +120,7 @@ namespace fwdpp
         /// \param u Index a fwdpp::ts::node
         /// \param f A function equivalent to void (*process_samples)(TS_NODE_INT)
         {
-            samples_iterator si(m, u, false);
+            samples_iterator si(m, u, convert_sample_index_to_nodes(false));
             while (si(f))
                 {
                 }
@@ -124,7 +134,7 @@ namespace fwdpp
         /// \param u Index a fwdpp::ts::node
         /// \param f A function equivalent to void (*process_samples)(TS_NODE_INT)
         {
-            samples_iterator si(m, u, true);
+            samples_iterator si(m, u, convert_sample_index_to_nodes(true));
             while (si(f))
                 {
                 }
@@ -136,9 +146,7 @@ namespace fwdpp
         /// The return value contains node ids (as opposed to sample indexes)
         {
             std::vector<TS_NODE_INT> rv;
-            process_samples(m, u, [&rv](TS_NODE_INT x) {
-                rv.push_back(x);
-            });
+            process_samples(m, u, [&rv](TS_NODE_INT x) { rv.push_back(x); });
             return rv;
         }
 

--- a/fwdpp/ts/marginal_tree_functions/samples.hpp
+++ b/fwdpp/ts/marginal_tree_functions/samples.hpp
@@ -76,7 +76,7 @@ namespace fwdpp
                     }
                 else
                     {
-                        current_sample = t.right_sib[current_sample];
+                        current_sample = t.next_sample[current_sample];
                     }
                 return c;
             }
@@ -90,7 +90,7 @@ namespace fwdpp
             /// Returns false to signify end of iteration.
             {
                 auto s = this->operator()();
-                bool rv = (s == TS_NULL_NODE);
+                bool rv = (s != TS_NULL_NODE);
                 if (rv)
                     {
                         f(s);

--- a/fwdpp/ts/marginal_tree_functions/samples.hpp
+++ b/fwdpp/ts/marginal_tree_functions/samples.hpp
@@ -1,0 +1,137 @@
+#ifndef FWDPP_TS_MARGINAL_TREE_FUNCTIONS_SAMPLES_HPP__
+#define FWDPP_TS_MARGINAL_TREE_FUNCTIONS_SAMPLES_HPP__
+
+#include <stdexcept>
+#include "../marginal_tree.hpp"
+
+namespace fwdpp
+{
+    namespace ts
+    {
+        class samples_iterator
+        /// \brief Faciliate traversal of the samples descending from a node
+        /// \headerfile fwdpp/ts/marginal_tree_functions/samples.hpp
+        {
+          private:
+            const marginal_tree &t;
+            TS_NODE_INT current_sample, right_sample;
+
+            inline const marginal_tree &
+            init_marginal(const marginal_tree &m)
+            {
+                if (!m.advancing_sample_list())
+                    {
+                        throw std::invalid_argument(
+                            "samples lists are not being updated");
+                    }
+                return m;
+            }
+
+            inline TS_NODE_INT
+            init_left_sample(TS_NODE_INT u)
+            {
+                if (static_cast<std::size_t>(u) >= t.size())
+                    {
+                        throw std::invalid_argument("node index out of range");
+                    }
+                return t.left_sample[u];
+            }
+
+            inline TS_NODE_INT
+            init_right_sample(TS_NODE_INT u)
+            {
+                if (static_cast<std::size_t>(u) >= t.size())
+                    {
+                        throw std::invalid_argument("node index out of range");
+                    }
+                return t.right_sample[u];
+            }
+
+          public:
+            samples_iterator(const marginal_tree &m, TS_NODE_INT u)
+                : t(init_marginal(m)), current_sample{ init_left_sample(u) },
+                  right_sample(init_right_sample(u))
+            /// \param m A marginal_tree
+            /// \param u A node index
+            {
+            }
+
+            inline TS_NODE_INT
+            operator()()
+            /// Advance to the next sample
+            ///
+            /// Returns fwdpp::ts::TS_NULL_NODE when no more samples remain.
+            {
+                if (current_sample == TS_NULL_NODE)
+                    {
+                        //end of iteration
+                        return current_sample;
+                    }
+                auto c = current_sample;
+                if (c == right_sample)
+                    {
+                        // We are at the end of the samples list for this node,
+                        // so we ensure that iteration will end
+                        current_sample = TS_NULL_NODE;
+                    }
+                else
+                    {
+                        current_sample = t.right_sib[current_sample];
+                    }
+                return c;
+            }
+
+            template <typename F>
+            inline bool
+            operator()(const F &f)
+            /// Apply a function to each sample
+            /// \param f A function equivalent to void (*process_sample)(TS_NODE_INT)
+            ///
+            /// Returns false to signify end of iteration.
+            {
+                auto s = this->operator()();
+                bool rv = (s == TS_NULL_NODE);
+                if (rv)
+                    {
+                        f(s);
+                    }
+                return rv;
+            }
+        };
+
+        template <typename F>
+        inline void
+        process_samples(const marginal_tree &m, TS_NODE_INT u, const F &f)
+        /// \brief Apply a function to samples of node \a u
+        /// \param m A fwdpp::ts::marginal_tree
+        /// \param u Index a fwdpp::ts::node
+        /// \param f A function equivalent to void (*process_samples)(TS_NODE_INT)
+        {
+            samples_iterator si(m, u);
+            while (si(f))
+                {
+                }
+        }
+
+        inline std::vector<TS_NODE_INT>
+        get_samples(const marginal_tree &m, TS_NODE_INT u)
+        /// Return a vector of samples descending from node \a u in marginal_tree \a m.
+        {
+            std::vector<TS_NODE_INT> rv;
+            process_samples(m, u, [&rv](TS_NODE_INT x) { rv.push_back(x); });
+            return rv;
+        }
+
+        inline int
+        num_samples(const marginal_tree &m, TS_NODE_INT u)
+        /// Return the number of samples descending from node \a u in marginal_tree \a m.
+        {
+            int nsamples = 0;
+            process_samples(m, u,
+                            [&nsamples](TS_NODE_INT /*x*/) { ++nsamples; });
+            return nsamples;
+        }
+    } // namespace ts
+} // namespace fwdpp
+
+#endif

--- a/fwdpp/ts/mark_multiple_roots.hpp
+++ b/fwdpp/ts/mark_multiple_roots.hpp
@@ -21,13 +21,13 @@ namespace fwdpp
         ///
         /// \version 0.7.0 Added to library
         /// \version 0.7.4 Refactored to use root tracking method
-		/// \version 0.8.0 Refactored to use ts::num_roots and ts::process_roots
+        /// \version 0.8.0 Refactored to use ts::num_roots and ts::process_roots
         ///
         /// See fwdpp::ts::mutate_tables for discussion.
         {
             std::map<TS_NODE_INT, std::vector<std::pair<double, double>>> rv;
-            tree_visitor mti(tables, samples);
-            while (mti(std::false_type(), std::false_type()))
+            tree_visitor mti(tables, samples, update_samples_list(false));
+            while (mti())
                 {
                     auto &tree = mti.tree();
                     if (num_roots(tree) > 1)

--- a/fwdpp/ts/tree_visitor.hpp
+++ b/fwdpp/ts/tree_visitor.hpp
@@ -285,13 +285,11 @@ namespace fwdpp
                                 marginal.left_sib[c] = TS_NULL_NODE;
                                 marginal.right_sib[c] = TS_NULL_NODE;
                                 detail::outgoing_leaf_counts(
-                                    marginal, k->parent, k->child,
-                                    std::true_type());
+                                    marginal, k->parent, k->child);
                                 if (advancing_sample_list)
                                     {
-                                        detail::update_samples_list(
-                                            marginal, k->parent,
-                                            std::true_type());
+                                        detail::update_samples_list(marginal,
+                                                                    k->parent);
                                     }
                                 update_roots_outgoing(p, c, marginal);
                                 ++k;
@@ -320,13 +318,11 @@ namespace fwdpp
                                 marginal.parents[c] = j->parent;
                                 marginal.right_child[p] = c;
                                 detail::incoming_leaf_counts(
-                                    marginal, j->parent, j->child,
-                                    std::true_type());
+                                    marginal, j->parent, j->child);
                                 if (advancing_sample_list)
                                     {
-                                        detail::update_samples_list(
-                                            marginal, j->parent,
-                                            std::true_type());
+                                        detail::update_samples_list(marginal,
+                                                                    j->parent);
                                     }
                                 update_roots_incoming(p, c, lsib, rsib,
                                                       marginal);

--- a/fwdpp/ts/tree_visitor.hpp
+++ b/fwdpp/ts/tree_visitor.hpp
@@ -206,7 +206,8 @@ namespace fwdpp
                   k(tables.output_right.cbegin()),
                   kM(tables.output_right.cend()), x(0.0),
                   maxpos(tables.genome_length()),
-                  marginal(tables.num_nodes(), std::forward<SAMPLES>(samples)),
+                  marginal(tables.num_nodes(), std::forward<SAMPLES>(samples),
+                           update.get()),
                   advancing_sample_list(update.get())
             /// \todo Document
             {
@@ -240,7 +241,8 @@ namespace fwdpp
                   k(tables.output_right.cbegin()),
                   kM(tables.output_right.cend()), x(0.0),
                   maxpos(tables.genome_length()),
-                  marginal(tables.num_nodes(), samples, preserved_nodes),
+                  marginal(tables.num_nodes(), samples, preserved_nodes,
+                           update.get()),
                   advancing_sample_list(update.get())
             {
                 if ((j == jM || k == kM) && !tables.edge_table.empty())

--- a/testsuite/tree_sequences/simple_table_collection.hpp
+++ b/testsuite/tree_sequences/simple_table_collection.hpp
@@ -46,9 +46,10 @@ class simple_table_collection
     double total_time;
     explicit simple_table_collection()
         : tables(init_tables()), samples{ { 0, 1, 2, 3 } },
-          tv(tables, samples), total_time(9)
+          tv(tables, samples, fwdpp::ts::update_samples_list(false)),
+          total_time(9)
     {
-        tv(std::false_type(), std::false_type());
+        tv();
     }
 };
 

--- a/testsuite/tree_sequences/simple_table_collection.hpp
+++ b/testsuite/tree_sequences/simple_table_collection.hpp
@@ -46,7 +46,7 @@ class simple_table_collection
     double total_time;
     explicit simple_table_collection()
         : tables(init_tables()), samples{ { 0, 1, 2, 3 } },
-          tv(tables, samples, fwdpp::ts::update_samples_list(false)),
+          tv(tables, samples, fwdpp::ts::update_samples_list(true)),
           total_time(9)
     {
         tv();

--- a/testsuite/tree_sequences/simple_table_collection_polytomy.hpp
+++ b/testsuite/tree_sequences/simple_table_collection_polytomy.hpp
@@ -36,21 +36,23 @@ class simple_table_collection_polytomy
         t.push_back_edge(0, 1, 5, 1);
         t.push_back_edge(0, 1, 5, 2);
         t.sort_edges();
-		t.build_indexes(); //NOTE: critical!
+        t.build_indexes(); //NOTE: critical!
         return t;
     }
 
   public:
     fwdpp::ts::table_collection tables;
     std::vector<fwdpp::ts::TS_NODE_INT> samples;
-	// NOTE: tv is auto advanced to the first tree
-	// by the constructor
+    // NOTE: tv is auto advanced to the first tree
+    // by the constructor
     fwdpp::ts::tree_visitor tv;
-	double total_time;
+    double total_time;
     explicit simple_table_collection_polytomy()
-        : tables(init_tables()), samples{ { 0, 1, 2, 3, 4 } }, tv(tables, samples), total_time(10)
+        : tables(init_tables()), samples{ { 0, 1, 2, 3, 4 } },
+          tv(tables, samples, fwdpp::ts::update_samples_list(false)),
+          total_time(10)
     {
-        tv(std::false_type(), std::false_type());
+        tv();
     }
 };
 

--- a/testsuite/tree_sequences/simple_table_collection_polytomy.hpp
+++ b/testsuite/tree_sequences/simple_table_collection_polytomy.hpp
@@ -49,7 +49,7 @@ class simple_table_collection_polytomy
     double total_time;
     explicit simple_table_collection_polytomy()
         : tables(init_tables()), samples{ { 0, 1, 2, 3, 4 } },
-          tv(tables, samples, fwdpp::ts::update_samples_list(false)),
+          tv(tables, samples, fwdpp::ts::update_samples_list(true)),
           total_time(10)
     {
         tv();

--- a/testsuite/tree_sequences/test_marginal_tree_statistics.cc
+++ b/testsuite/tree_sequences/test_marginal_tree_statistics.cc
@@ -57,8 +57,8 @@ BOOST_FIXTURE_TEST_CASE(test_total_time_polytomy_decapitate,
                         simple_table_collection_polytomy)
 {
     fwdpp::ts::decapitate(tables, 0.);
-    tv = fwdpp::ts::tree_visitor(tables, samples);
-    tv(std::false_type(), std::false_type());
+    tv = fwdpp::ts::tree_visitor(tables, samples, fwdpp::ts::update_samples_list(false));
+    tv();
     auto ttime = fwdpp::ts::total_time(tv.tree(), tables.node_table, true);
     BOOST_REQUIRE(ttime != total_time);
     BOOST_REQUIRE_EQUAL(ttime, naive_branch_length(tv.tree(), samples,

--- a/testsuite/tree_sequences/test_node_traversal.cc
+++ b/testsuite/tree_sequences/test_node_traversal.cc
@@ -151,7 +151,7 @@ BOOST_FIXTURE_TEST_CASE(num_samples_simple_table_collection,
     // is the number of nodes in the tree.  More generally,
     // we need to do a node traveral, but that hasn't been tested yet
     // (see below).
-    for (int i = 0; i < tables.node_table.size(); ++i)
+    for (std::size_t i = 0; i < tables.node_table.size(); ++i)
         {
             BOOST_REQUIRE_EQUAL(fwdpp::ts::num_samples(tv.tree(), i),
                                 naive_num_samples(tv.tree(), i));

--- a/testsuite/tree_sequences/test_node_traversal.cc
+++ b/testsuite/tree_sequences/test_node_traversal.cc
@@ -33,8 +33,9 @@ BOOST_FIXTURE_TEST_CASE(test_polytomy_decapitate,
                         simple_table_collection_polytomy)
 {
     fwdpp::ts::decapitate(tables, 0.);
-    tv = fwdpp::ts::tree_visitor(tables, samples);
-    tv(std::false_type(), std::false_type());
+    tv = fwdpp::ts::tree_visitor(tables, samples,
+                                 fwdpp::ts::update_samples_list(false));
+    tv();
     auto c = fwdpp::ts::get_children(tv.tree(), 5, false);
     decltype(c) expected = { 2, 1, 0 };
     BOOST_REQUIRE(c == expected);
@@ -58,16 +59,18 @@ BOOST_AUTO_TEST_CASE(test_roots_after_decapitation)
 {
     fwdpp::ts::decapitate(tables, 0.);
     std::vector<fwdpp::ts::TS_NODE_INT> expected_roots{ 4, 5 };
-    tv = fwdpp::ts::tree_visitor(tables, samples);
-    tv(std::false_type(), std::false_type());
+    tv = fwdpp::ts::tree_visitor(tables, samples,
+                                 fwdpp::ts::update_samples_list(false));
+    tv();
     auto r = fwdpp::ts::get_roots(tv.tree());
     BOOST_REQUIRE_EQUAL(r.size(), 2);
     BOOST_REQUIRE_EQUAL(r == expected_roots, true);
 
     fwdpp::ts::decapitate(tables, 1);
     expected_roots = { 2, 3, 4 };
-    tv = fwdpp::ts::tree_visitor(tables, samples);
-    tv(std::false_type(), std::false_type());
+    tv = fwdpp::ts::tree_visitor(tables, samples,
+                                 fwdpp::ts::update_samples_list(false));
+    tv();
     r = fwdpp::ts::get_roots(tv.tree());
     std::sort(begin(r), end(r));
     BOOST_REQUIRE_EQUAL(r.size(), 3);
@@ -75,8 +78,9 @@ BOOST_AUTO_TEST_CASE(test_roots_after_decapitation)
 
     fwdpp::ts::decapitate(tables, 2);
     expected_roots = { 0, 1, 2, 3 };
-    tv = fwdpp::ts::tree_visitor(tables, samples);
-    tv(std::false_type(), std::false_type());
+    tv = fwdpp::ts::tree_visitor(tables, samples,
+                                 fwdpp::ts::update_samples_list(false));
+    tv();
     r = fwdpp::ts::get_roots(tv.tree());
     std::sort(begin(r), end(r));
     BOOST_REQUIRE_EQUAL(r.size(), 4);
@@ -90,7 +94,8 @@ BOOST_FIXTURE_TEST_SUITE(test_simple_table_collection_traversal,
 
 BOOST_AUTO_TEST_CASE(test_construction)
 {
-    BOOST_REQUIRE_NO_THROW({ fwdpp::ts::node_iterator(tv.tree(), fwdpp::ts::nodes_preorder()); });
+    BOOST_REQUIRE_NO_THROW(
+        { fwdpp::ts::node_iterator(tv.tree(), fwdpp::ts::nodes_preorder()); });
 }
 
 BOOST_AUTO_TEST_CASE(test_preorder_traversal)
@@ -122,8 +127,9 @@ BOOST_AUTO_TEST_CASE(test_preorder_traversal_subtree)
 BOOST_AUTO_TEST_CASE(test_preorder_traversal_after_decaptitation)
 {
     fwdpp::ts::decapitate(tables, 1.);
-    tv = fwdpp::ts::tree_visitor(tables, samples);
-    tv(std::false_type(), std::false_type());
+    tv = fwdpp::ts::tree_visitor(tables, samples,
+                                 fwdpp::ts::update_samples_list(false));
+    tv();
     auto nodes = fwdpp::ts::get_nodes(tv.tree(), fwdpp::ts::nodes_preorder());
     std::vector<fwdpp::ts::TS_NODE_INT> expected_nodes = { 4, 0, 1, 2, 3 };
     BOOST_REQUIRE_EQUAL(nodes.size(), expected_nodes.size());
@@ -162,10 +168,15 @@ BOOST_AUTO_TEST_CASE(test_preorder_traversal_other_subtree)
 BOOST_AUTO_TEST_CASE(test_preorder_traversal_after_decaptitation)
 {
     fwdpp::ts::decapitate(tables, 0.);
-    tv = fwdpp::ts::tree_visitor(tables, samples);
-    tv(std::false_type(), std::false_type());
+    tv = fwdpp::ts::tree_visitor(tables, samples,
+                                 fwdpp::ts::update_samples_list(false));
+    tv();
     auto nodes = fwdpp::ts::get_nodes(tv.tree(), fwdpp::ts::nodes_preorder());
-    for(auto n:nodes){std::cout<<n<<' ';}std::cout<<'\n';
+    for (auto n : nodes)
+        {
+            std::cout << n << ' ';
+        }
+    std::cout << '\n';
     std::vector<fwdpp::ts::TS_NODE_INT> expected_nodes
         = { 5, 0, 1, 2, 6, 3, 4 };
     BOOST_REQUIRE_EQUAL(nodes.size(), expected_nodes.size());

--- a/testsuite/tree_sequences/test_node_traversal.cc
+++ b/testsuite/tree_sequences/test_node_traversal.cc
@@ -51,7 +51,8 @@ get_tip(const fwdpp::ts::marginal_tree &m, fwdpp::ts::TS_NODE_INT u,
 
 std::vector<fwdpp::ts::TS_NODE_INT>
 naive_get_samples(const fwdpp::ts::marginal_tree &m, fwdpp::ts::TS_NODE_INT u)
-// NOTE: only works if all tips are samples
+// NOTE: only works if all tips are samples.  This test can be used also 
+// as an independent count of the number of samples for this case.
 {
     std::vector<fwdpp::ts::TS_NODE_INT> rv;
     get_tip(m, u, rv);

--- a/testsuite/tree_sequences/test_node_traversal.cc
+++ b/testsuite/tree_sequences/test_node_traversal.cc
@@ -51,7 +51,7 @@ get_tip(const fwdpp::ts::marginal_tree &m, fwdpp::ts::TS_NODE_INT u,
 
 std::vector<fwdpp::ts::TS_NODE_INT>
 naive_get_samples(const fwdpp::ts::marginal_tree &m, fwdpp::ts::TS_NODE_INT u)
-// NOTE: only works if all tips are samples.  This test can be used also 
+// NOTE: only works if all tips are samples.  This test can be used also
 // as an independent count of the number of samples for this case.
 {
     std::vector<fwdpp::ts::TS_NODE_INT> rv;
@@ -169,6 +169,19 @@ BOOST_FIXTURE_TEST_CASE(test_sample_lists, simple_table_collection)
             BOOST_CHECK(fwdpp::ts::get_samples(tv.tree(), i)
                         == naive_get_samples(tv.tree(), i));
         }
+}
+
+BOOST_FIXTURE_TEST_CASE(test_subset_of_nodes_as_samples,
+                        simple_table_collection)
+{
+    samples = { 0, 1, 3 };
+    tv = fwdpp::ts::tree_visitor(tables, samples,
+                                 fwdpp::ts::update_samples_list(true));
+    tv();
+    BOOST_REQUIRE_EQUAL(naive_num_samples(tv.tree(), 6), samples.size());
+    auto x = fwdpp::ts::get_samples(tv.tree(), 6);
+    BOOST_CHECK(x.size() == samples.size());
+    BOOST_CHECK(x == samples);
 }
 
 BOOST_FIXTURE_TEST_CASE(test_exception, simple_table_collection)

--- a/testsuite/tree_sequences/test_node_traversal_order_adl.cc
+++ b/testsuite/tree_sequences/test_node_traversal_order_adl.cc
@@ -1,6 +1,6 @@
 #include "preorder_adl.hpp"
 #include "simple_table_collection.hpp"
-#include <fwdpp/ts/marginal_tree_functions.hpp>
+#include <fwdpp/ts/marginal_tree_functions/nodes.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(test_adl)

--- a/testsuite/tree_sequences/test_tree_visitor.cc
+++ b/testsuite/tree_sequences/test_tree_visitor.cc
@@ -12,15 +12,20 @@ BOOST_AUTO_TEST_CASE(test_construction)
     // NOTE: this is a "cheat", as we cannot get this far
     // if this doesn't work, as the fixture constructor
     // does this.
-    BOOST_REQUIRE_NO_THROW({ fwdpp::ts::tree_visitor(tables, samples); });
+    BOOST_REQUIRE_NO_THROW({
+        fwdpp::ts::tree_visitor(tables, samples,
+                                fwdpp::ts::update_samples_list(0));
+    });
 }
 
 BOOST_AUTO_TEST_CASE(test_unindexed_tables)
 {
     tables.input_left.clear();
     tables.output_right.clear();
-    BOOST_REQUIRE_THROW(fwdpp::ts::tree_visitor tv(tables, samples),
-                        std::invalid_argument);
+    BOOST_REQUIRE_THROW(
+        fwdpp::ts::tree_visitor tv(tables, samples,
+                                   fwdpp::ts::update_samples_list(0)),
+        std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -30,8 +35,10 @@ BOOST_FIXTURE_TEST_SUITE(test_tree_visitor_with_empty_table_collection,
 
 BOOST_AUTO_TEST_CASE(test_construction)
 {
-    BOOST_REQUIRE_THROW(fwdpp::ts::tree_visitor tv(tables, empty_samples),
-                        fwdpp::ts::empty_samples);
+    BOOST_REQUIRE_THROW(
+        fwdpp::ts::tree_visitor tv(tables, empty_samples,
+                                   fwdpp::ts::update_samples_list(0)),
+        fwdpp::ts::empty_samples);
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -46,8 +53,9 @@ BOOST_FIXTURE_TEST_CASE(test_group_labels, simple_table_collection_polytomy)
             groups.emplace_back(i, 0);
         }
     groups[2].group = 1;
-    tv = fwdpp::ts::tree_visitor(tables, groups);
-    tv(std::true_type(), std::true_type());
+    tv = fwdpp::ts::tree_visitor(tables, groups,
+                                 fwdpp::ts::update_samples_list(1));
+    tv();
     auto c = tv.tree().left_sample[5];
     BOOST_REQUIRE(c == 0);
     BOOST_REQUIRE(tv.tree().sample_group(c) == 0);


### PR DESCRIPTION
* tree_visitor now always updates leaf counts
* Updating samples_lists via tree_visitor is now handled via the constructor
* marginal_tree knows if samples lists are being updated
* Add ts::samples_iterator to facilitate iteration over sample indexes or their corresponding node labels.

See also #205.  This PR is a new feature on top of those changes.