### PR TITLE
fix compiler warnings when compiling a debug build

### DIFF
--- a/examples/K_linked_regions_extensions.cc
+++ b/examples/K_linked_regions_extensions.cc
@@ -121,7 +121,6 @@ main(int argc, char **argv)
     pop.mutations.reserve(
         size_t(2 * std::ceil(std::log(2 * N) * (theta) + 0.667 * (theta))));
     unsigned generation = 0;
-    double wbar;
 
     // Set up mutation models
     std::vector<double> locus_starts(K);

--- a/examples/K_linked_regions_generalized_rec.cc
+++ b/examples/K_linked_regions_generalized_rec.cc
@@ -66,7 +66,6 @@ main(int argc, char **argv)
     pop.mutations.reserve(
         size_t(2 * std::ceil(std::log(2 * N) * (theta) + 0.667 * (theta))));
     unsigned generation = 0;
-    double wbar;
 
     fwdpp::general_rec_variation recvar;
     for (unsigned i = 0; i < K; ++i)

--- a/examples/custom_diploid.cc
+++ b/examples/custom_diploid.cc
@@ -61,7 +61,7 @@ namespace fwdpp
 }
 
 int
-main(int argc, char** argv)
+main(int /*argc**/, char** /*argv*/)
 {
     dip_with_deme dip(0, 34, 11);
     dip_with_deme dip2;

--- a/examples/custom_mutation.cc
+++ b/examples/custom_mutation.cc
@@ -133,7 +133,7 @@ using mtype = TwoDmutation;
 #include "common_ind.hpp"
 
 int
-main(int argc, char **argv)
+main(int /*argc*/, char** /* argv*/)
 {
     TwoDmutation::array_t s{ 0, 1 }, h{ 1, 1 };
 

--- a/examples/diploid_fixed_sh_ind.cc
+++ b/examples/diploid_fixed_sh_ind.cc
@@ -77,10 +77,9 @@ main(int argc, char **argv)
                     [s]() { return s; }, [h]() { return h; });
             };
 
