### PR TITLE
Edge buffering

### DIFF
--- a/fwdpp/ts/Makefile.am
+++ b/fwdpp/ts/Makefile.am
@@ -25,6 +25,8 @@ pkginclude_HEADERS= definitions.hpp \
 			mutation_tools.hpp \
 			table_types.hpp \
 			visit_sites.hpp \
-			site_visitor.hpp
+			site_visitor.hpp \
+			edge_buffer.hpp \
+			diploid_edge_buffer.hpp
 
 

--- a/fwdpp/ts/Makefile.in
+++ b/fwdpp/ts/Makefile.in
@@ -290,7 +290,9 @@ pkginclude_HEADERS = definitions.hpp \
 			mutation_tools.hpp \
 			table_types.hpp \
 			visit_sites.hpp \
-			site_visitor.hpp
+			site_visitor.hpp \
+			edge_buffer.hpp \
+			diploid_edge_buffer.hpp
 
 all: all-am
 

--- a/fwdpp/ts/detail/Makefile.am
+++ b/fwdpp/ts/detail/Makefile.am
@@ -1,4 +1,5 @@
 pkgincludedir=$(prefix)/include/fwdpp/ts/detail
 
 pkginclude_HEADERS= advance_marginal_tree_policies.hpp \
-	generate_data_matrix_details.hpp
+	generate_data_matrix_details.hpp \
+	split_breakpoints.hpp

--- a/fwdpp/ts/detail/Makefile.in
+++ b/fwdpp/ts/detail/Makefile.in
@@ -266,7 +266,8 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 pkginclude_HEADERS = advance_marginal_tree_policies.hpp \
-	generate_data_matrix_details.hpp
+	generate_data_matrix_details.hpp \
+	split_breakpoints.hpp
 
 all: all-am
 

--- a/fwdpp/ts/detail/split_breakpoints.hpp
+++ b/fwdpp/ts/detail/split_breakpoints.hpp
@@ -1,0 +1,121 @@
+#ifndef FWDPP_TS_DETAIL_SPLIT_BREAKPOINTS_HPP
+#define FWDPP_TS_DETAIL_SPLIT_BREAKPOINTS_HPP
+
+#include <vector>
+#include <limits>
+#include <algorithm>
+#include <cassert>
+#include <tuple>
+#include "../definitions.hpp"
+#include "../edge.hpp"
+
+namespace fwdpp
+{
+    namespace ts
+    {
+        namespace detail
+        {
+            template <typename F>
+            void
+            split_breakpoints_add_edges(
+                const std::vector<double>& breakpoints,
+                const std::tuple<TS_NODE_INT, TS_NODE_INT>& parents,
+                const TS_NODE_INT next_index, const double genome_length,
+                const F& f)
+            {
+                if (breakpoints.front() != 0.0)
+                    {
+                        f(edge{ 0.0, breakpoints.front(), std::get<0>(parents),
+                                next_index });
+                        //this->push_back_edge(0., breakpoints.front(),
+                        //                     std::get<0>(parents), next_index);
+                    }
+                // TODO: replace with exception via a debug mode
+                assert(std::count(begin(breakpoints), end(breakpoints),
+                                  std::numeric_limits<double>::max())
+                       == 1);
+                assert(breakpoints.back()
+                       == std::numeric_limits<double>::max());
+                for (unsigned j = 1; j < breakpoints.size(); ++j)
+                    {
+                        double a = breakpoints[j - 1];
+                        double b = (j < breakpoints.size() - 1)
+                                       ? breakpoints[j]
+                                       : genome_length;
+                        if (b <= a)
+                            {
+                                throw std::invalid_argument(
+                                    "right must be > left");
+                            }
+                        if (j % 2 == 0.)
+                            {
+                                f(edge{ a, b, std::get<0>(parents),
+                                        next_index });
+                            }
+                        else
+                            {
+                                f(edge{ a, b, std::get<1>(parents),
+                                        next_index });
+                            }
+                    }
+            }
+
+            template <typename F>
+            void
+            split_breakpoints(
+                const std::vector<double>& breakpoints,
+                const std::tuple<TS_NODE_INT, TS_NODE_INT>& parents,
+                const TS_NODE_INT next_index, const double genome_length,
+                const F& f)
+            {
+                if (breakpoints.empty())
+                    {
+                        f(edge{ 0., genome_length, std::get<0>(parents),
+                                next_index });
+                        return;
+                    }
+                auto itr = std::adjacent_find(std::begin(breakpoints),
+                                              std::end(breakpoints));
+                if (itr == std::end(breakpoints))
+                    {
+                        split_breakpoints_add_edges(breakpoints, parents,
+                                                    next_index, genome_length,
+                                                    f);
+                    }
+                else
+                    {
+                        // Here, we need to reduce the input
+                        // breakpoints to only those seen
+                        // an odd number of times.
+                        // Even numbers of the same breakpoint
+                        // are "double x-overs" and thus
+                        // cannot affect the genealogy.
+                        std::vector<double> odd_breakpoints;
+                        auto start = breakpoints.begin();
+                        while (itr < breakpoints.end())
+                            {
+                                auto not_equal
+                                    = std::find_if(itr, breakpoints.end(),
+                                                   [itr](const double d) {
+                                                       return d != *itr;
+                                                   });
+                                int even = (std::distance(itr, not_equal) % 2
+                                            == 0.0);
+                                odd_breakpoints.insert(odd_breakpoints.end(),
+                                                       start, itr + 1 - even);
+                                start = not_equal;
+                                itr = std::adjacent_find(
+                                    start, std::end(breakpoints));
+                            }
+                        odd_breakpoints.insert(odd_breakpoints.end(), start,
+                                               breakpoints.end());
+                        split_breakpoints_add_edges(odd_breakpoints, parents,
+                                                    next_index, genome_length,
+                                                    f);
+                    }
+            }
+        } // namespace detail
+    }     // namespace ts
+} // namespace fwdpp
+
+#endif

