### PR TITLE
Rework site and mutation tables

### DIFF
--- a/examples/confirm_mutation_counts.hpp
+++ b/examples/confirm_mutation_counts.hpp
@@ -41,7 +41,7 @@ confirm_mutation_counts(poptype &pop,
                 }
         }
     decltype(pop.mcounts) mc;
-    fwdpp::fwdpp_internal::process_gametes(pop.gametes, pop.mutations, mc);
+    fwdpp::fwdpp_internal::process_haploid_genomes(pop.haploid_genomes, pop.mutations, mc);
     for (std::size_t i = 0; i < pop.mcounts.size(); ++i)
         {
             if (!pop.mutations[i].neutral)

--- a/examples/evolve_generation_ts.hpp
+++ b/examples/evolve_generation_ts.hpp
@@ -76,12 +76,16 @@ evolve_generation(const rng_t& rng, poptype& pop,
                 first_parental_index, p1, offspring_data.first.swapped);
             auto p2id = fwdpp::ts::get_parent_ids(
                 first_parental_index, p2, offspring_data.second.swapped);
-            tables.add_offspring_data(
-                next_index_local++, offspring_data.first.breakpoints,
-                offspring_data.first.mutation_keys, p1id, 0, generation);
-            tables.add_offspring_data(
-                next_index_local++, offspring_data.second.breakpoints,
-                offspring_data.second.mutation_keys, p2id, 0, generation);
+            next_index_local = tables.register_diploid_offspring(
+                offspring_data.first.breakpoints, p1id, 0, generation);
+            fwdpp::ts::record_mutations_infinite_sites(
+                next_index_local, pop.mutations,
+                offspring_data.first.mutation_keys, tables);
+            next_index_local = tables.register_diploid_offspring(
+                offspring_data.second.breakpoints, p2id, 0, generation);
+            fwdpp::ts::record_mutations_infinite_sites(
+                next_index_local, pop.mutations,
+                offspring_data.second.mutation_keys, tables);
 
             // Give the caller a chance to generate
             // any metadata for the offspring that

--- a/examples/evolve_generation_ts.hpp
+++ b/examples/evolve_generation_ts.hpp
@@ -93,7 +93,7 @@ evolve_generation(const rng_t& rng, poptype& pop,
             update_offspring(next_offspring, p1, p2);
         }
     assert(next_index_local
-           == next_index + 2 * static_cast<std::int32_t>(N_next));
+           == next_index + 2 * static_cast<std::int32_t>(N_next) - 1);
     // This is constant-time
     pop.diploids.swap(offspring);
 }