-            double wbar = 1;
             for (generation = 0; generation < ngens; ++generation)
                 {
-                    wbar = fwdpp::sample_diploid(
+                    fwdpp::sample_diploid(
                         r.get(), pop.haploid_genomes, pop.diploids,
                         pop.mutations, pop.mcounts, N, mu_neutral + mu_del,
                         mmodel,

--- a/examples/diploid_ind.cc
+++ b/examples/diploid_ind.cc
@@ -78,7 +78,6 @@ main(int argc, char **argv)
             pop.mutations.reserve(
                 size_t(std::ceil(std::log(2 * N) * theta + 0.667 * theta)));
             unsigned generation = 0;
-            double wbar;
 
             const auto mmodel = [&pop, &r, &generation](
                                     fwdpp::flagged_mutation_queue &recbin,
@@ -91,7 +90,7 @@ main(int argc, char **argv)
             for (generation = 0; generation < ngens; ++generation)
                 {
                     // Iterate the population through 1 generation
-                    wbar = fwdpp::sample_diploid(
+                    fwdpp::sample_diploid(
                         r.get(),
                         pop.haploid_genomes, // non-const reference to haploid_genomes
                         pop.diploids,        // non-const reference to diploids

--- a/examples/juvenile_migration.cc
+++ b/examples/juvenile_migration.cc
@@ -89,6 +89,8 @@ struct parent_lookup_tables
     // lookup1 and lookup2 to diploids in the population
     // object.
     std::vector<std::size_t> parents1, parents2;
+
+    parent_lookup_tables() : lookup1{}, lookup2{}, parents1{}, parents2{} {}
 };
 
 template <typename fitness_fxn>
@@ -157,14 +159,14 @@ migrate_and_calc_fitness(const gsl_rng *r, diploid_population &pop,
             if (deme_labels[i] == 0)
                 {
                     rv.parents1.push_back(i);
-                    w1.push_back(
-                        wfxn(pop.diploids[i], pop.haploid_genomes, pop.mutations));
+                    w1.push_back(wfxn(pop.diploids[i], pop.haploid_genomes,
+                                      pop.mutations));
                 }
             else
                 {
                     rv.parents2.push_back(i);
-                    w2.push_back(
-                        wfxn(pop.diploids[i], pop.haploid_genomes, pop.mutations));
+                    w2.push_back(wfxn(pop.diploids[i], pop.haploid_genomes,
+                                      pop.mutations));
                 }
         }
 
@@ -184,7 +186,8 @@ evolve_two_demes(const gsl_rng *r, diploid_population &pop,
 {
     // Handle mutation/haploid_genome "recycling":
     auto mut_recycling_bin = fwdpp::make_mut_queue(pop.mcounts);
-    auto gam_recycling_bin = fwdpp::make_haploid_genome_queue(pop.haploid_genomes);
+    auto gam_recycling_bin
+        = fwdpp::make_haploid_genome_queue(pop.haploid_genomes);
 
     // Migration and build lookup tables:
     auto lookups = migrate_and_calc_fitness(r, pop, wfxn, N1, N2, m12, m21);
@@ -242,7 +245,7 @@ evolve_two_demes(const gsl_rng *r, diploid_population &pop,
                                     pop.neutral, pop.selected);
         }
     fwdpp::debug::validate_sum_haploid_genome_counts(pop.haploid_genomes,
-                                             2 * pop.diploids.size());
+                                                     2 * pop.diploids.size());
 #ifndef NDEBUG
     for (const auto &dip : pop.diploids)
         {
@@ -254,8 +257,8 @@ evolve_two_demes(const gsl_rng *r, diploid_population &pop,
 #endif
 
     // Update mutation counts
-    fwdpp::fwdpp_internal::process_haploid_genomes(pop.haploid_genomes, pop.mutations,
-                                           pop.mcounts);
+    fwdpp::fwdpp_internal::process_haploid_genomes(pop.haploid_genomes,
+                                                   pop.mutations, pop.mcounts);
 
     assert(pop.mcounts.size() == pop.mutations.size());
 #ifndef NDEBUG
@@ -267,9 +270,9 @@ evolve_two_demes(const gsl_rng *r, diploid_population &pop,
     fwdpp::debug::validate_pop_data(pop);
 
     // Prune fixations from haploid_genomes
-    fwdpp::fwdpp_internal::haploid_genome_cleaner(pop.haploid_genomes, pop.mutations,
-                                          pop.mcounts, 2 * (N1 + N2),
-                                          std::true_type());
+    fwdpp::fwdpp_internal::haploid_genome_cleaner(
+        pop.haploid_genomes, pop.mutations, pop.mcounts, 2 * (N1 + N2),
+        std::true_type());
 }
 
 int
@@ -331,8 +334,8 @@ main(int argc, char **argv)
 
     for (generation = 0; generation < ngens; ++generation)
         {
-            fwdpp::debug::validate_sum_haploid_genome_counts(pop.haploid_genomes,
-                                                     2 * (N1 + N2));
+            fwdpp::debug::validate_sum_haploid_genome_counts(
+                pop.haploid_genomes, 2 * (N1 + N2));
 
             // Call our fancy new evolve function
             evolve_two_demes(r.get(), pop, N1, N2, m12, m21,
@@ -340,6 +343,7 @@ main(int argc, char **argv)
             fwdpp::update_mutations(pop.mutations, pop.fixations,
                                     pop.fixation_times, pop.mut_lookup,
                                     pop.mcounts, generation, 2 * N);
-            fwdpp::debug::validate_sum_haploid_genome_counts(pop.haploid_genomes, 2 * N);
+            fwdpp::debug::validate_sum_haploid_genome_counts(
+                pop.haploid_genomes, 2 * N);
         }
 }

--- a/examples/juvenile_migration.cc
+++ b/examples/juvenile_migration.cc
@@ -329,7 +329,6 @@ main(int argc, char **argv)
             [h]() { return h; });
     };
 
-    double wbar = 1;
     for (generation = 0; generation < ngens; ++generation)
         {
             fwdpp::debug::validate_sum_haploid_genome_counts(pop.haploid_genomes,

--- a/examples/spatialts.cc
+++ b/examples/spatialts.cc
@@ -365,8 +365,10 @@ main(int argc, char **argv)
                                 first_parental_index, i, 0);
                             assert(x.first >= first_parental_index);
                             assert(x.second >= first_parental_index);
-                            assert(x.first < tables.num_nodes());
-                            assert(x.second < tables.num_nodes());
+                            assert(static_cast<std::size_t>(x.first)
+                                   < tables.num_nodes());
+                            assert(static_cast<std::size_t>(x.second)
+                                   < tables.num_nodes());
                             assert(tables.node_table[x.first].time
                                    == generation);
                             assert(tables.node_table[x.second].time
@@ -434,9 +436,8 @@ main(int argc, char **argv)
             return fwdpp::ts::new_variant_record(
                 pop.mutations[key].pos, 0, key, pop.mutations[key].neutral, 1);
         };
-    auto neutral_muts
-        = fwdpp::ts::mutate_tables(rng, neutral_variant_maker, tables, s,
-                                   theta / static_cast<double>(4 * N));
+    fwdpp::ts::mutate_tables(rng, neutral_variant_maker, tables, s,
+                             theta / static_cast<double>(4 * N));
     fwdpp::ts::count_mutations(tables, pop.mutations, s, pop.mcounts,
                                pop.mcounts_from_preserved_nodes);
     for (std::size_t i = 0; i < pop.mutations.size(); ++i)

--- a/examples/wfts_integration_test.cc
+++ b/examples/wfts_integration_test.cc
@@ -88,9 +88,9 @@ main(int argc, char **argv)
                   generate_h);
           };
 
-    const auto mmodel = [&rng, &o,
-                         &make_mutation](fwdpp::flagged_mutation_queue &recbin,
-                                         ts_examples_poptype::mcont_t &mutations) {
+    const auto mmodel = [&rng, &o, &make_mutation](
+                            fwdpp::flagged_mutation_queue &recbin,
+                            ts_examples_poptype::mcont_t &mutations) {
         std::vector<fwdpp::uint_t> rv;
         unsigned nmuts = gsl_ran_poisson(rng.get(), o.mu);
         for (unsigned i = 0; i < nmuts; ++i)
@@ -233,8 +233,10 @@ main(int argc, char **argv)
                                 first_parental_index, i, 0);
                             assert(x.first >= first_parental_index);
                             assert(x.second >= first_parental_index);
-                            assert(x.first < tables.num_nodes());
-                            assert(x.second < tables.num_nodes());
+                            assert(static_cast<std::size_t>(x.first)
+                                   < tables.num_nodes());
+                            assert(static_cast<std::size_t>(x.second)
+                                   < tables.num_nodes());
                             assert(tables.node_table[x.first].time
                                    == generation);
                             assert(tables.node_table[x.second].time
@@ -357,6 +359,6 @@ main(int argc, char **argv)
     execute_expensive_leaf_test(o, tables, s);
     execute_matrix_test(o, pop, tables, s);
     execute_serialization_test(o, tables);
-	visit_sites_test(o, pop, tables, s);
+    visit_sites_test(o, pop, tables, s);
     write_sfs(o, rng, tables, s);
 }

--- a/fwdpp/algorithm/compact_mutations.hpp
+++ b/fwdpp/algorithm/compact_mutations.hpp
@@ -39,9 +39,9 @@ namespace fwdpp
                       return pop.mutations[i].pos < pop.mutations[j].pos;
                   });
         std::vector<fwdpp::uint_t> reindex(indexes.size());
-        std::size_t new_indexes_size
+        auto new_indexes_size
             = std::distance(std::begin(indexes), new_indexes_end);
-        for (std::size_t i = 0; i < new_indexes_size; ++i)
+        for (uint_t i = 0; i < new_indexes_size; ++i)
             {
                 reindex[indexes[i]] = i;
             }
@@ -76,7 +76,10 @@ namespace fwdpp
                                 if (x.first->second == i)
                                     {
                                         x.first->second
-                                            = reordered_muts.size() - 1;
+                                            = static_cast<decltype(
+                                                  x.first->second)>(
+                                                  reordered_muts.size())
+                                              - 1;
                                         break;
                                     }
                                 ++x.first;

--- a/fwdpp/debug.hpp
+++ b/fwdpp/debug.hpp
@@ -30,6 +30,8 @@
  * code is compiled with -DNDEBUG, as they evaluate to empty functions.
  */
 
+#include <cstdint>
+
 namespace fwdpp
 {
     namespace debug
@@ -37,7 +39,7 @@ namespace fwdpp
         template <typename gcont_t>
         void
         validate_sum_haploid_genome_counts(const gcont_t &haploid_genomes,
-                                           const uint_t expected_sum)
+                                           const std::size_t expected_sum)
         /// Throw exception if sum of all haploid_genome counts != \a expected_sum
         {
             detail::validate_sum_haploid_genome_counts(haploid_genomes,

--- a/fwdpp/extensions/callbacks.hpp
+++ b/fwdpp/extensions/callbacks.hpp
@@ -51,7 +51,7 @@ namespace fwdpp
             std::function<double(const gsl_rng *)> s, h;
             //! Default constructor useful in extension situations that don't
             //! understand std::function
-            shmodel() = default;
+            shmodel() : s{}, h{} {}
             //! More efficient constructor for c++11-aware situations
             shmodel(std::function<double(const gsl_rng *)> sfxn,
                     std::function<double(const gsl_rng *)> hfxn)
@@ -204,6 +204,6 @@ namespace fwdpp
                 return gsl_ran_gamma(r, shape, mean / shape);
             }
         };
-    }
-}
+    } // namespace extensions
+} // namespace fwdpp
 #endif