--- a/fwdpp/ts/diploid_edge_buffer.hpp
+++ b/fwdpp/ts/diploid_edge_buffer.hpp
@@ -1,0 +1,54 @@
+#ifndef FWDPP_TS_DIPLOID_EDGE_BUFFER_HPP
+#define FWDPP_TS_DIPLOID_EDGE_BUFFER_HPP
+
+#include <limits>
+#include <tuple>
+#include <stdexcept>
+#include "edge_buffer.hpp"
+#include "detail/split_breakpoints.hpp"
+
+namespace fwdpp
+{
+    namespace ts
+    {
+        using diploid_edge_buffer = edge_buffer<2>;
+
+        inline TS_NODE_INT
+        register_offspring_and_buffer_edges(
+            const std::vector<double>& recombination_breakpoints,
+            std::size_t parent_index,
+            std::tuple<TS_NODE_INT, TS_NODE_INT> parent_nodes,
+            std::int32_t offspring_population, double birth_time,
+            table_collection& tables, diploid_edge_buffer& buffer)
+        {
+            auto offspring_node
+                = tables.emplace_back_node(offspring_population, birth_time);
+            if (offspring_node
+                >= std::numeric_limits<fwdpp::ts::TS_NODE_INT>::max())
+                {
+                    throw std::invalid_argument("node index too large");
+                }
+            std::size_t first_node_index = 0;
+            auto first_node = std::get<0>(parent_nodes);
+            auto second_node = std::get<1>(parent_nodes);
+            if (first_node > second_node)
+                {
+                    first_node_index = 1;
+                }
+            detail::split_breakpoints(
+                recombination_breakpoints, parent_nodes, offspring_node,
+                tables.genome_length(),
+                [parent_index, first_node_index, first_node,
+                 &buffer](edge&& e) {
+                    std::size_t offset = (e.parent == first_node)
+                                             ? first_node_index
+                                             : !first_node_index;
+                    buffer.current_epoch[parent_index][offset].emplace_back(
+                        std::move(e));
+                });
+            return offspring_node;
+        }
+    } // namespace ts
+} // namespace fwdpp
+#endif
+

--- a/fwdpp/ts/edge_buffer.hpp
+++ b/fwdpp/ts/edge_buffer.hpp
@@ -1,0 +1,69 @@
+#ifndef FWDPP_TS_EDGE_BUFFER_HPP
+#define FWDPP_TS_EDGE_BUFFER_HPP
+
+#include <vector>
+#include <utility>
+#include <array>
+#include "table_types.hpp"
+#include "table_collection.hpp"
+
+namespace fwdpp
+{
+    namespace ts
+    {
+        template <std::size_t PLOIDY> struct edge_buffer
+        {
+            std::vector<std::array<edge_vector, PLOIDY>> current_epoch;
+            edge_vector buffer;
+            std::vector<std::pair<std::size_t, std::size_t>> offsets;
+
+            edge_buffer() : current_epoch{}, buffer{}, offsets{} {}
+
+            inline void
+            begin_epoch(std::size_t n)
+            {
+                current_epoch.resize(n);
+            }
+
+            inline void
+            end_epoch()
+            {
+                std::size_t epoch_offset = buffer.size();
+                for (auto&& i : current_epoch)
+                    {
+                        for (auto&& j : i)
+                            {
+                                buffer.insert(end(buffer), begin(j), end(j));
+                                j.clear();
+                            }
+                    }
+                offsets.emplace_back(epoch_offset, buffer.size());
+            };
+
+            inline void
+            prepare_tables_for_simplification(table_collection& tables)
+            {
+                for (auto i = offsets.rbegin(); i < offsets.rend(); ++i)
+                    {
+                        tables.edge_table.insert(end(tables.edge_table),
+                                                 begin(buffer) + i->first,
+                                                 begin(buffer) + i->second);
+                    }
+                buffer.clear();
+                offsets.clear();
+
+                tables.sort_mutations();
+                if (tables.edge_offset > 0)
+                    {
+                        std::rotate(begin(tables.edge_table),
+                                    begin(tables.edge_table)
+                                        + tables.edge_offset,
+                                    end(tables.edge_table));
+                    }
+            }
+        };
+    } // namespace ts
+} // namespace fwdpp
+
+#endif
+

--- a/fwdpp/ts/table_collection.hpp
+++ b/fwdpp/ts/table_collection.hpp
@@ -350,7 +350,8 @@ namespace fwdpp
                     }
                 detail::split_breakpoints(breakpoints, parents, next_index, L,
                                           [this](fwdpp::ts::edge&& e) {
-                                              emplace_back_edge(std::move(e));
+                                              edge_table.push_back(
+                                                  std::move(e));
                                           });
                 return next_index;
             }

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -53,7 +53,8 @@ tree_sequences_tree_sequence_tests_SOURCES=tree_sequences/tree_sequence_tests.cc
 										tree_sequences/test_table_collection.cc \
 										tree_sequences/test_visit_sites.cc \
 										tree_sequences/test_site_visitor.cc \
-										tree_sequences/test_marginal_tree.cc
+										tree_sequences/test_marginal_tree.cc \
+										tree_sequences/test_diploid_edge_buffer.cc
 
 AM_CXXFLAGS=-W -Wall
 

--- a/testsuite/Makefile.in
+++ b/testsuite/Makefile.in
@@ -133,7 +133,8 @@ am__tree_sequences_tree_sequence_tests_SOURCES_DIST =  \
 	tree_sequences/test_table_collection.cc \
 	tree_sequences/test_visit_sites.cc \
 	tree_sequences/test_site_visitor.cc \
-	tree_sequences/test_marginal_tree.cc
+	tree_sequences/test_marginal_tree.cc \
+	tree_sequences/test_diploid_edge_buffer.cc
 @BUNIT_TEST_PRESENT_TRUE@am_tree_sequences_tree_sequence_tests_OBJECTS = tree_sequences/tree_sequence_tests.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_generate_offspring.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_preorder_node_traversal.$(OBJEXT) \