--- a/examples/simplify_tables.hpp
+++ b/examples/simplify_tables.hpp
@@ -23,7 +23,7 @@ simplify_tables(poptype &pop, const fwdpp::uint_t generation,
     tables.sort_tables_for_simplification();
     std::vector<std::int32_t> samples(num_samples);
     std::iota(samples.begin(), samples.end(), first_sample_node);
-    auto rv = simplifier.simplify(tables, samples, pop.mutations);
+    auto rv = simplifier.simplify(tables, samples);
     tables.build_indexes();
     for (auto &s : samples)
         {

--- a/examples/simplify_tables.hpp
+++ b/examples/simplify_tables.hpp
@@ -42,7 +42,12 @@ simplify_tables(poptype &pop, const fwdpp::uint_t generation,
                     return pop.mcounts[mr.key] == 2 * pop.diploids.size()
                            && mcounts_from_preserved_nodes[mr.key] == 0;
                 });
+            auto d = std::distance(itr, end(tables.mutation_table));
             tables.mutation_table.erase(itr, tables.mutation_table.end());
+            if (d)
+                {
+                    tables.rebuild_site_table();
+                }
             confirm_mutation_counts(pop, tables);
             fwdpp::ts::remove_fixations_from_haploid_genomes(
                 pop.haploid_genomes, pop.mutations, pop.mcounts,

--- a/examples/simplify_tables.hpp
+++ b/examples/simplify_tables.hpp
@@ -20,7 +20,7 @@ simplify_tables(poptype &pop, const fwdpp::uint_t generation,
                 const std::size_t num_samples,
                 const bool preserve_fixations = false)
 {
-    tables.sort_tables(pop.mutations);
+    tables.sort_tables_for_simplification();
     std::vector<std::int32_t> samples(num_samples);
     std::iota(samples.begin(), samples.end(), first_sample_node);
     auto rv = simplifier.simplify(tables, samples, pop.mutations);

--- a/examples/spatialts.cc
+++ b/examples/spatialts.cc
@@ -437,11 +437,6 @@ main(int argc, char **argv)
     auto neutral_muts
         = fwdpp::ts::mutate_tables(rng, neutral_variant_maker, tables, s,
                                    theta / static_cast<double>(4 * N));
-    std::sort(tables.mutation_table.begin(), tables.mutation_table.end(),
-              [&pop](const fwdpp::ts::mutation_record &a,
-                     const fwdpp::ts::mutation_record &b) {
-                  return pop.mutations[a.key].pos < pop.mutations[b.key].pos;
-              });
     fwdpp::ts::count_mutations(tables, pop.mutations, s, pop.mcounts,
                                pop.mcounts_from_preserved_nodes);
     for (std::size_t i = 0; i < pop.mutations.size(); ++i)

--- a/examples/spatialts.cc
+++ b/examples/spatialts.cc
@@ -24,6 +24,7 @@
 #include <fwdpp/ts/generate_data_matrix.hpp>
 #include <fwdpp/ts/remove_fixations_from_gametes.hpp>
 #include <fwdpp/ts/serialization.hpp>
+#include <fwdpp/ts/mutation_tools.hpp>
 #include <fwdpp/GSLrng_t.hpp>
 #include <fwdpp/popgenmut.hpp>
 #include <fwdpp/diploid_population.hpp>
@@ -420,17 +421,19 @@ main(int argc, char **argv)
     assert(tables.output_right.size() == tables.edge_table.size());
     std::vector<fwdpp::ts::TS_NODE_INT> s(2 * N);
     std::iota(s.begin(), s.end(), 0);
-    const auto neutral_variant_maker
-        = [&rng, &pop, &genetics](const double left, const double right,
-                                  const fwdpp::uint_t generation) {
-              return fwdpp::infsites_popgenmut(
-                  genetics.mutation_recycling_bin, pop.mutations, rng.get(),
-                  pop.mut_lookup, generation, 0.0,
-                  [left, right, &rng] {
-                      return gsl_ran_flat(rng.get(), left, right);
-                  },
-                  []() { return 0.0; }, []() { return 0.0; });
-          };
+    const auto neutral_variant_maker =
+        [&rng, &pop, &genetics](const double left, const double right,
+                                const fwdpp::uint_t generation) {
+            auto key = fwdpp::infsites_popgenmut(
+                genetics.mutation_recycling_bin, pop.mutations, rng.get(),
+                pop.mut_lookup, generation, 0.0,
+                [left, right, &rng] {
+                    return gsl_ran_flat(rng.get(), left, right);
+                },
+                []() { return 0.0; }, []() { return 0.0; });
+            return fwdpp::ts::new_variant_record(
+                pop.mutations[key].pos, 0, key, pop.mutations[key].neutral, 1);
+        };
     auto neutral_muts
         = fwdpp::ts::mutate_tables(rng, neutral_variant_maker, tables, s,
                                    theta / static_cast<double>(4 * N));

--- a/examples/tree_sequence_examples_common.cc
+++ b/examples/tree_sequence_examples_common.cc
@@ -165,7 +165,6 @@ make_dfe(const fwdpp::uint_t N, const fwdpp::GSLrng_mt &r, const double mean,
 void
 matrix_runtime_test(const fwdpp::ts::table_collection &tables,
                     const std::vector<fwdpp::ts::TS_NODE_INT> &samples,
-                    const std::vector<fwdpp::popgenmut> &mutations,
                     const std::vector<fwdpp::uint_t> &mcounts)
 {
     auto dm
@@ -302,14 +301,13 @@ execute_matrix_test_detail(const options &o, const poptype &pop,
     if (o.matrix_test)
         {
             std::cerr << "Matrix test with respect to last generation...";
-            matrix_runtime_test(tables, samples, pop.mutations, pop.mcounts);
+            matrix_runtime_test(tables, samples, pop.mcounts);
             std::cerr << "passed\n";
             if (!tables.preserved_nodes.empty())
                 {
                     std::cout << "Matrix test with respect to preserved "
                                  "samples...";
                     matrix_runtime_test(tables, tables.preserved_nodes,
-                                        pop.mutations,
                                         pop.mcounts_from_preserved_nodes);
                     std::cerr << "passed\n";
                     auto sc = samples;
@@ -321,7 +319,7 @@ execute_matrix_test_detail(const options &o, const poptype &pop,
                                    mc.begin(), std::plus<fwdpp::uint_t>());
                     std::cout << "Matrix test with respect to last generation "
                                  "+ preserved nodes...";
-                    matrix_runtime_test(tables, sc, pop.mutations, mc);
+                    matrix_runtime_test(tables, sc, mc);
                     std::cout << "passed.\n";
                     std::cout << "Matrix test with respect to most recent "
                                  "ancient sampling time point...";
@@ -338,7 +336,7 @@ execute_matrix_test_detail(const options &o, const poptype &pop,
                         });
                     mc.clear();
                     fwdpp::ts::count_mutations(tables, pop.mutations, sc, mc);
-                    matrix_runtime_test(tables, sc, pop.mutations, mc);
+                    matrix_runtime_test(tables, sc, mc);
                     std::cout << "passed\n";
                 }
         }
@@ -365,8 +363,7 @@ execute_serialization_test(const options &o,
 void
 write_sfs(const options &o, const fwdpp::GSLrng_mt &rng,
           const fwdpp::ts::table_collection &tables,
-          const std::vector<fwdpp::ts::TS_NODE_INT> &samples,
-          const std::vector<fwdpp::popgenmut> &mutations)
+          const std::vector<fwdpp::ts::TS_NODE_INT> &samples)
 {
     if (!o.sfsfilename.empty())
         {

--- a/examples/tree_sequence_examples_common.cc
+++ b/examples/tree_sequence_examples_common.cc
@@ -55,7 +55,7 @@ apply_neutral_mutations(const options &o, const fwdpp::GSLrng_mt &rng,
 
 options::options()
     : N{}, gcint(100), theta(), rho(), mean(0.), shape(1.), mu(),
-      scoeff(std::numeric_limits<double>::max()), dominance(1.), scaling(2.),
+      scoeff(std::numeric_limits<double>::quiet_NaN()), dominance(1.), scaling(2.),
       seed(42), ancient_sampling_interval(-1), ancient_sample_size(-1),
       nsam(0), leaf_test(false), matrix_test(false), preserve_fixations(false),
       filename(), sfsfilename()

--- a/examples/tree_sequence_examples_common.cc
+++ b/examples/tree_sequence_examples_common.cc
@@ -55,10 +55,10 @@ apply_neutral_mutations(const options &o, const fwdpp::GSLrng_mt &rng,
 
 options::options()
     : N{}, gcint(100), theta(), rho(), mean(0.), shape(1.), mu(),
-      scoeff(std::numeric_limits<double>::quiet_NaN()), dominance(1.), scaling(2.),
-      seed(42), ancient_sampling_interval(-1), ancient_sample_size(-1),
-      nsam(0), leaf_test(false), matrix_test(false), preserve_fixations(false),
-      filename(), sfsfilename()
+      scoeff(std::numeric_limits<double>::quiet_NaN()), dominance(1.),
+      scaling(2.), seed(42), ancient_sampling_interval(-1),
+      ancient_sample_size(-1), nsam(0), leaf_test(false), matrix_test(false),
+      preserve_fixations(false), filename(), sfsfilename()
 {
 }
 
@@ -168,8 +168,8 @@ matrix_runtime_test(const fwdpp::ts::table_collection &tables,
                     const std::vector<fwdpp::popgenmut> &mutations,
                     const std::vector<fwdpp::uint_t> &mcounts)
 {
-    auto dm = fwdpp::ts::generate_data_matrix(tables, samples, mutations, true,
-                                              true, false);
+    auto dm
+        = fwdpp::ts::generate_data_matrix(tables, samples, true, true, false);
     auto rs = fwdpp::row_sums(dm);
     for (std::size_t i = 0; i < rs.first.size(); ++i)
         {
@@ -379,7 +379,7 @@ write_sfs(const options &o, const fwdpp::GSLrng_mt &rng,
                            s.data(), s.size(), sizeof(fwdpp::ts::TS_NODE_INT));
             std::iota(small_sample.begin(), small_sample.end(), 0);
             auto dm = fwdpp::ts::generate_data_matrix(
-                tables, small_sample, mutations, true, false, true);
+                tables, small_sample, true, false, true);
             auto rs = fwdpp::row_sums(dm);
             std::vector<int> sfs(small_sample.size() - 1);
             for (auto i : rs.first)

--- a/examples/tree_sequence_examples_common.cc
+++ b/examples/tree_sequence_examples_common.cc
@@ -40,11 +40,6 @@ apply_neutral_mutations_details(
     auto neutral_muts
         = fwdpp::ts::mutate_tables(rng, neutral_variant_maker, tables, s,
                                    o.theta / static_cast<double>(4 * o.N));
-    std::sort(tables.mutation_table.begin(), tables.mutation_table.end(),
-              [&pop](const fwdpp::ts::mutation_record &a,
-                     const fwdpp::ts::mutation_record &b) {
-                  return pop.mutations[a.key].pos < pop.mutations[b.key].pos;
-              });
     return neutral_muts;
 }
 

--- a/examples/tree_sequence_examples_common.cc
+++ b/examples/tree_sequence_examples_common.cc
@@ -267,6 +267,10 @@ test_serialization(const fwdpp::ts::table_collection &tables,
         {
             throw std::runtime_error("mutation tables do not match");
         }
+    if (tables.site_table != tables2.site_table)
+        {
+            throw std::runtime_error("site tables do no match");
+        }
     if (tables != tables2)
         {
             throw std::runtime_error("tables failed equality check");
@@ -378,8 +382,8 @@ write_sfs(const options &o, const fwdpp::GSLrng_mt &rng,
             gsl_ran_choose(rng.get(), small_sample.data(), small_sample.size(),
                            s.data(), s.size(), sizeof(fwdpp::ts::TS_NODE_INT));
             std::iota(small_sample.begin(), small_sample.end(), 0);
-            auto dm = fwdpp::ts::generate_data_matrix(
-                tables, small_sample, true, false, true);
+            auto dm = fwdpp::ts::generate_data_matrix(tables, small_sample,
+                                                      true, false, true);
             auto rs = fwdpp::row_sums(dm);
             std::vector<int> sfs(small_sample.size() - 1);
             for (auto i : rs.first)

--- a/examples/tree_sequence_examples_common.hpp
+++ b/examples/tree_sequence_examples_common.hpp
@@ -69,7 +69,6 @@ void test_serialization(const fwdpp::ts::table_collection &tables,
 void
 write_sfs(const options &o, const fwdpp::GSLrng_mt &rng,
           const fwdpp::ts::table_collection &tables,
-          const std::vector<fwdpp::ts::TS_NODE_INT> &samples,
-          const std::vector<fwdpp::popgenmut> &mutations);
+          const std::vector<fwdpp::ts::TS_NODE_INT> &samples);
 
 #endif

--- a/examples/wfts.cc
+++ b/examples/wfts.cc
@@ -321,6 +321,14 @@ main(int argc, char **argv)
 
     auto neutral_muts = apply_neutral_mutations(
         o, rng, tables, pop, genetics.mutation_recycling_bin);
+    for (auto &mr : tables.mutation_table)
+        {
+            if (pop.mutations[mr.key].pos
+                != tables.site_table[mr.site].position)
+                {
+                    throw std::runtime_error("site table data incorrect");
+                }
+        }
 
     fwdpp::ts::count_mutations(tables, pop.mutations, s, pop.mcounts,
                                pop.mcounts_from_preserved_nodes);

--- a/examples/wfts.cc
+++ b/examples/wfts.cc
@@ -283,6 +283,25 @@ main(int argc, char **argv)
                     assert(md.n2 != fwdpp::ts::TS_NULL_NODE);
                 }
         }
+    // This is an infinite-sites simulation, so we can do some
+    // simple tests on our site table:
+    if (tables.site_table.size() != tables.mutation_table.size())
+        {
+            throw std::runtime_error("mutation and site table sizes differ");
+        }
+    if (!std::is_sorted(begin(tables.site_table), end(tables.site_table)))
+        {
+            throw std::runtime_error("site table is not sorted");
+        }
+    for (std::size_t i = 0; i < tables.site_table.size(); ++i)
+        {
+            if (tables.site_table[i].position
+                != pop.mutations[tables.mutation_table[i].key].pos)
+                {
+                    throw std::runtime_error("site table data are incorrect");
+                }
+        }
+
     // If we have done things correctly, then our
     // ancient sample metadata must match up with
     // what is in our node table.

--- a/examples/wfts.cc
+++ b/examples/wfts.cc
@@ -355,5 +355,5 @@ main(int argc, char **argv)
     execute_expensive_leaf_test(o, tables, s);
     execute_matrix_test(o, pop, tables, s);
     execute_serialization_test(o, tables);
-    write_sfs(o, rng, tables, s, pop.mutations);
+    write_sfs(o, rng, tables, s);
 }

--- a/examples/wfts.cc
+++ b/examples/wfts.cc
@@ -321,12 +321,18 @@ main(int argc, char **argv)
 
     auto neutral_muts = apply_neutral_mutations(
         o, rng, tables, pop, genetics.mutation_recycling_bin);
+    if (!std::is_sorted(begin(tables.site_table), end(tables.site_table)))
+        {
+            throw std::runtime_error(
+                "site table is not sorted after adding neutral mutations");
+        }
     for (auto &mr : tables.mutation_table)
         {
             if (pop.mutations[mr.key].pos
                 != tables.site_table[mr.site].position)
                 {
-                    throw std::runtime_error("site table data incorrect");
+                    throw std::runtime_error("site table data incorrect after "
+                                             "adding neutral mutations");
                 }
         }
 

--- a/fwdpp/ts/Makefile.am
+++ b/fwdpp/ts/Makefile.am
@@ -22,6 +22,7 @@ pkginclude_HEADERS= definitions.hpp \
 			marginal_tree_functions.hpp \
 			decapitate.hpp \
 			exceptions.hpp \
-			mutation_tools.hpp
+			mutation_tools.hpp \
+			table_types.hpp
 
 

--- a/fwdpp/ts/Makefile.am
+++ b/fwdpp/ts/Makefile.am
@@ -22,6 +22,6 @@ pkginclude_HEADERS= definitions.hpp \
 			marginal_tree_functions.hpp \
 			decapitate.hpp \
 			exceptions.hpp \
-			new_variant_record.hpp
+			mutation_tools.hpp
 
 

--- a/fwdpp/ts/Makefile.am
+++ b/fwdpp/ts/Makefile.am
@@ -21,6 +21,7 @@ pkginclude_HEADERS= definitions.hpp \
 			serialization.hpp \
 			marginal_tree_functions.hpp \
 			decapitate.hpp \
-			exceptions.hpp
+			exceptions.hpp \
+			new_variant_record.hpp
 
 

--- a/fwdpp/ts/Makefile.am
+++ b/fwdpp/ts/Makefile.am
@@ -3,6 +3,7 @@ pkgincludedir=$(prefix)/include/fwdpp/ts
 pkginclude_HEADERS= definitions.hpp \
 			node.hpp \
 			edge.hpp \
+			site.hpp \
 			table_collection.hpp \
 			table_simplifier.hpp \
 			get_parent_ids.hpp \

--- a/fwdpp/ts/Makefile.in
+++ b/fwdpp/ts/Makefile.in
@@ -287,7 +287,7 @@ pkginclude_HEADERS = definitions.hpp \
 			marginal_tree_functions.hpp \
 			decapitate.hpp \
 			exceptions.hpp \
-			new_variant_record.hpp
+			mutation_tools.hpp
 
 all: all-am
 

--- a/fwdpp/ts/Makefile.in
+++ b/fwdpp/ts/Makefile.in
@@ -286,7 +286,8 @@ pkginclude_HEADERS = definitions.hpp \
 			serialization.hpp \
 			marginal_tree_functions.hpp \
 			decapitate.hpp \
-			exceptions.hpp
+			exceptions.hpp \
+			new_variant_record.hpp
 
 all: all-am
 

--- a/fwdpp/ts/Makefile.in
+++ b/fwdpp/ts/Makefile.in
@@ -268,6 +268,7 @@ top_srcdir = @top_srcdir@
 pkginclude_HEADERS = definitions.hpp \
 			node.hpp \
 			edge.hpp \
+			site.hpp \
 			table_collection.hpp \
 			table_simplifier.hpp \
 			get_parent_ids.hpp \

--- a/fwdpp/ts/Makefile.in
+++ b/fwdpp/ts/Makefile.in
@@ -287,7 +287,8 @@ pkginclude_HEADERS = definitions.hpp \
 			marginal_tree_functions.hpp \
 			decapitate.hpp \
 			exceptions.hpp \
-			mutation_tools.hpp
+			mutation_tools.hpp \
+			table_types.hpp
 
 all: all-am
 

--- a/fwdpp/ts/definitions.hpp
+++ b/fwdpp/ts/definitions.hpp
@@ -13,6 +13,10 @@ namespace fwdpp
         using TS_NODE_INT = std::int32_t;
         /// Index value of a NULL node
         constexpr TS_NODE_INT TS_NULL_NODE = -1;
+        /// Convention for the ancestral state of a site
+        constexpr std::int8_t default_ancestral_state = 0;
+        /// Convention for the derived state of a site
+        constexpr std::int8_t default_derived_state = 1;
     } // namespace ts
 } // namespace fwdpp
 

--- a/fwdpp/ts/detail/generate_data_matrix_details.hpp
+++ b/fwdpp/ts/detail/generate_data_matrix_details.hpp
@@ -6,8 +6,7 @@
 #include <algorithm>
 #include <fwdpp/data_matrix.hpp>
 #include "../marginal_tree.hpp"
-#include "../site.hpp"
-#include "../mutation_record.hpp"
+#include "../table_types.hpp"
 
 namespace fwdpp
 {
@@ -15,97 +14,126 @@ namespace fwdpp
     {
         namespace detail
         {
-            inline void
-            process_samples(const marginal_tree& marginal,
-                            const TS_NODE_INT node, TS_NODE_INT index,
-                            std::vector<std::int8_t>& genotypes)
+            class data_matrix_filler
             {
-                auto right = marginal.right_sample[node];
-                // Set all genotypes to ancestral state
-                //std::fill(genotypes.begin(), genotypes.end(), 0);
-                int x = 0;
-                while (true)
-                    {
-                        ++x;
-                        if (genotypes[index] == 1)
-                            {
-                                throw std::runtime_error("inconsist"
-                                                         "ent "
-                                                         "samples "
-                                                         "list");
-                            }
-                        genotypes[index] = 1;
-                        if (index == right)
-                            {
-                                break;
-                            }
-                        index = marginal.next_sample[index];
-                    }
-            }
+              private:
+                site_vector::const_iterator site_table_begin;
+                bool record_neutral, record_selected, skip_fixed;
+                std::vector<std::int8_t> genotypes;
+                bool filled;
+                data_matrix dm;
 
-            inline void
-            update_data_matrix(const std::size_t key, const double position,
-                               const bool neutral,
-                               const std::vector<std::int8_t>& genotypes,
-                               data_matrix& rv)
-            {
-                auto& sm = (neutral) ? rv.neutral : rv.selected;
-                auto& k = (neutral) ? rv.neutral_keys : rv.selected_keys;
-                sm.positions.push_back(position);
-                sm.data.insert(sm.data.end(), genotypes.begin(),
-                               genotypes.end());
-                k.push_back(key);
-            }
+                inline void
+                process_samples(const marginal_tree& marginal,
+                                const TS_NODE_INT node, TS_NODE_INT index)
+                {
+                    auto right = marginal.right_sample[node];
+                    // Set all genotypes to ancestral state
+                    //std::fill(genotypes.begin(), genotypes.end(), 0);
+                    int x = 0;
+                    while (true)
+                        {
+                            ++x;
+                            if (genotypes[index] == 1)
+                                {
+                                    throw std::runtime_error("inconsist"
+                                                             "ent "
+                                                             "samples "
+                                                             "list");
+                                }
+                            genotypes[index] = 1;
+                            if (index == right)
+                                {
+                                    break;
+                                }
+                            index = marginal.next_sample[index];
+                        }
+                }
 
-            template <typename site_table_iterator, typename mtable_iterator>
-            std::pair<bool, mtable_iterator>
-            process_site(const marginal_tree& tree, const site& current_site,
-                         site_table_iterator site_table_begin,
-                         mtable_iterator mut, mtable_iterator mut_end,
-                         bool record_neutral, bool record_selected,
-                         bool skip_fixed, std::vector<std::int8_t>& genotypes)
-            {
-                bool initialized_site = false;
-                bool filled = false;
-                for (; mut < mut_end
-                       && (site_table_begin + mut->site)->position
-                              == current_site.position;
-                     ++mut)
-                    {
-                        std::size_t total_leaf_count
-                            = tree.preserved_leaf_counts[mut->node]
-                              + tree.leaf_counts[mut->node];
-                        if (total_leaf_count
-                            && (!skip_fixed
-                                || (skip_fixed
-                                    && total_leaf_count < tree.sample_size())))
-                            {
-                                if ((mut->neutral && record_neutral)
-                                    || (!mut->neutral && record_selected))
-                                    {
-                                        if (!initialized_site)
-                                            {
-                                                std::fill(
-                                                    begin(genotypes),
-                                                    end(genotypes),
-                                                    current_site
-                                                        .ancestral_state);
-                                            }
-                                        auto index
-                                            = tree.left_sample[mut->node];
-                                        // Check if mutation leads to a sample
-                                        if (index != TS_NULL_NODE)
-                                            {
-                                                process_samples(
-                                                    tree, mut->node, index,
-                                                    genotypes);
-                                                filled = true;
-                                            }
-                                    }
-                            }
-                    }
-                return std::make_pair(filled, mut);
-            }
+                inline void
+                update_data_matrix(const std::size_t key,
+                                   const double position, const bool neutral)
+                {
+                    auto& sm = (neutral) ? dm.neutral : dm.selected;
+                    auto& k = (neutral) ? dm.neutral_keys : dm.selected_keys;
+                    sm.positions.push_back(position);
+                    sm.data.insert(sm.data.end(), genotypes.begin(),
+                                   genotypes.end());
+                    k.push_back(key);
+                }
+
+              public:
+                data_matrix_filler(site_vector::const_iterator b, bool rn,
+                                   bool rs, bool sf, std::size_t sample_size)
+                    : site_table_begin(b), record_neutral(rn),
+                      record_selected(rs), skip_fixed(sf),
+                      genotypes(sample_size, -1), filled(false),
+                      dm(sample_size)
+                {
+                }
+
+                inline mutation_key_vector::const_iterator
+                operator()(const marginal_tree& tree, const site& current_site,
+                           mutation_key_vector::const_iterator mut,
+                           mutation_key_vector::const_iterator mut_end)
+                {
+                    bool initialized_site = false;
+                    // mcopy prevents and off-by-one error in the return value
+                    auto mcopy = mut;
+                    for (; mut < mut_end
+                           && (site_table_begin + mut->site)->position
+                                  == current_site.position;
+                         ++mut)
+                        {
+                            std::size_t total_leaf_count
+                                = tree.preserved_leaf_counts[mut->node]
+                                  + tree.leaf_counts[mut->node];
+                            if (total_leaf_count
+                                && (!skip_fixed
+                                    || (skip_fixed
+                                        && total_leaf_count
+                                               < tree.sample_size())))
+                                {
+                                    if ((mut->neutral && record_neutral)
+                                        || (!mut->neutral && record_selected))
+                                        {
+                                            if (!initialized_site)
+                                                {
+                                                    std::fill(
+                                                        begin(genotypes),
+                                                        end(genotypes),
+                                                        current_site
+                                                            .ancestral_state);
+                                                }
+                                            auto index
+                                                = tree.left_sample[mut->node];
+                                            // Check if mutation leads to a sample
+                                            if (index != TS_NULL_NODE)
+                                                {
+                                                    process_samples(tree,
+                                                                    mut->node,
+                                                                    index);
+                                                    filled = true;
+                                                }
+                                            mcopy = mut;
+                                        }
+                                }
+                            if (filled)
+                                {
+                                    update_data_matrix(mcopy->key,
+                                                       current_site.position,
+                                                       mcopy->neutral);
+                                }
+                        }
+                    return mut;
+                }
+
+                data_matrix
+                data()
+                {
+                    return data_matrix(std::move(dm));
+                }
+            };
         } // namespace detail
     }     // namespace ts
 } // namespace fwdpp

--- a/fwdpp/ts/detail/generate_data_matrix_details.hpp
+++ b/fwdpp/ts/detail/generate_data_matrix_details.hpp
@@ -20,9 +20,11 @@ namespace fwdpp
             {
                 auto right = marginal.right_sample[node];
                 // Set all genotypes to ancestral state
-                std::fill(genotypes.begin(), genotypes.end(), 0);
+                //std::fill(genotypes.begin(), genotypes.end(), 0);
+                int x = 0;
                 while (true)
                     {
+                        ++x;
                         if (genotypes[index] == 1)
                             {
                                 throw std::runtime_error("inconsist"

--- a/fwdpp/ts/detail/generate_data_matrix_details.hpp
+++ b/fwdpp/ts/detail/generate_data_matrix_details.hpp
@@ -25,23 +25,16 @@ namespace fwdpp
 
                 inline void
                 process_samples(const marginal_tree& marginal,
-                                const TS_NODE_INT node, TS_NODE_INT index)
+                                const mutation_record& mut, TS_NODE_INT index)
                 {
-                    auto right = marginal.right_sample[node];
+                    auto right = marginal.right_sample[mut.node];
                     // Set all genotypes to ancestral state
                     //std::fill(genotypes.begin(), genotypes.end(), 0);
                     int x = 0;
                     while (true)
                         {
                             ++x;
-                            if (genotypes[index] == 1)
-                                {
-                                    throw std::runtime_error("inconsist"
-                                                             "ent "
-                                                             "samples "
-                                                             "list");
-                                }
-                            genotypes[index] = 1;
+                            genotypes[index] = mut.derived_state;
                             if (index == right)
                                 {
                                     break;
@@ -104,26 +97,26 @@ namespace fwdpp
                                                         end(genotypes),
                                                         current_site
                                                             .ancestral_state);
+                                                    initialized_site = true;
                                                 }
                                             auto index
                                                 = tree.left_sample[mut->node];
                                             // Check if mutation leads to a sample
                                             if (index != TS_NULL_NODE)
                                                 {
-                                                    process_samples(tree,
-                                                                    mut->node,
+                                                    process_samples(tree, *mut,
                                                                     index);
                                                     filled = true;
                                                 }
                                             mcopy = mut;
                                         }
                                 }
-                            if (filled)
-                                {
-                                    update_data_matrix(mcopy->key,
-                                                       current_site.position,
-                                                       mcopy->neutral);
-                                }
+                        }
+                    if (filled)
+                        {
+                            update_data_matrix(mcopy->key,
+                                               current_site.position,
+                                               mcopy->neutral);
                         }
                     return mut;
                 }

--- a/fwdpp/ts/detail/generate_data_matrix_details.hpp
+++ b/fwdpp/ts/detail/generate_data_matrix_details.hpp
@@ -39,22 +39,21 @@ namespace fwdpp
                     }
             }
 
-            template <typename mcont_t>
             inline void
-            update_data_matrix(const mcont_t& mutations, const std::size_t key,
+            update_data_matrix(const std::size_t key, const double position,
+                               const bool neutral,
                                const std::vector<std::int8_t>& genotypes,
                                data_matrix& rv)
             {
-                auto n = mutations[key].neutral;
-                auto& sm = (n) ? rv.neutral : rv.selected;
-                auto& k = (n) ? rv.neutral_keys : rv.selected_keys;
-                sm.positions.push_back(mutations[key].pos);
+                auto& sm = (neutral) ? rv.neutral : rv.selected;
+                auto& k = (neutral) ? rv.neutral_keys : rv.selected_keys;
+                sm.positions.push_back(position);
                 sm.data.insert(sm.data.end(), genotypes.begin(),
                                genotypes.end());
                 k.push_back(key);
             }
         } // namespace detail
-    } // namespace ts
+    }     // namespace ts
 } // namespace fwdpp
 
 #endif

--- a/fwdpp/ts/exceptions.hpp
+++ b/fwdpp/ts/exceptions.hpp
@@ -11,6 +11,7 @@ namespace fwdpp
         class empty_samples : public std::exception
         /// Thrown when an empty sample (node) list
         /// is passed in an invalid context
+        /// \version 0.8.0 Added to library
         {
           private:
             std::string message_;
@@ -26,6 +27,26 @@ namespace fwdpp
                 return message_.c_str();
             }
         };
+
+        class tables_error : public std::exception
+        /// Thrown when table_collection objects are in an invalid state.
+        /// \version 0.8.0 Added to library
+        {
+          private:
+            std::string message_;
+
+          public:
+            explicit tables_error(std::string message)
+                : message_(std::move(message))
+            {
+            }
+            virtual const char*
+            what() const noexcept
+            {
+                return message_.c_str();
+            }
+        };
+
     } // namespace ts
 } // namespace fwdpp
 