--- a/fwdpp/internal/data_matrix_details.hpp
+++ b/fwdpp/internal/data_matrix_details.hpp
@@ -101,15 +101,16 @@ namespace fwdpp
                     const std::pair<std::size_t, uint_t> &mutation_record,
                     const matrix_type mtype)
         {
-            int onfirst
+            std::int8_t onfirst
                 = (std::find(first.begin(), first.end(), mutation_record.first)
                    != first.end());
-            int onsecond = (std::find(second.begin(), second.end(),
-                                      mutation_record.first)
-                            != second.end());
+            std::int8_t onsecond = (std::find(second.begin(), second.end(),
+                                              mutation_record.first)
+                                    != second.end());
             if (mtype == matrix_type::genotype)
                 {
-                    site.push_back(onfirst + onsecond);
+                    site.push_back(
+                        static_cast<std::int8_t>(onfirst + onsecond));
                 }
             else
                 {

--- a/fwdpp/internal/debug_details.hpp
+++ b/fwdpp/internal/debug_details.hpp
@@ -28,18 +28,18 @@ namespace fwdpp
             template <typename gcont_t>
             void
             validate_sum_haploid_genome_counts(const gcont_t &haploid_genomes,
-                                       const uint_t expected_sum)
+                                               const std::size_t expected_sum)
             {
 #ifndef NDEBUG
-                uint_t s = 0;
+                std::size_t s = 0;
                 for (auto &g : haploid_genomes)
                     {
                         s += g.n;
                     }
                 if (s != expected_sum)
                     {
-                        throw std::runtime_error(
-                            "FWDPP DEBUG: unexpectd sum of haploid_genome counts");
+                        throw std::runtime_error("FWDPP DEBUG: unexpectd sum "
+                                                 "of haploid_genome counts");
                     }
 #endif
             }
@@ -76,7 +76,8 @@ namespace fwdpp
 
             template <typename haploid_genome_t, typename mcont_t>
             void
-            haploid_genome_is_sorted(const haploid_genome_t &g, const mcont_t &m)
+            haploid_genome_is_sorted(const haploid_genome_t &g,
+                                     const mcont_t &m)
             /*!
              * \brief Check that neutral mutation keys are sorted according to mutation
              * position
@@ -105,9 +106,9 @@ namespace fwdpp
             template <typename key_container, typename mcont_t>
             void
             haploid_genome_data_valid(const key_container &keys,
-                              const mcont_t &mutations,
-                              const std::vector<uint_t> &mutcounts,
-                              const bool expected_neutrality)
+                                      const mcont_t &mutations,
+                                      const std::vector<uint_t> &mutcounts,
+                                      const bool expected_neutrality)
             {
 #ifndef NDEBUG
                 for (auto &k : keys)
@@ -130,8 +131,9 @@ namespace fwdpp
 
             template <typename haploid_genome_t, typename mcont_t>
             void
-            haploid_genome_data_valid(const haploid_genome_t &g, const mcont_t &mutations,
-                              const std::vector<uint_t> &mutcounts)
+            haploid_genome_data_valid(const haploid_genome_t &g,
+                                      const mcont_t &mutations,
+                                      const std::vector<uint_t> &mutcounts)
             /*
       \brief Check that "neutral" and "non-neutral" mutations are where we
       expect them to be.
@@ -139,10 +141,10 @@ namespace fwdpp
             {
 #ifndef NDEBUG
                 detail::haploid_genome_is_sorted(g, mutations);
-                detail::haploid_genome_data_valid(g.mutations, mutations, mutcounts,
-                                          true);
-                detail::haploid_genome_data_valid(g.smutations, mutations, mutcounts,
-                                          false);
+                detail::haploid_genome_data_valid(g.mutations, mutations,
+                                                  mutcounts, true);
+                detail::haploid_genome_data_valid(g.smutations, mutations,
+                                                  mutcounts, false);
 #endif
             }
 
@@ -154,15 +156,20 @@ namespace fwdpp
                                      const std::vector<uint_t> &mutcounts)
             {
 #ifndef NDEBUG
-                if (!haploid_genomes[dip.first].n || !haploid_genomes[dip.second].n)
+                if (!haploid_genomes[dip.first].n
+                    || !haploid_genomes[dip.second].n)
                     {
                         throw std::runtime_error(
                             "FWDPP DEBUG: haploid_genome count is zero");
                     }
-                haploid_genome_is_sorted(haploid_genomes[dip.first], mutations);
-                haploid_genome_is_sorted(haploid_genomes[dip.second], mutations);
-                haploid_genome_data_valid(haploid_genomes[dip.first], mutations, mutcounts);
-                haploid_genome_data_valid(haploid_genomes[dip.second], mutations, mutcounts);
+                haploid_genome_is_sorted(haploid_genomes[dip.first],
+                                         mutations);
+                haploid_genome_is_sorted(haploid_genomes[dip.second],
+                                         mutations);
+                haploid_genome_data_valid(haploid_genomes[dip.first],
+                                          mutations, mutcounts);
+                haploid_genome_data_valid(haploid_genomes[dip.second],
+                                          mutations, mutcounts);
 #endif
             }
 
@@ -173,8 +180,8 @@ namespace fwdpp
 #ifndef NDEBUG
                 for (const auto &d : pop.diploids)
                     {
-                        validate_pop_data_common(d, pop.haploid_genomes, pop.mutations,
-                                                 pop.mcounts);
+                        validate_pop_data_common(d, pop.haploid_genomes,
+                                                 pop.mutations, pop.mcounts);
                     }
 #endif
             }
@@ -206,7 +213,7 @@ namespace fwdpp
             template <typename poptype>
             void
             all_haploid_genomes_extant(const poptype &pop,
-                               const fwdpp::poptypes::DIPLOID_TAG)
+                                       const fwdpp::poptypes::DIPLOID_TAG)
             {
 #ifndef NEBUG
                 for (auto &dip : pop.diploids)

--- a/fwdpp/mutate_recombine.hpp
+++ b/fwdpp/mutate_recombine.hpp
@@ -175,7 +175,7 @@ namespace fwdpp
 
     template <typename gcont_t, typename mcont_t, typename queue_type,
               typename new_mutations_type, typename breakpoints_type>
-    uint_t
+    std::size_t
     mutate_recombine(
         const new_mutations_type &new_mutations,
         const breakpoints_type &breakpoints, const std::size_t g1,

--- a/testsuite/fixtures/fwdpp_fixtures.hpp
+++ b/testsuite/fixtures/fwdpp_fixtures.hpp
@@ -26,8 +26,7 @@ using mtype = fwdpp::mutation;
 using mcont_t = std::vector<mtype>;
 using gcont_t = std::vector<fwdpp::haploid_genome>;
 using dipvector_t = std::vector<std::pair<std::size_t, std::size_t>>;
-using lookup_table_t
-    = std::unordered_multimap<double, fwdpp::uint_t>;
+using lookup_table_t = std::unordered_multimap<double, fwdpp::uint_t>;
 using mcounts_t = std::vector<fwdpp::uint_t>;
 
 struct standard_empty_single_deme_fixture
@@ -47,42 +46,22 @@ struct standard_empty_single_deme_fixture
     fwdpp::haploid_genome::mutation_container neutral, selected;
     gsl_rng *r;
     standard_empty_single_deme_fixture()
-        : mutations(mcont_t()), fixations(mcont_t()), haploid_genomes(gcont_t()),
-          diploids(dipvector_t()), mut_lookup(lookup_table_t()),
-          mcounts(mcounts_t()), fixation_times(mcounts_t()),
+        : mutations(mcont_t()), fixations(mcont_t()),
+          haploid_genomes(gcont_t()), diploids(dipvector_t()),
+          mut_lookup(lookup_table_t()), mcounts(mcounts_t()),
+          fixation_times(mcounts_t()),
           neutral(fwdpp::haploid_genome::mutation_container()),
           selected(fwdpp::haploid_genome::mutation_container()),
           r(gsl_rng_alloc(gsl_rng_mt19937))
     {
     }
+    standard_empty_single_deme_fixture(
+        const standard_empty_single_deme_fixture &)
+        = delete;
+    standard_empty_single_deme_fixture &
+    operator=(const standard_empty_single_deme_fixture &)
+        = delete;
     ~standard_empty_single_deme_fixture() { gsl_rng_free(r); }
 };
 
-struct standard_empty_multiloc_fixture
-/*!
-  Basic stuff needed for a simulation of a multilocus simulation using the low
-  level bit of fwdpp
-  \note In practice, one would use fwdpp::multilocus instead of this.  This
-  object is for unit/integration testing only!!
-  \ingroup unit
-*/
-{
-    mcont_t mutations, fixations;
-    gcont_t haploid_genomes;
-    std::vector<dipvector_t> diploids;
-    lookup_table_t mut_lookup;
-    mcounts_t mcounts, fixation_times;
-    fwdpp::haploid_genome::mutation_container neutral, selected;
-    gsl_rng *r;
-    standard_empty_multiloc_fixture()
-        : mutations(mcont_t()), fixations(mcont_t()), haploid_genomes(gcont_t()),
-          diploids(std::vector<dipvector_t>()), mut_lookup(lookup_table_t()),
-          mcounts(mcounts_t()), fixation_times(mcounts_t()),
-          neutral(fwdpp::haploid_genome::mutation_container()),
-          selected(fwdpp::haploid_genome::mutation_container()),
-          r(gsl_rng_alloc(gsl_rng_mt19937))
-    {
-    }
-    ~standard_empty_multiloc_fixture() { gsl_rng_free(r); }
-};
 #endif

--- a/testsuite/unit/test_general_rec_variation.cc
+++ b/testsuite/unit/test_general_rec_variation.cc
@@ -13,7 +13,7 @@
 
 struct fixture
 {
-    const gsl_rng* r;
+    gsl_rng* r;
     const double not_a_num, inf;
     fwdpp::general_rec_variation recvar;
     fwdpp::poisson_interval pi;
@@ -32,6 +32,16 @@ struct fixture
           ci3{ 1e-3, 0.5, false }, g{ 0 }, diploid{ 0, 0 }, mutations{}
     {
         gsl_rng_set(r, 42);
+    }
+
+    fixture(const fixture&) = delete;
+    fixture& operator=(const fixture&) = delete;
+    ~fixture()
+    {
+        if (r != nullptr)
+            {
+                gsl_rng_free(r);
+            }
     }
 };
 


### PR DESCRIPTION
Audit of warnings for the following setup:

./configure --enable-debug=yes CPPFLAGS='-Wall -W -Weffc++ -Wconversion'

Will do this under gcc 9.2.1.