@@ -149,7 +150,8 @@ am__tree_sequences_tree_sequence_tests_SOURCES_DIST =  \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_table_collection.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_visit_sites.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_site_visitor.$(OBJEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_marginal_tree.$(OBJEXT)
+@BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_marginal_tree.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_diploid_edge_buffer.$(OBJEXT)
 tree_sequences_tree_sequence_tests_OBJECTS =  \
 	$(am_tree_sequences_tree_sequence_tests_OBJECTS)
 tree_sequences_tree_sequence_tests_LDADD = $(LDADD)
@@ -231,6 +233,7 @@ am__depfiles_remade = fixtures/$(DEPDIR)/sugar_fixtures.Po \
 	integration/$(DEPDIR)/sugar_singlepop_custom_diploidTest.Po \
 	tree_sequences/$(DEPDIR)/independent_implementations.Po \
 	tree_sequences/$(DEPDIR)/test_decapitate.Po \
+	tree_sequences/$(DEPDIR)/test_diploid_edge_buffer.Po \
 	tree_sequences/$(DEPDIR)/test_generate_data_matrix.Po \
 	tree_sequences/$(DEPDIR)/test_generate_offspring.Po \
 	tree_sequences/$(DEPDIR)/test_marginal_tree.Po \
@@ -674,7 +677,8 @@ top_srcdir = @top_srcdir@
 @BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_table_collection.cc \
 @BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_visit_sites.cc \
 @BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_site_visitor.cc \
-@BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_marginal_tree.cc
+@BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_marginal_tree.cc \
+@BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_diploid_edge_buffer.cc
 
 @BUNIT_TEST_PRESENT_TRUE@AM_CXXFLAGS = -W -Wall
 all: all-am
@@ -794,6 +798,9 @@ tree_sequences/test_site_visitor.$(OBJEXT):  \
 tree_sequences/test_marginal_tree.$(OBJEXT):  \
 	tree_sequences/$(am__dirstamp) \
 	tree_sequences/$(DEPDIR)/$(am__dirstamp)
+tree_sequences/test_diploid_edge_buffer.$(OBJEXT):  \
+	tree_sequences/$(am__dirstamp) \
+	tree_sequences/$(DEPDIR)/$(am__dirstamp)
 
 tree_sequences/tree_sequence_tests$(EXEEXT): $(tree_sequences_tree_sequence_tests_OBJECTS) $(tree_sequences_tree_sequence_tests_DEPENDENCIES) $(EXTRA_tree_sequences_tree_sequence_tests_DEPENDENCIES) tree_sequences/$(am__dirstamp)
 	@rm -f tree_sequences/tree_sequence_tests$(EXEEXT)
@@ -887,6 +894,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@integration/$(DEPDIR)/sugar_singlepop_custom_diploidTest.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/independent_implementations.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_decapitate.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_diploid_edge_buffer.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_generate_data_matrix.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_generate_offspring.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_marginal_tree.Po@am__quote@ # am--include-marker
@@ -1289,6 +1297,7 @@ distclean: distclean-am
 	-rm -f integration/$(DEPDIR)/sugar_singlepop_custom_diploidTest.Po
 	-rm -f tree_sequences/$(DEPDIR)/independent_implementations.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_decapitate.Po
+	-rm -f tree_sequences/$(DEPDIR)/test_diploid_edge_buffer.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_generate_data_matrix.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_generate_offspring.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_marginal_tree.Po
@@ -1379,6 +1388,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f integration/$(DEPDIR)/sugar_singlepop_custom_diploidTest.Po
 	-rm -f tree_sequences/$(DEPDIR)/independent_implementations.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_decapitate.Po
+	-rm -f tree_sequences/$(DEPDIR)/test_diploid_edge_buffer.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_generate_data_matrix.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_generate_offspring.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_marginal_tree.Po

--- a/testsuite/tree_sequences/test_diploid_edge_buffer.cc
+++ b/testsuite/tree_sequences/test_diploid_edge_buffer.cc
@@ -100,7 +100,114 @@ diploid_wf(const fwdpp::GSLrng_mt& rng, unsigned N,
                           parental_generation + generation - 1);
 }
 