--- a/fwdpp/ts/generate_data_matrix.hpp
+++ b/fwdpp/ts/generate_data_matrix.hpp
@@ -78,9 +78,10 @@ namespace fwdpp
                                                 = tree.leaf_counts[mut->node]
                                                   + tree.preserved_leaf_counts
                                                         [mut->node];
-                                            if (!skip_fixed
-                                                || (skip_fixed
-                                                    && tc < tree.sample_size()))
+                                            if (tc
+                                                && (!skip_fixed
+                                                    || (skip_fixed
+                                                        && tc < tree.sample_size())))
                                                 {
                                                     // Mutation leads to a polymorphism
                                                     bool is_neutral

--- a/fwdpp/ts/generate_data_matrix.hpp
+++ b/fwdpp/ts/generate_data_matrix.hpp
@@ -59,9 +59,10 @@ namespace fwdpp
                                         {
                                             return rv;
                                         }
-                                    auto tc = tree.leaf_counts[mut->node]
-                                              + tree.preserved_leaf_counts
-                                                    [mut->node];
+                                    std::size_t tc
+                                        = tree.leaf_counts[mut->node]
+                                          + tree.preserved_leaf_counts
+                                                [mut->node];
                                     if (!skip_fixed
                                         || (skip_fixed
                                             && tc < tree.sample_size()))

--- a/fwdpp/ts/generate_data_matrix.hpp
+++ b/fwdpp/ts/generate_data_matrix.hpp
@@ -67,64 +67,69 @@ namespace fwdpp
                                         {
                                             ++mut;
                                         }
-                                    bool initialized_site = false;
-                                    for (; mut < mut_end
-                                           && tables.site_table[mut->site]
-                                                      .position
-                                                  == pos;
-                                         ++mut)
+                                    auto process_results = detail::process_site(
+                                        tree, *site_table_location,
+                                        tables.site_table.begin(), mut,
+                                        mut_end, record_neutral,
+                                        record_selected, skip_fixed,
+                                        genotypes);
+                                    if (process_results.first)
                                         {
-                                            std::size_t tc
-                                                = tree.leaf_counts[mut->node]
-                                                  + tree.preserved_leaf_counts
-                                                        [mut->node];
-                                            if (tc
-                                                && (!skip_fixed
-                                                    || (skip_fixed
-                                                        && tc < tree.sample_size())))
-                                                {
-                                                    // Mutation leads to a polymorphism
-                                                    bool is_neutral
-                                                        = mut->neutral;
-                                                    if ((is_neutral
-                                                         && record_neutral)
-                                                        || (!is_neutral
-                                                            && record_selected))
-                                                        {
-                                                            if (!initialized_site)
-                                                                {
-                                                                    std::fill(
-                                                                        begin(
-                                                                            genotypes),
-                                                                        end(genotypes),
-                                                                        site_table_location
-                                                                            ->ancestral_state);
-                                                                    initialized_site
-                                                                        = true;
-                                                                }
-                                                            auto index
-                                                                = tree.left_sample
-                                                                      [mut->node];
-                                                            // Check if mutation leads to a sample
-                                                            if (index
-                                                                != TS_NULL_NODE)
-                                                                {
-                                                                    detail::process_samples(
-                                                                        tree,
-                                                                        mut->node,
-                                                                        index,
-                                                                        genotypes);
-                                                                    // Update our return value
-                                                                    detail::update_data_matrix(
-                                                                        mut->key,
-                                                                        pos,
-                                                                        mut->neutral,
-                                                                        genotypes,
-                                                                        rv);
-                                                                }
-                                                        }
-                                                }
+                                            detail::update_data_matrix(
+                                                mut->key, pos, mut->neutral,
+                                                genotypes, rv);
                                         }
+                                    mut = process_results.second;
+                                    //std::size_t tc
+                                    //    = tree.leaf_counts[mut->node]
+                                    //      + tree.preserved_leaf_counts
+                                    //            [mut->node];
+                                    //if (tc
+                                    //    && (!skip_fixed
+                                    //        || (skip_fixed
+                                    //            && tc < tree.sample_size())))
+                                    //    {
+                                    //        // Mutation leads to a polymorphism
+                                    //        bool is_neutral
+                                    //            = mut->neutral;
+                                    //        if ((is_neutral
+                                    //             && record_neutral)
+                                    //            || (!is_neutral
+                                    //                && record_selected))
+                                    //            {
+                                    //                if (!initialized_site)
+                                    //                    {
+                                    //                        std::fill(
+                                    //                            begin(
+                                    //                                genotypes),
+                                    //                            end(genotypes),
+                                    //                            site_table_location
+                                    //                                ->ancestral_state);
+                                    //                        initialized_site
+                                    //                            = true;
+                                    //                    }
+                                    //                auto index
+                                    //                    = tree.left_sample
+                                    //                          [mut->node];
+                                    //                // Check if mutation leads to a sample
+                                    //                if (index
+                                    //                    != TS_NULL_NODE)
+                                    //                    {
+                                    //                        detail::process_samples(
+                                    //                            tree,
+                                    //                            mut->node,
+                                    //                            index,
+                                    //                            genotypes);
+                                    //                        // Update our return value
+                                    //                        detail::update_data_matrix(
+                                    //                            mut->key,
+                                    //                            pos,
+                                    //                            mut->neutral,
+                                    //                            genotypes,
+                                    //                            rv);
+                                    //                    }
+                                    //            }
+                                    //    }
                                 }
                         }
                     // Terminate early if we're lucky

--- a/fwdpp/ts/generate_data_matrix.hpp
+++ b/fwdpp/ts/generate_data_matrix.hpp
@@ -31,69 +31,96 @@ namespace fwdpp
                 }
             auto mut = tables.mutation_table.cbegin();
             const auto mut_end = tables.mutation_table.cend();
+            auto site_table_location = begin(tables.site_table);
+            const auto site_table_end = end(tables.site_table);
             tree_visitor tv(tables, std::forward<SAMPLES>(samples),
                             update_samples_list(true));
             std::vector<std::int8_t> genotypes(samples.size(), 0);
             data_matrix rv(samples.size());
             while (tv())
                 {
-                    // Advance the mutation table records until we are
-                    // in the current tree
                     const auto& tree = tv.tree();
-                    while (mut < mut_end
-                           && tables.site_table[mut->site].position
-                                  < tree.left)
+                    // Advance site table to start of tree:
+                    while (site_table_location < site_table_end
+                           && site_table_location->position < tree.left)
                         {
-                            ++mut;
+                            ++site_table_location;
                         }
                     // Process mutations on this tree
-                    for (;
-                         mut < mut_end
-                         && tables.site_table[mut->site].position < tree.right;
-                         ++mut)
+                    for (; site_table_location < site_table_end
+                           && site_table_location->position < tree.right;
+                         ++site_table_location)
                         {
-                            auto pos = tables.site_table[mut->site].position;
+                            auto pos = site_table_location->position;
                             if (pos >= start)
                                 {
                                     if (!(pos < stop))
                                         {
                                             return rv;
                                         }
-                                    std::size_t tc
-                                        = tree.leaf_counts[mut->node]
-                                          + tree.preserved_leaf_counts
-                                                [mut->node];
-                                    if (!skip_fixed
-                                        || (skip_fixed
-                                            && tc < tree.sample_size()))
+                                    //catch the mutation table up
+                                    //to the site table
+                                    while (mut < mut_end
+                                           && tables.site_table[mut->site]
+                                                      .position
+                                                  != pos)
                                         {
-                                            // Mutation leads to a polymorphism
-                                            bool is_neutral = mut->neutral;
-                                            if ((is_neutral && record_neutral)
-                                                || (!is_neutral
-                                                    && record_selected))
+                                            ++mut;
+                                        }
+                                    bool initialized_site = false;
+                                    for (; mut < mut_end
+                                           && tables.site_table[mut->site]
+                                                      .position
+                                                  == pos;
+                                         ++mut)
+                                        {
+                                            std::size_t tc
+                                                = tree.leaf_counts[mut->node]
+                                                  + tree.preserved_leaf_counts
+                                                        [mut->node];
+                                            if (!skip_fixed
+                                                || (skip_fixed
+                                                    && tc < tree.sample_size()))
                                                 {
-                                                    auto index
-                                                        = tree.left_sample
-                                                              [mut->node];
-                                                    // Check if mutation leads to a sample
-                                                    if (index != TS_NULL_NODE)
+                                                    // Mutation leads to a polymorphism
+                                                    bool is_neutral
+                                                        = mut->neutral;
+                                                    if ((is_neutral
+                                                         && record_neutral)
+                                                        || (!is_neutral
+                                                            && record_selected))
                                                         {
-                                                            detail::
-                                                                process_samples(
-                                                                    tree,
-                                                                    mut->node,
-                                                                    index,
-                                                                    genotypes);
-                                                            // Update our return value
-                                                            detail::update_data_matrix(
-                                                                mut->key,
-                                                                tables
-                                                                    .site_table
-                                                                        [mut->site]
-                                                                    .position,
-                                                                mut->neutral,
-                                                                genotypes, rv);
+                                                            if (!initialized_site)
+                                                                {
+                                                                    std::fill(
+                                                                        begin(
+                                                                            genotypes),
+                                                                        end(genotypes),
+                                                                        site_table_location
+                                                                            ->ancestral_state);
+                                                                    initialized_site
+                                                                        = true;
+                                                                }
+                                                            auto index
+                                                                = tree.left_sample
+                                                                      [mut->node];
+                                                            // Check if mutation leads to a sample
+                                                            if (index
+                                                                != TS_NULL_NODE)
+                                                                {
+                                                                    detail::process_samples(
+                                                                        tree,
+                                                                        mut->node,
+                                                                        index,
+                                                                        genotypes);
+                                                                    // Update our return value
+                                                                    detail::update_data_matrix(
+                                                                        mut->key,
+                                                                        pos,
+                                                                        mut->neutral,
+                                                                        genotypes,
+                                                                        rv);
+                                                                }
                                                         }
                                                 }
                                         }

--- a/fwdpp/ts/mutate_tables.hpp
+++ b/fwdpp/ts/mutate_tables.hpp
@@ -122,6 +122,7 @@ namespace fwdpp
                         }
                     nmuts += nm;
                 }
+            tables.sort_mutations_rebuild_site_table();
             return nmuts;
         }
     } // namespace ts

--- a/fwdpp/ts/mutate_tables.hpp
+++ b/fwdpp/ts/mutate_tables.hpp
@@ -7,6 +7,7 @@
 #include "definitions.hpp"
 #include "mark_multiple_roots.hpp"
 #include "table_collection.hpp"
+#include "mutation_tools.hpp"
 
 namespace fwdpp
 {
@@ -35,9 +36,9 @@ namespace fwdpp
         /// The result of this function is to populate \a tables.mutation_table with neutral variants.
         ///
         /// The parameter \a make_mutation is a function that must conform to
-        /// std::function<std::size_t(double, double, fwdpp::uint_t)>.  The three arguments
+        /// std::function<new_variant_record(double, double, fwdpp::uint_t)>.  The three arguments
         /// are interpreted as "left", "right", and "time".  The function's return value
-        /// corresponds to the index of the new mutation in the simulation's mutation container.
+        /// allows us to properly update the site and mutation tables in \a tables.
         /// The new mutation must have a position on the half-open interval [left, right). The
         /// "time" parameger represents the generation when the mutation arose and will be
         /// uniformly assigned between the parental birth time and that of the child.
@@ -89,10 +90,14 @@ namespace fwdpp
                                 {
                                     unsigned g = static_cast<unsigned>(
                                         gsl_ran_flat(r.get(), 1, dt + 1));
-                                    auto k
+                                    new_variant_record r
                                         = make_mutation(j.first, j.second, g);
+                                    auto site = tables.emplace_back_site(
+                                        std::move(r.s));
                                     tables.mutation_table.emplace_back(
-                                        mutation_record{ i.first, k });
+                                        mutation_record{ i.first, r.key, site,
+                                                         r.derived_state,
+                                                         r.neutral });
                                 }
                         }
                 }
@@ -107,9 +112,13 @@ namespace fwdpp
                         {
                             unsigned g = static_cast<unsigned>(
                                 gsl_ran_flat(r.get(), pt + 1, ct + 1));
-                            auto k = make_mutation(e.left, e.right, g);
+                            new_variant_record r
+                                = make_mutation(e.left, e.right, g);
+                            auto site
+                                = tables.emplace_back_site(std::move(r.s));
                             tables.mutation_table.emplace_back(
-                                mutation_record{ e.child, k });
+                                mutation_record{ e.child, r.key, site,
+                                                 r.derived_state, r.neutral });
                         }
                     nmuts += nm;
                 }

--- a/fwdpp/ts/mutation_record.hpp
+++ b/fwdpp/ts/mutation_record.hpp
@@ -18,15 +18,17 @@ namespace fwdpp
             /// The index of the mutation in the
             /// population's mutation container
             std::size_t key;
-            double position;
-            std::int32_t derived_state; // TODO: should this be a template type?
+            /// Character state of the mutation
+            std::int8_t derived_state; // TODO: should this be a template type?
+            /// True if mutation affects fitness, otherwise false.
             bool neutral;
         };
 
         inline bool
         operator==(const mutation_record& a, const mutation_record& b)
         {
-            return std::tie(a.node, a.key) == std::tie(b.node, b.key);
+            return std::tie(a.node, a.key, a.derived_state, a.neutral)
+                   == std::tie(b.node, b.key, b.derived_state, b.neutral);
         }
     } // namespace ts
 } // namespace fwdpp

--- a/fwdpp/ts/mutation_record.hpp
+++ b/fwdpp/ts/mutation_record.hpp
@@ -18,6 +18,9 @@ namespace fwdpp
             /// The index of the mutation in the
             /// population's mutation container
             std::size_t key;
+            double position;
+            std::int32_t derived_state; // TODO: should this be a template type?
+            bool neutral;
         };
 
         inline bool

--- a/fwdpp/ts/mutation_record.hpp
+++ b/fwdpp/ts/mutation_record.hpp
@@ -19,7 +19,7 @@ namespace fwdpp
             /// population's mutation container
             std::size_t key;
             /// Row in the site table.
-            std::size_t site_id;
+            std::size_t site;
             /// Character state of the mutation
             std::int8_t derived_state; // TODO: should this be a template type?
             /// True if mutation affects fitness, otherwise false.