-struct wfnorec
+using parent_nodes
+    = std::tuple<fwdpp::ts::TS_NODE_INT, fwdpp::ts::TS_NODE_INT>;
+
+struct parent_record
+{
+    std::size_t index;
+    parent_nodes nodes;
+    parent_record(std::size_t i, fwdpp::ts::TS_NODE_INT a,
+                  fwdpp::ts::TS_NODE_INT b)
+        : index(i), nodes{ a, b }
+    {
+    }
+};
+
+void
+simple_overlapping_generations(const fwdpp::GSLrng_mt& rng, unsigned K,
+                               unsigned nbirths_per_step, unsigned nsteps,
+                               std::vector<parent_record>& alive_parents,
+                               fwdpp::ts::table_collection& tables,
+                               fwdpp::ts::diploid_edge_buffer& buffer)
+// Simplistic simulation of overlapping generations.
+// While this works, it reveals deficiencies in the edge_buffer
+// interface.  The notes below mark where the API could provide
+// better abstractions
+{
+    buffer.begin_epoch(alive_parents.size());
+
+    auto next_parental_index = alive_parents.size();
+    std::vector<double> breakpoints; //no recombination
+    std::vector<std::size_t> alive, will_die;
+    for (unsigned step = 0; step < nsteps; ++step)
+        {
+            std::size_t last_parent = alive_parents.size();
+            std::size_t pre_birth_epoch_size = buffer.current_epoch.size();
+            for (unsigned birth = 0; birth < nbirths_per_step; ++birth)
+                {
+                    std::size_t parent
+                        = gsl_ran_flat(rng.get(), 0, last_parent);
+                    auto pn0 = std::get<0>(alive_parents[parent].nodes);
+                    auto pn1 = std::get<1>(alive_parents[parent].nodes);
+                    if (gsl_rng_uniform(rng.get()) < 0.5)
+                        {
+                            std::swap(pn0, pn1);
+                        }
+                    auto next_offspring_node1
+                        = fwdpp::ts::register_offspring_and_buffer_edges(
+                            breakpoints, alive_parents[parent].index,
+                            std::make_tuple(pn0, pn1), 0, step + 1, tables,
+                            buffer);
+                    parent = gsl_ran_flat(rng.get(), 0, last_parent);
+                    pn0 = std::get<0>(alive_parents[parent].nodes);
+                    pn1 = std::get<1>(alive_parents[parent].nodes);
+                    if (gsl_rng_uniform(rng.get()) < 0.5)
+                        {
+                            std::swap(pn0, pn1);
+                        }
+                    auto next_offspring_node2
+                        = fwdpp::ts::register_offspring_and_buffer_edges(
+                            breakpoints, alive_parents[parent].index,
+                            std::make_tuple(pn0, pn1), 0, step + 1, tables,
+                            buffer);
+                    alive_parents.emplace_back(next_parental_index++,
+                                               next_offspring_node1,
+                                               next_offspring_node2);
+                    // NOTE: poor abstraction
+                    buffer.current_epoch.resize(buffer.current_epoch.size()
+                                                + 1);
+                }
+            // NOTE: poor abstraction
+            buffer.offsets.emplace_back(pre_birth_epoch_size,
+                                        buffer.current_epoch.size());
+            // Now, regulate
+            alive.resize(alive_parents.size());
+            will_die.resize(alive_parents.size() - K);
+            std::iota(begin(alive), end(alive), 0);
+            gsl_ran_choose(rng.get(), will_die.data(), will_die.size(),
+                           alive.data(), alive.size(), sizeof(std::size_t));
+            for (auto wd : will_die)
+                {
+                    alive_parents[wd].index
+                        = std::numeric_limits<std::size_t>::max();
+                }
+            alive_parents.erase(
+                std::remove_if(
+                    begin(alive_parents), end(alive_parents),
+                    [](const parent_record& pr) {
+                        return pr.index
+                               == std::numeric_limits<std::size_t>::max();
+                    }),
+                end(alive_parents));
+        }
+    // NOTE: poor abstraction
+    for (auto i = buffer.offsets.rbegin(); i != buffer.offsets.rend(); ++i)
+        {
+            for (auto j = begin(buffer.current_epoch) + i->first;
+                 j < begin(buffer.current_epoch) + i->second; ++j)
+                {
+                    for (auto&& k : *j)
+                        {
+                            tables.edge_table.insert(end(tables.edge_table),
+                                                     begin(k), end(k));
+                            k.clear();
+                        }
+                }
+        }
+}
+
+struct edge_buffer_fixture
 {
     const double L;
     const fwdpp::ts::TS_NODE_INT N;
@@ -111,7 +218,7 @@ struct wfnorec
     // stochastic functions.
     fwdpp::GSLrng_mt rng, rng2;
     unsigned parental_generation;
-    wfnorec()
+    edge_buffer_fixture()
         : L{ 1.0 }, N{ 1000 }, tables(2 * N, 0.0, 0, L),
           tables2(tables), buffer{}, buffer2{}, rng{ 42 }, rng2{ 42 },
           parental_generation{ 0 }
@@ -119,9 +226,31 @@ struct wfnorec
     }
 };
 
+class edge_buffer_fixture_for_overlapping : public edge_buffer_fixture
+{
+  private:
+    std::vector<parent_record>
+    fill_parents(fwdpp::ts::TS_NODE_INT num_individuals)
+    {
+        std::vector<parent_record> rv;
+        for (decltype(num_individuals) i = 0; i < num_individuals; ++i)
+            {
+                rv.emplace_back(i, 2 * i, 2 * i + 1);
+            }
+        return rv;
+    }
+
+  public:
+    std::vector<parent_record> alive_parents;
+    edge_buffer_fixture_for_overlapping()
+        : edge_buffer_fixture(), alive_parents(fill_parents(N))
+    {
+    }
+};
+
 BOOST_AUTO_TEST_SUITE(test_diploid_edge_buffer)
 
-BOOST_FIXTURE_TEST_CASE(test_sort_order, wfnorec)
+BOOST_FIXTURE_TEST_CASE(test_sort_order, edge_buffer_fixture)
 {
     auto p = diploid_wf(rng, N, parental_generation, 100, 0, tables, buffer,
                         true);
@@ -133,7 +262,7 @@ BOOST_FIXTURE_TEST_CASE(test_sort_order, wfnorec)
     BOOST_REQUIRE_EQUAL(tables.edges_are_sorted(), true);
 }
 
-BOOST_FIXTURE_TEST_CASE(test_two_rounds, wfnorec)
+BOOST_FIXTURE_TEST_CASE(test_two_rounds, edge_buffer_fixture)
 {
     auto p = diploid_wf(rng, N, parental_generation, 100, 0, tables, buffer,
                         true);
@@ -150,7 +279,7 @@ BOOST_FIXTURE_TEST_CASE(test_two_rounds, wfnorec)
     BOOST_REQUIRE_EQUAL(tables.edges_are_sorted(), true);
 }
 