@@ -29,13 +29,12 @@ namespace fwdpp
         inline bool
         operator==(const mutation_record& a, const mutation_record& b)
         {
-            if (a.site_id == b.site_id)
-                {
-                    return std::tie(a.node, a.key, a.derived_state, a.neutral)
-                           == std::tie(b.node, b.key, b.derived_state,
-                                       b.neutral);
-                }
-            return false;
+            // Test site first b/c two mutations cannot be equal
+            // if they aren't at the same site.
+            return a.site == b.site
+                   && std::tie(a.node, a.key, a.derived_state, a.neutral)
+                          == std::tie(b.node, b.key, b.derived_state,
+                                      b.neutral);
         }
     } // namespace ts
 } // namespace fwdpp

--- a/fwdpp/ts/mutation_record.hpp
+++ b/fwdpp/ts/mutation_record.hpp
@@ -18,6 +18,8 @@ namespace fwdpp
             /// The index of the mutation in the
             /// population's mutation container
             std::size_t key;
+            /// Row in the site table.
+            std::size_t site_id;
             /// Character state of the mutation
             std::int8_t derived_state; // TODO: should this be a template type?
             /// True if mutation affects fitness, otherwise false.
@@ -27,8 +29,13 @@ namespace fwdpp
         inline bool
         operator==(const mutation_record& a, const mutation_record& b)
         {
-            return std::tie(a.node, a.key, a.derived_state, a.neutral)
-                   == std::tie(b.node, b.key, b.derived_state, b.neutral);
+            if (a.site_id == b.site_id)
+                {
+                    return std::tie(a.node, a.key, a.derived_state, a.neutral)
+                           == std::tie(b.node, b.key, b.derived_state,
+                                       b.neutral);
+                }
+            return false;
         }
     } // namespace ts
 } // namespace fwdpp

--- a/fwdpp/ts/mutation_tools.hpp
+++ b/fwdpp/ts/mutation_tools.hpp
@@ -1,0 +1,24 @@
+#ifndef FWDPP_TS_MUTATION_TOOLS_HPP__
+#define FWDPP_TS_MUTATION_TOOLS_HPP__
+
+#include "site.hpp"
+
+namespace fwdpp
+{
+    namespace ts
+    {
+        struct new_variant_record
+        {
+            site s;
+            std::size_t key;
+            new_variant_record(double position, std::int8_t ancestral_state,
+                               std::size_t index)
+                : s{ position, ancestral_state }, key{ index }
+            /// \version 0.8.0 Added to library
+            {
+            }
+        };
+    } // namespace ts
+} // namespace fwdpp
+
+#endif

--- a/fwdpp/ts/mutation_tools.hpp
+++ b/fwdpp/ts/mutation_tools.hpp
@@ -11,9 +11,12 @@ namespace fwdpp
         {
             site s;
             std::size_t key;
+            bool neutral;
+            std::int8_t derived_state;
             new_variant_record(double position, std::int8_t ancestral_state,
-                               std::size_t index)
-                : s{ position, ancestral_state }, key{ index }
+                               std::size_t index, bool n, std::int8_t d)
+                : s{ position, ancestral_state }, key{ index }, neutral{ n },
+                  derived_state{ d }
             /// \version 0.8.0 Added to library
             {
             }

--- a/fwdpp/ts/serialization.hpp
+++ b/fwdpp/ts/serialization.hpp
@@ -203,10 +203,12 @@ namespace fwdpp
                 sw(o, &tables.edge_offset);
                 std::size_t num_edges = tables.edge_table.size(),
                             num_nodes = tables.num_nodes(),
-                            num_mutations = tables.mutation_table.size();
+                            num_mutations = tables.mutation_table.size(),
+                            num_sites = tables.site_table.size();
                 sw(o, &num_edges);
                 sw(o, &num_nodes);
                 sw(o, &num_mutations);
+                sw(o, &num_sites);
                 if (!tables.edge_table.empty())
                     {
                         o.write(reinterpret_cast<const char*>(
@@ -225,6 +227,12 @@ namespace fwdpp
                                     tables.mutation_table.data()),
                                 tables.mutation_table.size()
                                     * sizeof(mutation_record));
+                    }
+                if (!tables.site_table.empty())
+                    {
+                        o.write(reinterpret_cast<const char*>(
+                                    tables.site_table.data()),
+                                tables.site_table.size() * sizeof(site));
                     }
                 std::size_t num_preserved_samples
                     = tables.preserved_nodes.size();
@@ -263,19 +271,15 @@ namespace fwdpp
                 std::uint32_t format;
                 fwdpp::io::scalar_reader sr;
                 sr(i, &format);
-                //if (format != TS_TABLES_VERSION)
-                //    {
-                //        throw std::runtime_error(
-                //            "invalid serialization version detected");
-                //    }
                 double L;
                 sr(i, &L);
                 table_collection tables(L);
                 sr(i, &tables.edge_offset);
-                std::size_t num_edges, num_nodes, num_mutations;
+                std::size_t num_edges, num_nodes, num_mutations, num_sites;
                 sr(i, &num_edges);
                 sr(i, &num_nodes);
                 sr(i, &num_mutations);
+                sr(i, &num_sites);
                 if (format == TS_TABLES_VERSION)
                     {
                         tables.edge_table.resize(num_edges);
@@ -290,6 +294,10 @@ namespace fwdpp
                         i.read(reinterpret_cast<char*>(
                                    tables.mutation_table.data()),
                                num_mutations * sizeof(mutation_record));
+                        tables.site_table.resize(num_sites);
+                        i.read(
+                            reinterpret_cast<char*>(tables.site_table.data()),
+                            num_mutations * sizeof(site));
                     }
                 else if (format == 1)
                     {

--- a/fwdpp/ts/serialization.hpp
+++ b/fwdpp/ts/serialization.hpp
@@ -304,7 +304,7 @@ namespace fwdpp
                         tables.site_table.resize(num_sites);
                         i.read(
                             reinterpret_cast<char*>(tables.site_table.data()),
-                            num_mutations * sizeof(site));
+                            num_sites * sizeof(site));
                     }
                 else if (format == 1)
                     {

--- a/fwdpp/ts/serialization_version.hpp
+++ b/fwdpp/ts/serialization_version.hpp
@@ -11,8 +11,9 @@ namespace fwdpp
 			/*! \brief Current version number of binary formats
 			 *  \version 0.7.0 Added to library
              *  \version 0.7.4 Updated value to 2
+             *  \version 0.8.0 Updated value to 3
 			 */
-            constexpr const std::uint32_t TS_TABLES_VERSION = 2;
+            constexpr const std::uint32_t TS_TABLES_VERSION = 3;
         }
     } // namespace ts
 } // namespace fwdpp

--- a/fwdpp/ts/site.hpp
+++ b/fwdpp/ts/site.hpp
@@ -17,6 +17,12 @@ namespace fwdpp
         };
 
         inline bool
+        operator<(const site& a, const site& b)
+        {
+            return a.position < b.position;
+        }
+
+        inline bool
         operator==(const site& a, const site& b)
         {
             return std::tie(a.position, a.ancestral_state)

--- a/fwdpp/ts/site.hpp
+++ b/fwdpp/ts/site.hpp
@@ -1,0 +1,29 @@
+#ifndef FWDPP_TS_SITE_HPP
+#define FWDPP_TS_SITE_HPP
+
+#include <tuple>
+#include <cstdint>
+
+namespace fwdpp
+{
+    namespace ts
+    {
+        struct site
+        /// Entry in a site table
+        /// \version 0.8.0 Added to llibrary
+        {
+            double position;
+            std::int8_t ancestral_state;
+        };
+
+        inline bool
+        operator==(const site& a, const site& b)
+        {
+            return std::tie(a.position, a.ancestral_state)
+                   == std::tie(b.position, b.ancestral_state);
+        }
+    } // namespace ts
+} // namespace fwdpp
+
+#endif
+

--- a/fwdpp/ts/table_collection.hpp
+++ b/fwdpp/ts/table_collection.hpp
@@ -435,16 +435,9 @@ namespace fwdpp
             }
 
             void
-            sort_mutations_rebuild_site_table()
-            /// O(n*log(n)) time plus O(n) additional memory.
+            rebuild_site_table()
+            /// Complete rebuild of the site table.
             {
-                std::sort(begin(mutation_table), end(mutation_table),
-                          [this](const mutation_record& a,
-                                 const mutation_record& b) {
-                              return site_table[a.site].position
-                                     < site_table[b.site].position;
-                          });
-
                 auto site_table_copy(site_table);
                 site_table.clear();
                 for (auto& mr : mutation_table)
@@ -459,6 +452,17 @@ namespace fwdpp
                                     "error rebuilding site table");
                             }
                     }
+            }
+
+            void
+            sort_mutations_rebuild_site_table()
+            /// O(n*log(n)) time plus O(n) additional memory.
+            /// This is called by sort_tables, but also should
+            /// be called after adding mutations by some manual
+            /// means to a table collection.
+            {
+                sort_mutations();
+                rebuild_site_table();
                 if (site_table.size() != mutation_table.size())
                     {
                         throw std::runtime_error(

--- a/fwdpp/ts/table_collection.hpp
+++ b/fwdpp/ts/table_collection.hpp
@@ -12,29 +12,13 @@
 #include <stdexcept>
 #include <fwdpp/forward_types.hpp>
 #include <fwdpp/ts/exceptions.hpp>
-#include "node.hpp"
-#include "edge.hpp"
-#include "site.hpp"
-#include "mutation_record.hpp"
+#include "table_types.hpp"
 #include "indexed_edge.hpp" //TODO: create fewer header dependencies
 
 namespace fwdpp
 {
     namespace ts
     {
-        /// An "edge table"
-        ///  \version 0.7.0 Added to fwdpp
-        using edge_vector = std::vector<edge>;
-        /// A "node table"
-        ///  \version 0.7.0 Added to fwdpp
-        using node_vector = std::vector<node>;
-        /// A "mutation table"
-        ///  \version 0.7.0 Added to fwdpp
-        using mutation_key_vector = std::vector<mutation_record>;
-        /// \brief Site table
-        /// \version 0.8.0 Added to fwdpp
-        using site_vector = std::vector<site>;
-
         struct table_collection
         /*!
 		 * \brief A collection of tables for a single simulation.

--- a/fwdpp/ts/table_collection.hpp
+++ b/fwdpp/ts/table_collection.hpp
@@ -361,11 +361,13 @@ namespace fwdpp
             }
 
             void
-            add_offspring_data(
+            register_diploid_offspring(
                 const TS_NODE_INT next_index,
                 const std::vector<double>& breakpoints,
                 const std::tuple<TS_NODE_INT, TS_NODE_INT>& parents,
                 const std::int32_t population, const double time)
+			// TODO: decide if next_index needs to be part of the 
+			// API.  It should be the return value, right?
             {
                 // TODO: carefully document how to index node times.
                 emplace_back_node(population, time);
@@ -380,8 +382,8 @@ namespace fwdpp
                 const std::tuple<TS_NODE_INT, TS_NODE_INT>& parents,
                 const std::int32_t population, const double time)
             {
-                add_offspring_data(next_index, breakpoints, parents,
-                                   population, time);
+                register_diploid_offspring(next_index, breakpoints, parents,
+                                           population, time);
                 for (auto& m : new_mutations)
                     {
                         mutation_table.emplace_back(

--- a/fwdpp/ts/table_collection.hpp
+++ b/fwdpp/ts/table_collection.hpp
@@ -13,6 +13,7 @@
 #include <fwdpp/forward_types.hpp>
 #include "node.hpp"
 #include "edge.hpp"
+#include "site.hpp"
 #include "mutation_record.hpp"
 #include "indexed_edge.hpp" //TODO: create fewer header dependencies
 
@@ -29,6 +30,9 @@ namespace fwdpp
         /// A "mutation table"
         ///  \version 0.7.0 Added to fwdpp
         using mutation_key_vector = std::vector<mutation_record>;
+        /// \brief Site table
+        /// \version 0.8.0 Added to fwdpp
+        using site_vector = std::vector<site>;
 
         struct table_collection
         /*!
@@ -139,6 +143,8 @@ namespace fwdpp
             edge_vector edge_table;
             /// Mutation table for this simulation;
             mutation_key_vector mutation_table;
+            /// Site table
+            site_vector site_table;
             /// The input edge vector. "I" in \cite Kelleher2016-cb, page 13
             indexed_edge_container input_left;
             /// The output edge vector. "O" in \cite Kelleher2016-cb, page 13
@@ -153,7 +159,7 @@ namespace fwdpp
 
             explicit table_collection(const double maxpos)
                 : L{ maxpos }, node_table{}, edge_table{}, mutation_table{},
-                  input_left{}, output_right{}, edge_offset{ 0 },
+                  site_table{}, input_left{}, output_right{}, edge_offset{ 0 },
                   preserved_nodes{}
             {
                 if (maxpos < 0 || !std::isfinite(maxpos))
@@ -167,7 +173,7 @@ namespace fwdpp
                              const double initial_time, TS_NODE_INT pop,
                              const double maxpos)
                 : L{ maxpos }, node_table{}, edge_table{}, mutation_table{},
-                  input_left{}, output_right{}, edge_offset{ 0 },
+                  site_table{}, input_left{}, output_right{}, edge_offset{ 0 },
                   preserved_nodes{}
             {
                 if (maxpos < 0 || !std::isfinite(maxpos))
@@ -407,6 +413,7 @@ namespace fwdpp
         operator==(const table_collection& a, const table_collection& b)
         {
             return a.genome_length() == b.genome_length()
+                   && a.site_table == b.site_table
                    && a.edge_table == b.edge_table
                    && a.node_table == b.node_table
                    && a.mutation_table == b.mutation_table

--- a/fwdpp/ts/table_collection.hpp
+++ b/fwdpp/ts/table_collection.hpp
@@ -458,11 +458,6 @@ namespace fwdpp
             {
                 sort_mutations();
                 rebuild_site_table();
-                if (site_table.size() != mutation_table.size())
-                    {
-                        throw std::runtime_error(
-                            "error rebuilding site table");
-                    }
             }
 
             std::size_t

--- a/fwdpp/ts/table_collection.hpp
+++ b/fwdpp/ts/table_collection.hpp
@@ -241,28 +241,31 @@ namespace fwdpp
                 assert(edges_are_sorted());
             }
 
-            template <typename mutation_container>
             void
-            sort_mutations(const mutation_container& mutations)
+            sort_mutations()
             {
+                if (site_table.size() != mutation_table.size())
+                    {
+                        throw std::runtime_error(
+                            "mutation and site table sizes differ");
+                    }
                 //mutations are sorted by increasing position
                 std::sort(mutation_table.begin(), mutation_table.end(),
-                          [&mutations](const mutation_record& a,
-                                       const mutation_record& b) {
-                              return mutations[a.key].pos
-                                     < mutations[b.key].pos;
+                          [this](const mutation_record& a,
+                                 const mutation_record& b) {
+                              return site_table[a.site].position
+                                     < site_table[b.site].position;
                           });
             }
 
-            template <typename mutation_container>
             void
-            sort_tables(const mutation_container& mutations)
-            /// Sorts the tables
-            /// Note that mutations can be mocked via any struct
-            /// containing double pos
+            sort_tables_for_simplification()
+            /// Sorts the tables for simplification, which means only
+            /// sorting edge and mutation tables, as the site table
+            /// will be rebuilt during simplification.
             {
                 sort_edges();
-                sort_mutations(mutations);
+                sort_mutations();
             }
 
             bool
@@ -443,7 +446,8 @@ namespace fwdpp
                 for (auto& mr : mutation_table)
                     {
                         auto os = mr.site;
-                        record_site_during_rebuild(site_table_copy[mr.site], mr);
+                        record_site_during_rebuild(site_table_copy[mr.site],
+                                                   mr);
                         if (site_table_copy[os].position
                             != site_table[mr.site].position)
                             {

--- a/fwdpp/ts/table_collection.hpp
+++ b/fwdpp/ts/table_collection.hpp
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <stdexcept>
 #include <fwdpp/forward_types.hpp>
+#include <fwdpp/ts/exceptions.hpp>
 #include "node.hpp"
 #include "edge.hpp"
 #include "site.hpp"
@@ -69,8 +70,7 @@ namespace fwdpp
                                        : L;
                         if (b <= a)
                             {
-                                throw std::runtime_error(
-                                    "right must be > left");
+                                throw std::invalid_argument("right must be > left");
                             }
                         if (j % 2 == 0.)
                             {
@@ -423,7 +423,7 @@ namespace fwdpp
                 auto next_index = emplace_back_node(population, time);
                 if (next_index >= std::numeric_limits<TS_NODE_INT>::max())
                     {
-                        throw std::runtime_error("node index too large");
+                        throw std::invalid_argument("node index too large");
                     }
                 split_breakpoints(breakpoints, parents, next_index);
                 return next_index;
@@ -443,7 +443,7 @@ namespace fwdpp
                         if (site_table_copy[os].position
                             != site_table[mr.site].position)
                             {
-                                throw std::runtime_error(
+                                throw tables_error(
                                     "error rebuilding site table");
                             }
                     }
@@ -510,7 +510,7 @@ namespace fwdpp
                                                          ancestral_state);
                     if (site >= std::numeric_limits<TS_NODE_INT>::max())
                         {
-                            throw std::runtime_error(
+                            throw std::invalid_argument(
                                 "site index out of range");
                         }
                     tables.push_back_mutation(u, k, site, derived_state,

--- a/fwdpp/ts/table_collection.hpp
+++ b/fwdpp/ts/table_collection.hpp
@@ -338,18 +338,20 @@ namespace fwdpp
                 return node_table.size() - 1;
             }
 
-            void
+            std::size_t
             push_back_edge(double l, double r, TS_NODE_INT parent,
                            TS_NODE_INT child)
             {
                 edge_table.push_back(edge{ l, r, parent, child });
+                return edge_table.size();
             }
 
             template <typename... args>
-            void
+            std::size_t
             emplace_back_edge(args&&... Args)
             {
                 edge_table.emplace_back(edge{ std::forward<args>(Args)... });
+                return edge_table.size();
             }
 
             template <typename... args>
@@ -369,19 +371,21 @@ namespace fwdpp
             }
 
             template <typename... args>
-            void
+            std::size_t
             push_back_mutation(args&&... Args)
             {
                 mutation_table.push_back(
                     mutation_record{ std::forward<args>(Args)... });
+                return mutation_table.size() - 1;
             }
 
             template <typename... args>
-            void
+            std::size_t
             emplace_back_mutation(args&&... Args)
             {
                 mutation_table.emplace_back(
                     mutation_record{ std::forward<args>(Args)... });
+                return mutation_table.size() - 1;
             }
 
             void

--- a/fwdpp/ts/table_collection.hpp
+++ b/fwdpp/ts/table_collection.hpp
@@ -298,14 +298,12 @@ namespace fwdpp
             void
             clear() noexcept
             /// Clears internal vectors.
-            /// Mostly used during simplification
-            /// where a table_collection is
-            /// used as a temp object.
             {
                 node_table.clear();
                 edge_table.clear();
                 mutation_table.clear();
                 preserved_nodes.clear();
+                site_table.clear();
             }
 
             void

--- a/fwdpp/ts/table_collection.hpp
+++ b/fwdpp/ts/table_collection.hpp
@@ -423,8 +423,6 @@ namespace fwdpp
                 const std::vector<double>& breakpoints,
                 const std::tuple<TS_NODE_INT, TS_NODE_INT>& parents,
                 const std::int32_t population, const double time)
-            // TODO: decide if next_index needs to be part of the
-            // API.  It should be the return value, right?
             {
                 // TODO: carefully document how to index node times.
                 auto next_index = emplace_back_node(population, time);

--- a/fwdpp/ts/table_collection.hpp
+++ b/fwdpp/ts/table_collection.hpp
@@ -136,6 +136,19 @@ namespace fwdpp
                     }
             }
 
+            template <typename mcont_t>
+            void
+            record_site(const site_vector& sites, const mcont_t& mutations,
+                        mutation_record& mr)
+            {
+                double pos = mutations[mr.key].pos;
+                if (site_table.empty() || site_table.back().position != pos)
+                    {
+                        emplace_back_site(sites[mr.site], pos);
+                    }
+                mr.site = site_table.size() - 1;
+            }
+
           public:
             /// Node table for this simulation
             node_vector node_table;
@@ -410,6 +423,20 @@ namespace fwdpp
                     }
                 split_breakpoints(breakpoints, parents, next_index);
                 return next_index;
+            }
+
+            template <typename mcont_t>
+            void
+            rebuild_site_table(const mcont_t& mutations)
+            /// O(n) time plus O(n) additional memory.
+            {
+                auto new_site_table(site_table);
+                site_table.clear();
+                for (auto& mr : mutation_table)
+                    {
+                        record_site(new_site_table, mutations, mr);
+                    }
+                site_table.swap(new_site_table);
             }
 
             std::size_t

--- a/fwdpp/ts/table_collection.hpp
+++ b/fwdpp/ts/table_collection.hpp
@@ -136,15 +136,15 @@ namespace fwdpp
                     }
             }
 
-            template <typename mcont_t>
             void
-            record_site(const site_vector& sites, const mcont_t& mutations,
-                        mutation_record& mr)
+            record_site_during_rebuild(const site_vector& sites,
+                                       mutation_record& mr)
             {
-                double pos = mutations[mr.key].pos;
+                double pos = sites[mr.site].position;
                 if (site_table.empty() || site_table.back().position != pos)
                     {
-                        emplace_back_site(sites[mr.site], pos);
+                        emplace_back_site(sites[mr.site].position,
+                                          sites[mr.site].ancestral_state);
                     }
                 mr.site = site_table.size() - 1;
             }
@@ -429,16 +429,15 @@ namespace fwdpp
                 return next_index;
             }
 
-            template <typename mcont_t>
             void
-            rebuild_site_table(const mcont_t& mutations)
+            rebuild_site_table()
             /// O(n) time plus O(n) additional memory.
             {
                 auto new_site_table(site_table);
                 site_table.clear();
                 for (auto& mr : mutation_table)
                     {
-                        record_site(new_site_table, mutations, mr);
+                        record_site_during_rebuild(new_site_table, mr);
                     }
                 site_table.swap(new_site_table);
             }

--- a/fwdpp/ts/table_collection.hpp
+++ b/fwdpp/ts/table_collection.hpp
@@ -268,6 +268,14 @@ namespace fwdpp
                 sort_mutations();
             }
 
+            void
+            sort_tables()
+            /// Sort all tables.  The site table is rebuilt.
+            {
+                sort_edges();
+                sort_mutations_rebuild_site_table();
+            }
+
             bool
             edges_are_sorted() const noexcept
             /// Test the MINIMAL sorting requirement.

--- a/fwdpp/ts/table_collection.hpp
+++ b/fwdpp/ts/table_collection.hpp
@@ -337,6 +337,36 @@ namespace fwdpp
                 edge_table.emplace_back(edge{ std::forward<args>(Args)... });
             }
 
+            template <typename... args>
+            void
+            push_back_site(args&&... Args)
+            {
+                site_table.push_back(site{ std::forward<args>(Args)... });
+            }
+
+            template <typename... args>
+            void
+            emplace_back_site(args&&... Args)
+            {
+                site_table.emplace_back(site{ std::forward<args>(Args)... });
+            }
+
+            template <typename... args>
+            void
+            push_back_mutation(args&&... Args)
+            {
+                mutation_table.push_back(
+                    mutation_record{ std::forward<args>(Args)... });
+            }
+
+            template <typename... args>
+            void
+            emplace_back_mutation(args&&... Args)
+            {
+                mutation_table.emplace_back(
+                    mutation_record{ std::forward<args>(Args)... });
+            }
+
             void
             build_indexes()
             /// Generates the index vectors referred to
@@ -366,8 +396,8 @@ namespace fwdpp
                 const std::vector<double>& breakpoints,
                 const std::tuple<TS_NODE_INT, TS_NODE_INT>& parents,
                 const std::int32_t population, const double time)
-			// TODO: decide if next_index needs to be part of the 
-			// API.  It should be the return value, right?
+            // TODO: decide if next_index needs to be part of the
+            // API.  It should be the return value, right?
             {
                 // TODO: carefully document how to index node times.
                 emplace_back_node(population, time);

--- a/fwdpp/ts/table_collection.hpp
+++ b/fwdpp/ts/table_collection.hpp
@@ -244,11 +244,6 @@ namespace fwdpp
             void
             sort_mutations()
             {
-                if (site_table.size() != mutation_table.size())
-                    {
-                        throw std::runtime_error(
-                            "mutation and site table sizes differ");
-                    }
                 //mutations are sorted by increasing position
                 std::sort(mutation_table.begin(), mutation_table.end(),
                           [this](const mutation_record& a,

--- a/fwdpp/ts/table_simplifier.hpp
+++ b/fwdpp/ts/table_simplifier.hpp
@@ -393,8 +393,7 @@ namespace fwdpp
             }
 
             void
-            record_site(const site_vector& sites, const double input_pos,
-                        mutation_record& mr)
+            record_site(const site_vector& sites, mutation_record& mr)
             {
                 double pos = sites[mr.site].position;
                 if (new_site_table.empty()
@@ -472,7 +471,7 @@ namespace fwdpp
                 preserved_variants.reserve(std::distance(itr, mt.end()));
                 for (auto i = mt.begin(); i != itr; ++i)
                     {
-                        record_site(sites, sites[i->site].position, *i);
+                        record_site(sites, *i);
                         preserved_variants.push_back(i->key);
                     }
 

--- a/fwdpp/ts/table_simplifier.hpp
+++ b/fwdpp/ts/table_simplifier.hpp
@@ -163,6 +163,7 @@ namespace fwdpp
             // their allocated memory persistent.
             edge_vector new_edge_table;
             node_vector new_node_table;
+            site_vector new_site_table;
             // segment_queue mimics a min queue of segments w.r.to
             // segment::left.
             std::vector<segment> segment_queue;
@@ -182,6 +183,7 @@ namespace fwdpp
             {
                 new_edge_table.clear();
                 new_node_table.clear();
+                new_site_table.clear();
                 E.clear();
                 // It is tempting to
                 // just clear out each
@@ -500,8 +502,9 @@ namespace fwdpp
 
           public:
             explicit table_simplifier(const double maxpos)
-                : new_edge_table{}, new_node_table{}, segment_queue{},
-                  Ancestry{}, E{}, L{ maxpos }, o{}, mutation_map{}
+                : new_edge_table{}, new_node_table{}, new_site_table{},
+                  segment_queue{}, Ancestry{}, E{}, L{ maxpos }, o{},
+                  mutation_map{}
             {
                 if (maxpos < 0 || !std::isfinite(maxpos))
                     {

--- a/fwdpp/ts/table_types.hpp
+++ b/fwdpp/ts/table_types.hpp
@@ -1,0 +1,29 @@
+#ifndef FWDPP_TS_TABLE_TYPES_HPP
+#define FWDPP_TS_TABLE_TYPES_HPP
+
+#include <vector>
+#include "node.hpp"
+#include "edge.hpp"
+#include "site.hpp"
+#include "mutation_record.hpp"
+
+namespace fwdpp
+{
+    namespace ts
+    {
+        /// An "edge table"
+        ///  \version 0.7.0 Added to fwdpp
+        using edge_vector = std::vector<edge>;
+        /// A "node table"
+        ///  \version 0.7.0 Added to fwdpp
+        using node_vector = std::vector<node>;
+        /// A "mutation table"
+        ///  \version 0.7.0 Added to fwdpp
+        using mutation_key_vector = std::vector<mutation_record>;
+        /// \brief Site table
+        /// \version 0.8.0 Added to fwdpp
+        using site_vector = std::vector<site>;
+    }
+}
+
+#endif

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -49,7 +49,8 @@ tree_sequences_tree_sequence_tests_SOURCES=tree_sequences/tree_sequence_tests.cc
 										tree_sequences/test_root_traversal.cc \
 										tree_sequences/test_node_children_traversal.cc \
 										tree_sequences/independent_implementations.cc \
-										tree_sequences/test_generate_data_matrix.cc
+										tree_sequences/test_generate_data_matrix.cc \
+										tree_sequences/test_table_collection.cc
 
 AM_CXXFLAGS=-W -Wall
 

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -48,7 +48,8 @@ tree_sequences_tree_sequence_tests_SOURCES=tree_sequences/tree_sequence_tests.cc
 										tree_sequences/test_sample_traversal.cc \
 										tree_sequences/test_root_traversal.cc \
 										tree_sequences/test_node_children_traversal.cc \
-										tree_sequences/independent_implementations.cc
+										tree_sequences/independent_implementations.cc \
+										tree_sequences/test_generate_data_matrix.cc
 
 AM_CXXFLAGS=-W -Wall
 

--- a/testsuite/Makefile.in
+++ b/testsuite/Makefile.in
@@ -129,7 +129,8 @@ am__tree_sequences_tree_sequence_tests_SOURCES_DIST =  \
 	tree_sequences/test_root_traversal.cc \
 	tree_sequences/test_node_children_traversal.cc \
 	tree_sequences/independent_implementations.cc \
-	tree_sequences/test_generate_data_matrix.cc
+	tree_sequences/test_generate_data_matrix.cc \
+	tree_sequences/test_table_collection.cc
 @BUNIT_TEST_PRESENT_TRUE@am_tree_sequences_tree_sequence_tests_OBJECTS = tree_sequences/tree_sequence_tests.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_generate_offspring.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_preorder_node_traversal.$(OBJEXT) \
@@ -141,7 +142,8 @@ am__tree_sequences_tree_sequence_tests_SOURCES_DIST =  \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_root_traversal.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_node_children_traversal.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/independent_implementations.$(OBJEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_generate_data_matrix.$(OBJEXT)
+@BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_generate_data_matrix.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_table_collection.$(OBJEXT)
 tree_sequences_tree_sequence_tests_OBJECTS =  \
 	$(am_tree_sequences_tree_sequence_tests_OBJECTS)
 tree_sequences_tree_sequence_tests_LDADD = $(LDADD)
@@ -231,6 +233,7 @@ am__depfiles_remade = fixtures/$(DEPDIR)/sugar_fixtures.Po \
 	tree_sequences/$(DEPDIR)/test_preorder_node_traversal.Po \
 	tree_sequences/$(DEPDIR)/test_root_traversal.Po \
 	tree_sequences/$(DEPDIR)/test_sample_traversal.Po \
+	tree_sequences/$(DEPDIR)/test_table_collection.Po \
 	tree_sequences/$(DEPDIR)/test_tree_visitor.Po \
 	tree_sequences/$(DEPDIR)/tree_sequence_tests.Po \
 	unit/$(DEPDIR)/extensions_callbacksTest.Po \
@@ -658,7 +661,8 @@ top_srcdir = @top_srcdir@
 @BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_root_traversal.cc \
 @BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_node_children_traversal.cc \
 @BUNIT_TEST_PRESENT_TRUE@										tree_sequences/independent_implementations.cc \
-@BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_generate_data_matrix.cc
+@BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_generate_data_matrix.cc \
+@BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_table_collection.cc
 
 @BUNIT_TEST_PRESENT_TRUE@AM_CXXFLAGS = -W -Wall
 all: all-am
@@ -766,6 +770,9 @@ tree_sequences/independent_implementations.$(OBJEXT):  \
 tree_sequences/test_generate_data_matrix.$(OBJEXT):  \
 	tree_sequences/$(am__dirstamp) \
 	tree_sequences/$(DEPDIR)/$(am__dirstamp)
+tree_sequences/test_table_collection.$(OBJEXT):  \
+	tree_sequences/$(am__dirstamp) \
+	tree_sequences/$(DEPDIR)/$(am__dirstamp)
 
 tree_sequences/tree_sequence_tests$(EXEEXT): $(tree_sequences_tree_sequence_tests_OBJECTS) $(tree_sequences_tree_sequence_tests_DEPENDENCIES) $(EXTRA_tree_sequences_tree_sequence_tests_DEPENDENCIES) tree_sequences/$(am__dirstamp)
 	@rm -f tree_sequences/tree_sequence_tests$(EXEEXT)
@@ -867,6 +874,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_preorder_node_traversal.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_root_traversal.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_sample_traversal.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_table_collection.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_tree_visitor.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/tree_sequence_tests.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@unit/$(DEPDIR)/extensions_callbacksTest.Po@am__quote@ # am--include-marker
@@ -1265,6 +1273,7 @@ distclean: distclean-am
 	-rm -f tree_sequences/$(DEPDIR)/test_preorder_node_traversal.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_root_traversal.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_sample_traversal.Po
+	-rm -f tree_sequences/$(DEPDIR)/test_table_collection.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_tree_visitor.Po
 	-rm -f tree_sequences/$(DEPDIR)/tree_sequence_tests.Po
 	-rm -f unit/$(DEPDIR)/extensions_callbacksTest.Po
@@ -1351,6 +1360,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f tree_sequences/$(DEPDIR)/test_preorder_node_traversal.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_root_traversal.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_sample_traversal.Po
+	-rm -f tree_sequences/$(DEPDIR)/test_table_collection.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_tree_visitor.Po
 	-rm -f tree_sequences/$(DEPDIR)/tree_sequence_tests.Po
 	-rm -f unit/$(DEPDIR)/extensions_callbacksTest.Po

--- a/testsuite/Makefile.in
+++ b/testsuite/Makefile.in
@@ -128,7 +128,8 @@ am__tree_sequences_tree_sequence_tests_SOURCES_DIST =  \
 	tree_sequences/test_sample_traversal.cc \
 	tree_sequences/test_root_traversal.cc \
 	tree_sequences/test_node_children_traversal.cc \
-	tree_sequences/independent_implementations.cc
+	tree_sequences/independent_implementations.cc \
+	tree_sequences/test_generate_data_matrix.cc
 @BUNIT_TEST_PRESENT_TRUE@am_tree_sequences_tree_sequence_tests_OBJECTS = tree_sequences/tree_sequence_tests.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_generate_offspring.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_preorder_node_traversal.$(OBJEXT) \
@@ -139,7 +140,8 @@ am__tree_sequences_tree_sequence_tests_SOURCES_DIST =  \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_sample_traversal.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_root_traversal.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_node_children_traversal.$(OBJEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	tree_sequences/independent_implementations.$(OBJEXT)
+@BUNIT_TEST_PRESENT_TRUE@	tree_sequences/independent_implementations.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_generate_data_matrix.$(OBJEXT)
 tree_sequences_tree_sequence_tests_OBJECTS =  \
 	$(am_tree_sequences_tree_sequence_tests_OBJECTS)
 tree_sequences_tree_sequence_tests_LDADD = $(LDADD)
@@ -221,6 +223,7 @@ am__depfiles_remade = fixtures/$(DEPDIR)/sugar_fixtures.Po \
 	integration/$(DEPDIR)/sugar_singlepop_custom_diploidTest.Po \
 	tree_sequences/$(DEPDIR)/independent_implementations.Po \
 	tree_sequences/$(DEPDIR)/test_decapitate.Po \
+	tree_sequences/$(DEPDIR)/test_generate_data_matrix.Po \
 	tree_sequences/$(DEPDIR)/test_generate_offspring.Po \
 	tree_sequences/$(DEPDIR)/test_marginal_tree_statistics.Po \
 	tree_sequences/$(DEPDIR)/test_node_children_traversal.Po \
@@ -654,7 +657,8 @@ top_srcdir = @top_srcdir@
 @BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_sample_traversal.cc \
 @BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_root_traversal.cc \
 @BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_node_children_traversal.cc \
-@BUNIT_TEST_PRESENT_TRUE@										tree_sequences/independent_implementations.cc
+@BUNIT_TEST_PRESENT_TRUE@										tree_sequences/independent_implementations.cc \
+@BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_generate_data_matrix.cc
 
 @BUNIT_TEST_PRESENT_TRUE@AM_CXXFLAGS = -W -Wall
 all: all-am
@@ -759,6 +763,9 @@ tree_sequences/test_node_children_traversal.$(OBJEXT):  \
 tree_sequences/independent_implementations.$(OBJEXT):  \
 	tree_sequences/$(am__dirstamp) \
 	tree_sequences/$(DEPDIR)/$(am__dirstamp)
+tree_sequences/test_generate_data_matrix.$(OBJEXT):  \
+	tree_sequences/$(am__dirstamp) \
+	tree_sequences/$(DEPDIR)/$(am__dirstamp)
 
 tree_sequences/tree_sequence_tests$(EXEEXT): $(tree_sequences_tree_sequence_tests_OBJECTS) $(tree_sequences_tree_sequence_tests_DEPENDENCIES) $(EXTRA_tree_sequences_tree_sequence_tests_DEPENDENCIES) tree_sequences/$(am__dirstamp)
 	@rm -f tree_sequences/tree_sequence_tests$(EXEEXT)
@@ -852,6 +859,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@integration/$(DEPDIR)/sugar_singlepop_custom_diploidTest.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/independent_implementations.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_decapitate.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_generate_data_matrix.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_generate_offspring.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_marginal_tree_statistics.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_node_children_traversal.Po@am__quote@ # am--include-marker
@@ -1249,6 +1257,7 @@ distclean: distclean-am
 	-rm -f integration/$(DEPDIR)/sugar_singlepop_custom_diploidTest.Po
 	-rm -f tree_sequences/$(DEPDIR)/independent_implementations.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_decapitate.Po
+	-rm -f tree_sequences/$(DEPDIR)/test_generate_data_matrix.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_generate_offspring.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_marginal_tree_statistics.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_node_children_traversal.Po
@@ -1334,6 +1343,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f integration/$(DEPDIR)/sugar_singlepop_custom_diploidTest.Po
 	-rm -f tree_sequences/$(DEPDIR)/independent_implementations.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_decapitate.Po
+	-rm -f tree_sequences/$(DEPDIR)/test_generate_data_matrix.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_generate_offspring.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_marginal_tree_statistics.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_node_children_traversal.Po

--- a/testsuite/tree_sequences/simple_table_collection_infinite_sites.hpp
+++ b/testsuite/tree_sequences/simple_table_collection_infinite_sites.hpp
@@ -1,0 +1,48 @@
+#ifndef FWDPP_TESTSUITE_SIMPLE_TABLE_COLLECTION_INFINITE_SITES_HPP
+#define FWDPP_TESTSUITE_SIMPLE_TABLE_COLLECTION_INFINITE_SITES_HPP
+
+#include <cmath>
+#include "simple_table_collection.hpp"
+
+class simple_table_collection_infinite_sites : public simple_table_collection
+{
+  private:
+    static const std::int8_t ancestral_state{ 0 };
+    static const std::int8_t derived_state{ 1 };
+
+  public:
+    simple_table_collection_infinite_sites() : simple_table_collection()
+    {
+        add_x_mutations_per_branch(1, 1);
+    }
+
+    void
+    add_x_mutations_per_branch(int x, int exclude_root)
+    {
+        tables.site_table.clear();
+        tables.mutation_table.clear();
+        // 0.6 is arbitrary.  It just means we won't hit genome_length.
+        double spacing_between_variants
+            = 0.6 * tables.genome_length()
+              / static_cast<double>(
+                  x + (tables.node_table.size() - exclude_root));
+        double next_variant_position = std::nexttoward(0., INFINITY);
+        for (std::size_t i = 0; i < tables.node_table.size() - exclude_root;
+             ++i)
+            {
+                for (int j = 0; j < x; ++j)
+                    {
+                        auto site = tables.emplace_back_site(
+                            next_variant_position, ancestral_state);
+                        tables.emplace_back_mutation(
+                            static_cast<std::int32_t>(i), i + j, site,
+                            derived_state, true);
+
+                        next_variant_position += spacing_between_variants;
+                    }
+            }
+    }
+};
+
+#endif
+

--- a/testsuite/tree_sequences/simple_table_collection_infinite_sites.hpp
+++ b/testsuite/tree_sequences/simple_table_collection_infinite_sites.hpp
@@ -7,11 +7,12 @@
 class simple_table_collection_infinite_sites : public simple_table_collection
 {
   private:
-    static const std::int8_t ancestral_state{ 0 };
-    static const std::int8_t derived_state{ 1 };
+    const std::int8_t ancestral_state;
+    const std::int8_t derived_state;
 
   public:
-    simple_table_collection_infinite_sites() : simple_table_collection()
+    simple_table_collection_infinite_sites()
+        : simple_table_collection(), ancestral_state{ 0 }, derived_state{ 1 }
     {
         add_x_mutations_per_branch(1, 1);
     }

--- a/testsuite/tree_sequences/test_generate_data_matrix.cc
+++ b/testsuite/tree_sequences/test_generate_data_matrix.cc
@@ -3,6 +3,7 @@
 #include <boost/test/unit_test.hpp>
 #include <fwdpp/ts/marginal_tree_functions/roots.hpp>
 #include <fwdpp/ts/marginal_tree_functions/nodes.hpp>
+#include <fwdpp/ts/marginal_tree_functions/samples.hpp>
 #include <fwdpp/ts/generate_data_matrix.hpp>
 #include "simple_table_collection_infinite_sites.hpp"
 
@@ -24,7 +25,7 @@ BOOST_FIXTURE_TEST_CASE(infinite_sites, simple_table_collection_infinite_sites)
 
     for (auto n : nodes)
         {
-            // Exclude the root node from test b/c 
+            // Exclude the root node from test b/c
             // the fixture doesn't put variants there.
             if (std::find(begin(roots), end(roots), n) == end(roots))
                 {
@@ -37,6 +38,22 @@ BOOST_FIXTURE_TEST_CASE(infinite_sites, simple_table_collection_infinite_sites)
             auto c = std::count(begin(rs.first), end(rs.first), i + 1);
             BOOST_CHECK_EQUAL(expected_sfs[i], c);
         }
+}
+
+BOOST_FIXTURE_TEST_CASE(simple_multiple_mutations_test,
+                        simple_table_collection)
+{
+    tables.emplace_back_site(0.1, fwdpp::ts::default_ancestral_state);
+    tables.emplace_back_mutation(4, 0lu, 0lu, fwdpp::ts::default_derived_state,
+                                 true);
+    auto d = fwdpp::ts::default_derived_state;
+    d++;
+    tables.emplace_back_mutation(4, 1lu, 0lu, d, true);
+    auto dm
+        = fwdpp::ts::generate_data_matrix(tables, samples, true, true, false);
+    BOOST_REQUIRE_EQUAL(
+        std::count(begin(dm.neutral.data), end(dm.neutral.data), d),
+        fwdpp::ts::num_samples(tv.tree(), 4));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/testsuite/tree_sequences/test_generate_data_matrix.cc
+++ b/testsuite/tree_sequences/test_generate_data_matrix.cc
@@ -1,0 +1,42 @@
+#include <iostream>
+#include <algorithm>
+#include <boost/test/unit_test.hpp>
+#include <fwdpp/ts/marginal_tree_functions/roots.hpp>
+#include <fwdpp/ts/marginal_tree_functions/nodes.hpp>
+#include <fwdpp/ts/generate_data_matrix.hpp>
+#include "simple_table_collection_infinite_sites.hpp"
+
+BOOST_AUTO_TEST_SUITE(test_generate_data_matrix)
+
+BOOST_FIXTURE_TEST_CASE(infinite_sites, simple_table_collection_infinite_sites)
+// There is exactly one mutation on each node, excluding the root.
+{
+    auto dm
+        = fwdpp::ts::generate_data_matrix(tables, samples, true, true, false);
+    BOOST_REQUIRE_EQUAL(dm.ncol, samples.size());
+    auto rs = fwdpp::row_sums(dm);
+    BOOST_REQUIRE(rs.second.empty());
+    BOOST_REQUIRE_EQUAL(rs.first.size(), tables.node_table.size() - 1);
+    auto roots = fwdpp::ts::get_roots(tv.tree());
+    auto nodes = fwdpp::ts::get_nodes(tv.tree(), fwdpp::ts::nodes_preorder());
+    std::vector<int> expected_sfs(samples.size(),
+                                  0); //includes the fixed class;
+
+    for (auto n : nodes)
+        {
+            // Exclude the root node from test b/c 
+            // the fixture doesn't put variants there.
+            if (std::find(begin(roots), end(roots), n) == end(roots))
+                {
+                    auto lc = tv.tree().leaf_counts[n];
+                    expected_sfs[lc - 1]++;
+                }
+        }
+    for (std::size_t i = 0; i < expected_sfs.size(); ++i)
+        {
+            auto c = std::count(begin(rs.first), end(rs.first), i + 1);
+            BOOST_CHECK_EQUAL(expected_sfs[i], c);
+        }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/testsuite/tree_sequences/test_table_collection.cc
+++ b/testsuite/tree_sequences/test_table_collection.cc
@@ -1,9 +1,10 @@
+#include <iostream>
 #include <boost/test/unit_test.hpp>
 #include <fwdpp/ts/table_collection.hpp>
 
 BOOST_AUTO_TEST_SUITE(test_mutation_and_site_tables)
 
-BOOST_AUTO_TEST_CASE(test_rebuild_one_mutation_per_site)
+BOOST_AUTO_TEST_CASE(test_rebuild_one_mutation_per_site_inconsistent_data)
 {
     fwdpp::ts::table_collection tables(1.);
     tables.emplace_back_site(0.1, fwdpp::ts::default_ancestral_state);
@@ -15,6 +16,23 @@ BOOST_AUTO_TEST_CASE(test_rebuild_one_mutation_per_site)
     BOOST_REQUIRE_EQUAL(tables.site_table.size(), 1);
     BOOST_REQUIRE_EQUAL(tables.mutation_table.size(), 1);
     BOOST_REQUIRE_EQUAL(tables.mutation_table[0].site, 0);
+}
+
+BOOST_AUTO_TEST_CASE(
+    test_rebuild_multiple_mutations_per_site_inconsistent_data)
+{
+    fwdpp::ts::table_collection tables(1.);
+    auto site
+        = tables.emplace_back_site(0.1, fwdpp::ts::default_ancestral_state);
+    tables.emplace_back_mutation(0, 0lu, site,
+                                 fwdpp::ts::default_derived_state, true);
+    site = tables.emplace_back_site(0.1, fwdpp::ts::default_ancestral_state);
+    tables.emplace_back_mutation(1, 1lu, site, std::int8_t{ 2 }, true);
+    tables.sort_mutations_rebuild_site_table();
+    BOOST_REQUIRE_EQUAL(tables.site_table.size(), 1);
+    BOOST_REQUIRE_EQUAL(tables.mutation_table.size(), 2);
+    BOOST_REQUIRE_EQUAL(tables.mutation_table[0].site, 0);
+    BOOST_REQUIRE_EQUAL(tables.mutation_table[1].site, 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/testsuite/tree_sequences/test_table_collection.cc
+++ b/testsuite/tree_sequences/test_table_collection.cc
@@ -1,0 +1,21 @@
+#include <boost/test/unit_test.hpp>
+#include <fwdpp/ts/table_collection.hpp>
+
+BOOST_AUTO_TEST_SUITE(test_mutation_and_site_tables)
+
+BOOST_AUTO_TEST_CASE(test_rebuild_one_mutation_per_site)
+{
+    fwdpp::ts::table_collection tables(1.);
+    tables.emplace_back_site(0.1, fwdpp::ts::default_ancestral_state);
+    tables.emplace_back_site(0.1, fwdpp::ts::default_ancestral_state);
+    // Mutation refers to site 1
+    tables.emplace_back_mutation(0, 0lu, 1lu, fwdpp::ts::default_derived_state,
+                                 true);
+    tables.sort_mutations_rebuild_site_table();
+    BOOST_REQUIRE_EQUAL(tables.site_table.size(), 1);
+    BOOST_REQUIRE_EQUAL(tables.mutation_table.size(), 1);
+    BOOST_REQUIRE_EQUAL(tables.mutation_table[0].site, 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+


### PR DESCRIPTION
* Add a "sites" table.
* Address #194 
* Fixes #213 

- [x] Add sites table
- [x] Rebuild it during simplification
- [x] Test its correction at the end of simulation in example program
- [x] Rework data_matrix_generation to account for derived_state.
- [x] Rework infinite_sites mutation to properly populate mutation fields and the site table.
- [x] Fix #212
- [x] Handle required changes to the binary format.
- [x] Remove template requirement for mutation list for functions that only use it to access mutation position.
- [x] Unit tests.