-BOOST_FIXTURE_TEST_CASE(test_simplification, wfnorec)
+BOOST_FIXTURE_TEST_CASE(test_simplification, edge_buffer_fixture)
 {
     auto p = diploid_wf(rng, N, parental_generation, 100, 0, tables, buffer,
                         true);
@@ -173,6 +302,14 @@ BOOST_FIXTURE_TEST_CASE(test_simplification, wfnorec)
     auto output_copy = simplifier.simplify(tables2, samples);
     BOOST_CHECK(output == output_copy);
     BOOST_CHECK(tables == tables2);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_overlapping_generations,
+                        edge_buffer_fixture_for_overlapping)
+{
+    simple_overlapping_generations(rng, N, 100, 100, alive_parents, tables,
+                                   buffer);
+    BOOST_CHECK(tables.edges_are_sorted());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/testsuite/tree_sequences/test_diploid_edge_buffer.cc
+++ b/testsuite/tree_sequences/test_diploid_edge_buffer.cc
@@ -1,2 +1,107 @@
 #include <boost/test/unit_test.hpp>
+#include <gsl/gsl_randist.h>
+#include <fwdpp/GSLrng_t.hpp>
 #include <fwdpp/ts/diploid_edge_buffer.hpp>
+
+std::pair<fwdpp::ts::TS_NODE_INT, unsigned>
+diploid_wf(const fwdpp::GSLrng_mt& rng, unsigned N,
+           unsigned starting_generation, unsigned ngenerations,
+           fwdpp::ts::TS_NODE_INT first_parental_index,
+           fwdpp::ts::table_collection& tables,
+           fwdpp::ts::diploid_edge_buffer& buffer)
+// Based on the tskit tutorial examples https://tskit-dev.github.io/tutorials/wfforward.html
+{
+    decltype(first_parental_index) parent_index_offset = first_parental_index;
+    fwdpp::ts::TS_NODE_INT next_offspring_node;
+    std::vector<double> breakpoints; //No rec.
+    const fwdpp::ts::TS_NODE_INT offspring_deme{ 0 };
+    unsigned generation = starting_generation;
+    for (; generation < starting_generation + ngenerations; ++generation)
+        {
+            buffer.begin_epoch(N);
+            for (unsigned offspring = 0; offspring < N; ++offspring)
+                {
+                    std::size_t parent = gsl_ran_flat(rng.get(), 0, N);
+                    fwdpp::ts::TS_NODE_INT pn0
+                        = parent_index_offset + 2 * parent;
+                    fwdpp::ts::TS_NODE_INT pn1 = pn0 + 1;
+                    if (gsl_rng_uniform(rng.get()) < 0.5)
+                        {
+                            std::swap(pn0, pn1);
+                        }
+                    next_offspring_node
+                        = fwdpp::ts::register_offspring_and_buffer_edges(
+                            breakpoints, parent, std::make_tuple(pn0, pn1),
+                            offspring_deme, generation, tables, buffer);
+                    if (next_offspring_node == fwdpp::ts::TS_NULL_NODE)
+                        {
+                            // NOTE: this is impossible, and really just
+                            // silences unused variable warnings re:
+                            // next_offspring_node
+                            throw std::runtime_error("NULL offspring node");
+                        }
+
+                    parent = gsl_ran_flat(rng.get(), 0, N);
+                    pn0 = parent_index_offset + 2 * parent;
+                    pn1 = pn0 + 1;
+                    if (gsl_rng_uniform(rng.get()) < 0.5)
+                        {
+                            std::swap(pn0, pn1);
+                        }
+
+                    next_offspring_node
+                        = fwdpp::ts::register_offspring_and_buffer_edges(
+                            breakpoints, parent, std::make_tuple(pn0, pn1),
+                            offspring_deme, generation, tables, buffer);
+                    if (next_offspring_node == fwdpp::ts::TS_NULL_NODE)
+                        {
+                            throw std::runtime_error("NULL offspring node");
+                        }
+                }
+            parent_index_offset += 2 * N;
+            buffer.end_epoch();
+        }
+    return std::make_pair(parent_index_offset, generation);
+}
+
+struct wfnorec
+{
+    const double L;
+    const fwdpp::ts::TS_NODE_INT N;
+    fwdpp::ts::table_collection tables;
+    fwdpp::ts::diploid_edge_buffer buffer;
+    fwdpp::GSLrng_mt rng;
+    unsigned generation;
+    wfnorec()
+        : L{ 1.0 }, N{ 1000 },
+          tables(2 * N, 0.0, 0, L), buffer{}, rng{ 42 }, generation{ 0 }
+    {
+    }
+};
+
+BOOST_AUTO_TEST_SUITE(test_diploid_edge_buffer)
+
+BOOST_FIXTURE_TEST_CASE(test_sort_order, wfnorec)
+{
+    auto p = diploid_wf(rng, N, generation, 100, 0, tables, buffer);
+    generation = p.second;
+    buffer.prepare_tables_for_simplification(tables);
+    BOOST_REQUIRE_EQUAL(tables.edge_table.size(), generation * 2 * N);
+    BOOST_REQUIRE_EQUAL(tables.node_table.size(), (generation + 1) * 2 * N);
+    BOOST_REQUIRE_EQUAL(tables.edges_are_sorted(), true);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_two_rounds, wfnorec)
+{
+    auto p = diploid_wf(rng, N, generation, 100, 0, tables, buffer);
+    buffer.prepare_tables_for_simplification(tables);
+    generation = p.second;
+    p = diploid_wf(rng, N, generation, 100, p.first, tables, buffer);
+    generation = p.second;
+    buffer.prepare_tables_for_simplification(tables);
+    BOOST_REQUIRE_EQUAL(tables.edge_table.size(), generation * 2 * N);
+    BOOST_REQUIRE_EQUAL(tables.node_table.size(), (generation + 1) * 2 * N);
+    BOOST_REQUIRE_EQUAL(tables.edges_are_sorted(), true);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/testsuite/tree_sequences/test_diploid_edge_buffer.cc
+++ b/testsuite/tree_sequences/test_diploid_edge_buffer.cc
@@ -164,9 +164,7 @@ BOOST_FIXTURE_TEST_CASE(test_simplification, wfnorec)
     tables_copy.sort_tables();
     BOOST_CHECK(p == p2);
     BOOST_CHECK_EQUAL(tables_copy.edges_are_sorted(), true);
-    BOOST_CHECK(tables.node_table == tables_copy.node_table);
-    BOOST_CHECK_EQUAL(tables.edge_table.size(), tables_copy.edge_table.size());
-    BOOST_CHECK(tables.edge_table == tables_copy.edge_table);
+    BOOST_REQUIRE(tables == tables_copy);
 
     std::vector<fwdpp::ts::TS_NODE_INT> samples(2 * N);
     std::iota(begin(samples), end(samples), p.first);

--- a/testsuite/tree_sequences/test_diploid_edge_buffer.cc
+++ b/testsuite/tree_sequences/test_diploid_edge_buffer.cc
@@ -300,6 +300,7 @@ BOOST_FIXTURE_TEST_CASE(test_simplification, edge_buffer_fixture)
 
     auto output = simplifier.simplify(tables, samples);
     auto output_copy = simplifier.simplify(tables2, samples);
+    BOOST_CHECK_EQUAL(tables2.edges_are_minimally_sorted(), true);
     BOOST_CHECK(output == output_copy);
     BOOST_CHECK(tables == tables2);
 }
@@ -310,6 +311,27 @@ BOOST_FIXTURE_TEST_CASE(test_overlapping_generations,
     simple_overlapping_generations(rng, N, 100, 100, alive_parents, tables,
                                    buffer);
     BOOST_CHECK(tables.edges_are_sorted());
+}
+
+BOOST_FIXTURE_TEST_CASE(test_overlapping_generations_simplify,
+                        edge_buffer_fixture_for_overlapping)
+{
+    simple_overlapping_generations(rng, N, 100, 100, alive_parents, tables,
+                                   buffer);
+    BOOST_CHECK(tables.edges_are_sorted());
+    std::vector<fwdpp::ts::TS_NODE_INT> samples;
+    for (auto&& a : alive_parents)
+        {
+            samples.push_back(std::get<0>(a.nodes));
+            samples.push_back(std::get<1>(a.nodes));
+        }
+    fwdpp::ts::table_simplifier simplifier(tables.genome_length());
+    auto rv = simplifier.simplify(tables, samples);
+    for (auto s : samples)
+        {
+            BOOST_REQUIRE(rv.first[s] != fwdpp::ts::TS_NULL_NODE);
+        }
+    BOOST_REQUIRE(tables.edges_are_minimally_sorted());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/testsuite/tree_sequences/test_diploid_edge_buffer.cc
+++ b/testsuite/tree_sequences/test_diploid_edge_buffer.cc
@@ -5,7 +5,7 @@
 
 std::pair<fwdpp::ts::TS_NODE_INT, unsigned>
 diploid_wf(const fwdpp::GSLrng_mt& rng, unsigned N,
-           unsigned starting_generation, unsigned ngenerations,
+           unsigned parental_generation, unsigned ngenerations,
            fwdpp::ts::TS_NODE_INT first_parental_index,
            fwdpp::ts::table_collection& tables,
            fwdpp::ts::diploid_edge_buffer& buffer)
@@ -15,8 +15,8 @@ diploid_wf(const fwdpp::GSLrng_mt& rng, unsigned N,
     fwdpp::ts::TS_NODE_INT next_offspring_node;
     std::vector<double> breakpoints; //No rec.
     const fwdpp::ts::TS_NODE_INT offspring_deme{ 0 };
-    unsigned generation = starting_generation;
-    for (; generation < starting_generation + ngenerations; ++generation)
+    unsigned generation = 1;
+    for (; generation <= ngenerations; ++generation)
         {
             buffer.begin_epoch(N);
             for (unsigned offspring = 0; offspring < N; ++offspring)
@@ -32,7 +32,8 @@ diploid_wf(const fwdpp::GSLrng_mt& rng, unsigned N,
                     next_offspring_node
                         = fwdpp::ts::register_offspring_and_buffer_edges(
                             breakpoints, parent, std::make_tuple(pn0, pn1),
-                            offspring_deme, generation, tables, buffer);
+                            offspring_deme, parental_generation + generation,
+                            tables, buffer);
                     if (next_offspring_node == fwdpp::ts::TS_NULL_NODE)
                         {
                             // NOTE: this is impossible, and really just
@@ -52,7 +53,8 @@ diploid_wf(const fwdpp::GSLrng_mt& rng, unsigned N,
                     next_offspring_node
                         = fwdpp::ts::register_offspring_and_buffer_edges(
                             breakpoints, parent, std::make_tuple(pn0, pn1),
-                            offspring_deme, generation, tables, buffer);
+                            offspring_deme, parental_generation + generation,
+                            tables, buffer);
                     if (next_offspring_node == fwdpp::ts::TS_NULL_NODE)
                         {
                             throw std::runtime_error("NULL offspring node");
@@ -61,7 +63,8 @@ diploid_wf(const fwdpp::GSLrng_mt& rng, unsigned N,
             parent_index_offset += 2 * N;
             buffer.end_epoch();
         }
-    return std::make_pair(parent_index_offset, generation);
+    return std::make_pair(parent_index_offset,
+                          parental_generation + generation - 1);
 }
 
 struct wfnorec
@@ -71,10 +74,12 @@ struct wfnorec
     fwdpp::ts::table_collection tables;
     fwdpp::ts::diploid_edge_buffer buffer;
     fwdpp::GSLrng_mt rng;
-    unsigned generation;
+    unsigned parental_generation;
     wfnorec()
         : L{ 1.0 }, N{ 1000 },
-          tables(2 * N, 0.0, 0, L), buffer{}, rng{ 42 }, generation{ 0 }
+          tables(2 * N, 0.0, 0, L), buffer{}, rng{ 42 }, parental_generation{
+              0
+          }
     {
     }
 };
@@ -83,24 +88,27 @@ BOOST_AUTO_TEST_SUITE(test_diploid_edge_buffer)
 
 BOOST_FIXTURE_TEST_CASE(test_sort_order, wfnorec)
 {
-    auto p = diploid_wf(rng, N, generation, 100, 0, tables, buffer);
-    generation = p.second;
+    auto p = diploid_wf(rng, N, parental_generation, 100, 0, tables, buffer);
+    parental_generation = p.second;
     buffer.prepare_tables_for_simplification(tables);
-    BOOST_REQUIRE_EQUAL(tables.edge_table.size(), generation * 2 * N);
-    BOOST_REQUIRE_EQUAL(tables.node_table.size(), (generation + 1) * 2 * N);
+    BOOST_REQUIRE_EQUAL(tables.edge_table.size(), parental_generation * 2 * N);
+    BOOST_REQUIRE_EQUAL(tables.node_table.size(),
+                        (parental_generation + 1) * 2 * N);
     BOOST_REQUIRE_EQUAL(tables.edges_are_sorted(), true);
 }
 
 BOOST_FIXTURE_TEST_CASE(test_two_rounds, wfnorec)
 {
-    auto p = diploid_wf(rng, N, generation, 100, 0, tables, buffer);
+    auto p = diploid_wf(rng, N, parental_generation, 100, 0, tables, buffer);
     buffer.prepare_tables_for_simplification(tables);
-    generation = p.second;
-    p = diploid_wf(rng, N, generation, 100, p.first, tables, buffer);
-    generation = p.second;
+    tables.edge_offset = tables.edge_table.size();
+    parental_generation = p.second;
+    p = diploid_wf(rng, N, parental_generation, 100, p.first, tables, buffer);
+    parental_generation = p.second;
     buffer.prepare_tables_for_simplification(tables);
-    BOOST_REQUIRE_EQUAL(tables.edge_table.size(), generation * 2 * N);
-    BOOST_REQUIRE_EQUAL(tables.node_table.size(), (generation + 1) * 2 * N);
+    BOOST_REQUIRE_EQUAL(tables.edge_table.size(), parental_generation * 2 * N);
+    BOOST_REQUIRE_EQUAL(tables.node_table.size(),
+                        (parental_generation + 1) * 2 * N);
     BOOST_REQUIRE_EQUAL(tables.edges_are_sorted(), true);
 }
 

--- a/testsuite/tree_sequences/test_diploid_edge_buffer.cc
+++ b/testsuite/tree_sequences/test_diploid_edge_buffer.cc
@@ -1,2 +1,2 @@
 #include <boost/test/unit_test.hpp>
-#include <fwdpp/ts/decapitate.hpp>
+#include <fwdpp/ts/diploid_edge_buffer.hpp>

--- a/testsuite/tree_sequences/test_diploid_edge_buffer.cc
+++ b/testsuite/tree_sequences/test_diploid_edge_buffer.cc
@@ -138,6 +138,11 @@ simple_overlapping_generations(const fwdpp::GSLrng_mt& rng, unsigned K,
                 {
                     std::size_t parent
                         = gsl_ran_flat(rng.get(), 0, last_parent);
+                    if (alive_parents[parent].index
+                        == std::numeric_limits<std::size_t>::max())
+                        {
+                            throw std::runtime_error("dead parent!");
+                        }
                     auto pn0 = std::get<0>(alive_parents[parent].nodes);
                     auto pn1 = std::get<1>(alive_parents[parent].nodes);
                     if (gsl_rng_uniform(rng.get()) < 0.5)
@@ -150,6 +155,11 @@ simple_overlapping_generations(const fwdpp::GSLrng_mt& rng, unsigned K,
                             std::make_tuple(pn0, pn1), 0, step + 1, tables,
                             buffer);
                     parent = gsl_ran_flat(rng.get(), 0, last_parent);
+                    if (alive_parents[parent].index
+                        == std::numeric_limits<std::size_t>::max())
+                        {
+                            throw std::runtime_error("dead parent!");
+                        }
                     pn0 = std::get<0>(alive_parents[parent].nodes);
                     pn1 = std::get<1>(alive_parents[parent].nodes);
                     if (gsl_rng_uniform(rng.get()) < 0.5)

--- a/testsuite/tree_sequences/test_diploid_edge_buffer.cc
+++ b/testsuite/tree_sequences/test_diploid_edge_buffer.cc
@@ -1,14 +1,17 @@
+#include <numeric>
 #include <boost/test/unit_test.hpp>
 #include <gsl/gsl_randist.h>
 #include <fwdpp/GSLrng_t.hpp>
 #include <fwdpp/ts/diploid_edge_buffer.hpp>
+#include <fwdpp/ts/table_simplifier.hpp>
+#include <iostream>
 
 std::pair<fwdpp::ts::TS_NODE_INT, unsigned>
 diploid_wf(const fwdpp::GSLrng_mt& rng, unsigned N,
            unsigned parental_generation, unsigned ngenerations,
            fwdpp::ts::TS_NODE_INT first_parental_index,
            fwdpp::ts::table_collection& tables,
-           fwdpp::ts::diploid_edge_buffer& buffer)
+           fwdpp::ts::diploid_edge_buffer& buffer, bool buffer_edges)
 // Based on the tskit tutorial examples https://tskit-dev.github.io/tutorials/wfforward.html
 {
     decltype(first_parental_index) parent_index_offset = first_parental_index;
@@ -18,7 +21,10 @@ diploid_wf(const fwdpp::GSLrng_mt& rng, unsigned N,
     unsigned generation = 1;
     for (; generation <= ngenerations; ++generation)
         {
-            buffer.begin_epoch(N);
+            if (buffer_edges)
+                {
+                    buffer.begin_epoch(N);
+                }
             for (unsigned offspring = 0; offspring < N; ++offspring)
                 {
                     std::size_t parent = gsl_ran_flat(rng.get(), 0, N);
@@ -29,11 +35,23 @@ diploid_wf(const fwdpp::GSLrng_mt& rng, unsigned N,
                         {
                             std::swap(pn0, pn1);
                         }
-                    next_offspring_node
-                        = fwdpp::ts::register_offspring_and_buffer_edges(
-                            breakpoints, parent, std::make_tuple(pn0, pn1),
-                            offspring_deme, parental_generation + generation,
-                            tables, buffer);
+                    if (buffer_edges)
+                        {
+                            next_offspring_node = fwdpp::ts::
+                                register_offspring_and_buffer_edges(
+                                    breakpoints, parent,
+                                    std::make_tuple(pn0, pn1), offspring_deme,
+                                    parental_generation + generation, tables,
+                                    buffer);
+                        }
+                    else
+                        {
+                            next_offspring_node
+                                = tables.register_diploid_offspring(
+                                    breakpoints, std::make_tuple(pn0, pn1),
+                                    offspring_deme,
+                                    parental_generation + generation);
+                        }
                     if (next_offspring_node == fwdpp::ts::TS_NULL_NODE)
                         {
                             // NOTE: this is impossible, and really just
@@ -50,18 +68,33 @@ diploid_wf(const fwdpp::GSLrng_mt& rng, unsigned N,
                             std::swap(pn0, pn1);
                         }
 
-                    next_offspring_node
-                        = fwdpp::ts::register_offspring_and_buffer_edges(
-                            breakpoints, parent, std::make_tuple(pn0, pn1),
-                            offspring_deme, parental_generation + generation,
-                            tables, buffer);
+                    if (buffer_edges)
+                        {
+                            next_offspring_node = fwdpp::ts::
+                                register_offspring_and_buffer_edges(
+                                    breakpoints, parent,
+                                    std::make_tuple(pn0, pn1), offspring_deme,
+                                    parental_generation + generation, tables,
+                                    buffer);
+                        }
+                    else
+                        {
+                            next_offspring_node
+                                = tables.register_diploid_offspring(
+                                    breakpoints, std::make_tuple(pn0, pn1),
+                                    offspring_deme,
+                                    parental_generation + generation);
+                        }
                     if (next_offspring_node == fwdpp::ts::TS_NULL_NODE)
                         {
                             throw std::runtime_error("NULL offspring node");
                         }
                 }
             parent_index_offset += 2 * N;
-            buffer.end_epoch();
+            if (buffer_edges)
+                {
+                    buffer.end_epoch();
+                }
         }
     return std::make_pair(parent_index_offset,
                           parental_generation + generation - 1);
@@ -73,13 +106,15 @@ struct wfnorec
     const fwdpp::ts::TS_NODE_INT N;
     fwdpp::ts::table_collection tables;
     fwdpp::ts::diploid_edge_buffer buffer;
-    fwdpp::GSLrng_mt rng;
+    // NOTE: have to have two rng 
+    // when comparing output from 
+    // stochastic functions.
+    fwdpp::GSLrng_mt rng, rng2;
     unsigned parental_generation;
     wfnorec()
         : L{ 1.0 }, N{ 1000 },
-          tables(2 * N, 0.0, 0, L), buffer{}, rng{ 42 }, parental_generation{
-              0
-          }
+          tables(2 * N, 0.0, 0, L), buffer{}, rng{ 42 }, rng2{ 42 },
+          parental_generation{ 0 }
     {
     }
 };
@@ -88,7 +123,8 @@ BOOST_AUTO_TEST_SUITE(test_diploid_edge_buffer)
 
 BOOST_FIXTURE_TEST_CASE(test_sort_order, wfnorec)
 {
-    auto p = diploid_wf(rng, N, parental_generation, 100, 0, tables, buffer);
+    auto p = diploid_wf(rng, N, parental_generation, 100, 0, tables, buffer,
+                        true);
     parental_generation = p.second;
     buffer.prepare_tables_for_simplification(tables);
     BOOST_REQUIRE_EQUAL(tables.edge_table.size(), parental_generation * 2 * N);
@@ -99,17 +135,48 @@ BOOST_FIXTURE_TEST_CASE(test_sort_order, wfnorec)
 
 BOOST_FIXTURE_TEST_CASE(test_two_rounds, wfnorec)
 {
-    auto p = diploid_wf(rng, N, parental_generation, 100, 0, tables, buffer);
+    auto p = diploid_wf(rng, N, parental_generation, 100, 0, tables, buffer,
+                        true);
     buffer.prepare_tables_for_simplification(tables);
     tables.edge_offset = tables.edge_table.size();
     parental_generation = p.second;
-    p = diploid_wf(rng, N, parental_generation, 100, p.first, tables, buffer);
+    p = diploid_wf(rng, N, parental_generation, 100, p.first, tables, buffer,
+                   true);
     parental_generation = p.second;
     buffer.prepare_tables_for_simplification(tables);
     BOOST_REQUIRE_EQUAL(tables.edge_table.size(), parental_generation * 2 * N);
     BOOST_REQUIRE_EQUAL(tables.node_table.size(),
                         (parental_generation + 1) * 2 * N);
     BOOST_REQUIRE_EQUAL(tables.edges_are_sorted(), true);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_simplification, wfnorec)
+{
+    auto tables_copy(tables);
+    auto buffer_copy(buffer);
+    auto p = diploid_wf(rng, N, parental_generation, 100, 0, tables, buffer,
+                        true);
+    buffer.prepare_tables_for_simplification(tables);
+    BOOST_CHECK_EQUAL(tables.edges_are_sorted(), true);
+    // NOTE: have to use the other rng here.
+    auto p2 = diploid_wf(rng2, N, parental_generation, 100, 0, tables_copy,
+                         buffer_copy, false);
+    tables_copy.sort_tables();
+    BOOST_CHECK(p == p2);
+    BOOST_CHECK_EQUAL(tables_copy.edges_are_sorted(), true);
+    BOOST_CHECK(tables.node_table == tables_copy.node_table);
+    BOOST_CHECK_EQUAL(tables.edge_table.size(), tables_copy.edge_table.size());
+    BOOST_CHECK(tables.edge_table == tables_copy.edge_table);
+
+    std::vector<fwdpp::ts::TS_NODE_INT> samples(2 * N);
+    std::iota(begin(samples), end(samples), p.first);
+
+    fwdpp::ts::table_simplifier simplifier(L);
+
+    auto output = simplifier.simplify(tables, samples);
+    auto output_copy = simplifier.simplify(tables_copy, samples);
+    BOOST_CHECK(output == output_copy);
+    BOOST_CHECK(tables == tables_copy);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/testsuite/tree_sequences/test_diploid_edge_buffer.cc
+++ b/testsuite/tree_sequences/test_diploid_edge_buffer.cc
@@ -1,0 +1,2 @@
+#include <boost/test/unit_test.hpp>
+#include <fwdpp/ts/decapitate.hpp>


### PR DESCRIPTION
Implement edge buffering in order to avoid sorting edge tables.  Based on ideas started in molpopgen/fwdpy11#278