### PR TITLE
Improve memory performance during simplification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,3 +37,9 @@ jobs:
           name: Run test suite
           command: |
               make check -j 2
+
+      - run:
+          name: Run example programs
+          command: |
+              ./examples/wfts_overlapping_generations 1000 1000 0.999 0.0 100 666
+              ./examples/wfts_overlapping_generations 1000 1000 0.999 0.25 100 42

--- a/configure
+++ b/configure
@@ -4483,7 +4483,7 @@ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
-ac_config_files="$ac_config_files Makefile fwdpp/version.hpp fwdpp/Makefile fwdpp/io/Makefile fwdpp/algorithm/Makefile fwdpp/io/detail/Makefile fwdpp/internal/Makefile fwdpp/tags/Makefile fwdpp/sugar/Makefile fwdpp/poptypes/Makefile fwdpp/gsl/Makefile fwdpp/extensions/Makefile fwdpp/meta/Makefile fwdpp/simfunctions/Makefile fwdpp/ts/Makefile fwdpp/ts/detail/Makefile fwdpp/ts/marginal_tree_functions/Makefile fwdpp/util/Makefile fwdpp/genetic_map/Makefile examples/Makefile testsuite/Makefile src/Makefile doc/fwdpp.doxygen"
+ac_config_files="$ac_config_files Makefile fwdpp/version.hpp fwdpp/Makefile fwdpp/io/Makefile fwdpp/algorithm/Makefile fwdpp/io/detail/Makefile fwdpp/internal/Makefile fwdpp/tags/Makefile fwdpp/sugar/Makefile fwdpp/poptypes/Makefile fwdpp/gsl/Makefile fwdpp/extensions/Makefile fwdpp/meta/Makefile fwdpp/simfunctions/Makefile fwdpp/ts/Makefile fwdpp/ts/detail/Makefile fwdpp/ts/marginal_tree_functions/Makefile fwdpp/ts/simplification/Makefile fwdpp/util/Makefile fwdpp/genetic_map/Makefile examples/Makefile testsuite/Makefile src/Makefile doc/fwdpp.doxygen"
 
 
 # Check whether --enable-debug was given.
@@ -6057,6 +6057,7 @@ do
     "fwdpp/ts/Makefile") CONFIG_FILES="$CONFIG_FILES fwdpp/ts/Makefile" ;;
     "fwdpp/ts/detail/Makefile") CONFIG_FILES="$CONFIG_FILES fwdpp/ts/detail/Makefile" ;;
     "fwdpp/ts/marginal_tree_functions/Makefile") CONFIG_FILES="$CONFIG_FILES fwdpp/ts/marginal_tree_functions/Makefile" ;;
+    "fwdpp/ts/simplification/Makefile") CONFIG_FILES="$CONFIG_FILES fwdpp/ts/simplification/Makefile" ;;
     "fwdpp/util/Makefile") CONFIG_FILES="$CONFIG_FILES fwdpp/util/Makefile" ;;
     "fwdpp/genetic_map/Makefile") CONFIG_FILES="$CONFIG_FILES fwdpp/genetic_map/Makefile" ;;
     "examples/Makefile") CONFIG_FILES="$CONFIG_FILES examples/Makefile" ;;

--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,7 @@ AC_CONFIG_FILES([Makefile fwdpp/version.hpp fwdpp/Makefile fwdpp/io/Makefile fwd
                  fwdpp/gsl/Makefile fwdpp/extensions/Makefile fwdpp/meta/Makefile
 				 fwdpp/simfunctions/Makefile
                  fwdpp/ts/Makefile fwdpp/ts/detail/Makefile fwdpp/ts/marginal_tree_functions/Makefile
+                 fwdpp/ts/simplification/Makefile
 				 fwdpp/util/Makefile
 				 fwdpp/genetic_map/Makefile
 				 examples/Makefile testsuite/Makefile src/Makefile doc/fwdpp.doxygen]) 

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -7,7 +7,8 @@ noinst_PROGRAMS=	diploid_ind \
 	custom_diploid \
 	wfts_overlapping_generations \
 	wfts_overlapping_generations_dynamic_indexing \
-	wfts_overlapping_generations_dynamic_indexing_with_mutation
+	wfts_overlapping_generations_dynamic_indexing_with_mutation \
+	load_table_collection
 
 
 diploid_ind_SOURCES=diploid_ind.cc common_ind.hpp
@@ -20,6 +21,7 @@ custom_diploid_SOURCES=custom_diploid.cc common_ind.hpp
 wfts_overlapping_generations_SOURCES=wfts_overlapping_generations.cc wfevolvets.cc wfevolvets.hpp
 wfts_overlapping_generations_dynamic_indexing_SOURCES=wfts_overlapping_generations_dynamic_indexing.cc wfevolvets.cc wfevolvets.hpp
 wfts_overlapping_generations_dynamic_indexing_with_mutation_SOURCES=wfts_overlapping_generations_dynamic_indexing_with_mutation.cc wfevolvets.cc wfevolvets.hpp
+load_table_collection_SOURCES=load_table_collection.cc
 
 # examples based on tree sequences that need boost program options
 if BPO_PRESENT

--- a/examples/Makefile.in
+++ b/examples/Makefile.in
@@ -93,7 +93,7 @@ noinst_PROGRAMS = diploid_ind$(EXEEXT) diploid_fixed_sh_ind$(EXEEXT) \
 	custom_diploid$(EXEEXT) wfts_overlapping_generations$(EXEEXT) \
 	wfts_overlapping_generations_dynamic_indexing$(EXEEXT) \
 	wfts_overlapping_generations_dynamic_indexing_with_mutation$(EXEEXT) \
-	$(am__EXEEXT_1)
+	load_table_collection$(EXEEXT) $(am__EXEEXT_1)
 
 # examples based on tree sequences that need boost program options
 @BPO_PRESENT_TRUE@am__append_1 = wfts_integration_test spatialts
@@ -145,6 +145,10 @@ am_juvenile_migration_OBJECTS = juvenile_migration.$(OBJEXT)
 juvenile_migration_OBJECTS = $(am_juvenile_migration_OBJECTS)
 juvenile_migration_LDADD = $(LDADD)
 juvenile_migration_DEPENDENCIES =
+am_load_table_collection_OBJECTS = load_table_collection.$(OBJEXT)
+load_table_collection_OBJECTS = $(am_load_table_collection_OBJECTS)
+load_table_collection_LDADD = $(LDADD)
+load_table_collection_DEPENDENCIES =
 am__spatialts_SOURCES_DIST = spatialts.cc
 @BPO_PRESENT_TRUE@am_spatialts_OBJECTS = spatialts.$(OBJEXT)
 spatialts_OBJECTS = $(am_spatialts_OBJECTS)
@@ -194,7 +198,8 @@ am__depfiles_remade = ./$(DEPDIR)/K_linked_regions_extensions.Po \
 	./$(DEPDIR)/K_linked_regions_generalized_rec.Po \
 	./$(DEPDIR)/custom_diploid.Po ./$(DEPDIR)/custom_mutation.Po \
 	./$(DEPDIR)/diploid_fixed_sh_ind.Po ./$(DEPDIR)/diploid_ind.Po \
-	./$(DEPDIR)/juvenile_migration.Po ./$(DEPDIR)/spatialts.Po \
+	./$(DEPDIR)/juvenile_migration.Po \
+	./$(DEPDIR)/load_table_collection.Po ./$(DEPDIR)/spatialts.Po \
 	./$(DEPDIR)/tree_sequence_examples_common.Po \
 	./$(DEPDIR)/wfevolvets.Po ./$(DEPDIR)/wfts_integration_test.Po \
 	./$(DEPDIR)/wfts_overlapping_generations.Po \
@@ -230,8 +235,8 @@ SOURCES = $(K_linked_regions_extensions_SOURCES) \
 	$(K_linked_regions_generalized_rec_SOURCES) \
 	$(custom_diploid_SOURCES) $(custom_mutation_SOURCES) \
 	$(diploid_fixed_sh_ind_SOURCES) $(diploid_ind_SOURCES) \
-	$(juvenile_migration_SOURCES) $(spatialts_SOURCES) \
-	$(wfts_integration_test_SOURCES) \
+	$(juvenile_migration_SOURCES) $(load_table_collection_SOURCES) \
+	$(spatialts_SOURCES) $(wfts_integration_test_SOURCES) \
 	$(wfts_overlapping_generations_SOURCES) \
 	$(wfts_overlapping_generations_dynamic_indexing_SOURCES) \
 	$(wfts_overlapping_generations_dynamic_indexing_with_mutation_SOURCES)
@@ -239,7 +244,8 @@ DIST_SOURCES = $(K_linked_regions_extensions_SOURCES) \
 	$(K_linked_regions_generalized_rec_SOURCES) \
 	$(custom_diploid_SOURCES) $(custom_mutation_SOURCES) \
 	$(diploid_fixed_sh_ind_SOURCES) $(diploid_ind_SOURCES) \
-	$(juvenile_migration_SOURCES) $(am__spatialts_SOURCES_DIST) \
+	$(juvenile_migration_SOURCES) $(load_table_collection_SOURCES) \
+	$(am__spatialts_SOURCES_DIST) \
 	$(am__wfts_integration_test_SOURCES_DIST) \
 	$(wfts_overlapping_generations_SOURCES) \
 	$(wfts_overlapping_generations_dynamic_indexing_SOURCES) \
@@ -378,6 +384,7 @@ custom_diploid_SOURCES = custom_diploid.cc common_ind.hpp
 wfts_overlapping_generations_SOURCES = wfts_overlapping_generations.cc wfevolvets.cc wfevolvets.hpp
 wfts_overlapping_generations_dynamic_indexing_SOURCES = wfts_overlapping_generations_dynamic_indexing.cc wfevolvets.cc wfevolvets.hpp
 wfts_overlapping_generations_dynamic_indexing_with_mutation_SOURCES = wfts_overlapping_generations_dynamic_indexing_with_mutation.cc wfevolvets.cc wfevolvets.hpp
+load_table_collection_SOURCES = load_table_collection.cc
 @BPO_PRESENT_TRUE@wfts_integration_test_SOURCES = wfts_integration_test.cc tree_sequence_examples_common.cc
 @BPO_PRESENT_TRUE@wfts_integration_test_LDADD = -lboost_program_options
 @BPO_PRESENT_TRUE@spatialts_SOURCES = spatialts.cc
@@ -451,6 +458,10 @@ juvenile_migration$(EXEEXT): $(juvenile_migration_OBJECTS) $(juvenile_migration_
 	@rm -f juvenile_migration$(EXEEXT)
 	$(AM_V_CXXLD)$(CXXLINK) $(juvenile_migration_OBJECTS) $(juvenile_migration_LDADD) $(LIBS)
 
+load_table_collection$(EXEEXT): $(load_table_collection_OBJECTS) $(load_table_collection_DEPENDENCIES) $(EXTRA_load_table_collection_DEPENDENCIES) 
+	@rm -f load_table_collection$(EXEEXT)
+	$(AM_V_CXXLD)$(CXXLINK) $(load_table_collection_OBJECTS) $(load_table_collection_LDADD) $(LIBS)
+
 spatialts$(EXEEXT): $(spatialts_OBJECTS) $(spatialts_DEPENDENCIES) $(EXTRA_spatialts_DEPENDENCIES) 
 	@rm -f spatialts$(EXEEXT)
 	$(AM_V_CXXLD)$(CXXLINK) $(spatialts_OBJECTS) $(spatialts_LDADD) $(LIBS)
@@ -484,6 +495,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/diploid_fixed_sh_ind.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/diploid_ind.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/juvenile_migration.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/load_table_collection.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/spatialts.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/tree_sequence_examples_common.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/wfevolvets.Po@am__quote@ # am--include-marker
@@ -645,6 +657,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/diploid_fixed_sh_ind.Po
 	-rm -f ./$(DEPDIR)/diploid_ind.Po
 	-rm -f ./$(DEPDIR)/juvenile_migration.Po
+	-rm -f ./$(DEPDIR)/load_table_collection.Po
 	-rm -f ./$(DEPDIR)/spatialts.Po
 	-rm -f ./$(DEPDIR)/tree_sequence_examples_common.Po
 	-rm -f ./$(DEPDIR)/wfevolvets.Po
@@ -704,6 +717,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/diploid_fixed_sh_ind.Po
 	-rm -f ./$(DEPDIR)/diploid_ind.Po
 	-rm -f ./$(DEPDIR)/juvenile_migration.Po
+	-rm -f ./$(DEPDIR)/load_table_collection.Po
 	-rm -f ./$(DEPDIR)/spatialts.Po
 	-rm -f ./$(DEPDIR)/tree_sequence_examples_common.Po
 	-rm -f ./$(DEPDIR)/wfevolvets.Po

--- a/examples/load_table_collection.cc
+++ b/examples/load_table_collection.cc
@@ -1,0 +1,53 @@
+// Example of reading in a table_collection that has
+// been dumped to an uncompressed file.  For example,
+// the output from wfts_integration_test
+
+#include <fstream>
+#include <iostream>
+#include <cstdlib>
+#include <stdexcept>
+#include <fwdpp/ts/serialization.hpp>
+
+int
+main(int argc, char** argv)
+{
+    if (argc < 2)
+        {
+            std::cerr << "Usage: " << argv[0] << " infile\n";
+            std::exit(1);
+        }
+
+    std::ifstream in(argv[1]);
+    if (!in)
+        {
+            throw std::invalid_argument("cannot open file for reading");
+        }
+
+    auto tables = fwdpp::ts::io::deserialize_tables(in);
+
+    std::cout << "Nodes:\n";
+    for (auto&& n : tables.node_table)
+        {
+            std::cout << n.time << ' ' << n.deme << '\n';
+        }
+
+    std::cout << "Edges:\n";
+    for (auto&& e : tables.edge_table)
+        {
+            std::cout << e.left << ' ' << e.right << ' ' << e.parent << ' '
+                      << e.child << '\n';
+        }
+
+    std::cout << "Sites:\n";
+    for (auto&& s : tables.site_table)
+        {
+            std::cout << s.position << ' ' << s.ancestral_state << '\n';
+        }
+
+    std::cout << "Mutations:\n";
+    for (auto&& m : tables.mutation_table)
+        {
+            std::cout << m.key << ' ' << m.node << ' ' << m.site << ' '
+                      << m.neutral << ' ' << m.derived_state << '\n';
+        }
+}

--- a/fwdpp/ts/Makefile.am
+++ b/fwdpp/ts/Makefile.am
@@ -1,5 +1,7 @@
 pkgincludedir=$(prefix)/include/fwdpp/ts
 
+SUBDIRS=simplification
+
 pkginclude_HEADERS= definitions.hpp \
 			node.hpp \
 			edge.hpp \

--- a/fwdpp/ts/simplification/Makefile.am
+++ b/fwdpp/ts/simplification/Makefile.am
@@ -1,0 +1,4 @@
+pkgincludedir=$(prefix)/include/fwdpp/ts/simplification
+
+pkginclude_HEADERS=segment.hpp \
+				   ancestry_list.hpp

--- a/fwdpp/ts/simplification/Makefile.in
+++ b/fwdpp/ts/simplification/Makefile.in
@@ -85,7 +85,7 @@ POST_INSTALL = :
 NORMAL_UNINSTALL = :
 PRE_UNINSTALL = :
 POST_UNINSTALL = :
-subdir = fwdpp/ts
+subdir = fwdpp/ts/simplification
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
 	$(top_srcdir)/configure.ac
@@ -111,14 +111,6 @@ am__v_at_0 = @
 am__v_at_1 = 
 SOURCES =
 DIST_SOURCES =
-RECURSIVE_TARGETS = all-recursive check-recursive cscopelist-recursive \
-	ctags-recursive dvi-recursive html-recursive info-recursive \
-	install-data-recursive install-dvi-recursive \
-	install-exec-recursive install-html-recursive \
-	install-info-recursive install-pdf-recursive \
-	install-ps-recursive install-recursive installcheck-recursive \
-	installdirs-recursive pdf-recursive ps-recursive \
-	tags-recursive uninstall-recursive
 am__can_run_installinfo = \
   case $$AM_UPDATE_INFO_DIR in \
     n|no|NO) false;; \
@@ -153,14 +145,6 @@ am__uninstall_files_from_dir = { \
   }
 am__installdirs = "$(DESTDIR)$(pkgincludedir)"
 HEADERS = $(pkginclude_HEADERS)
-RECURSIVE_CLEAN_TARGETS = mostlyclean-recursive clean-recursive	\
-  distclean-recursive maintainer-clean-recursive
-am__recursive_targets = \
-  $(RECURSIVE_TARGETS) \
-  $(RECURSIVE_CLEAN_TARGETS) \
-  $(am__extra_recursive_targets)
-AM_RECURSIVE_TARGETS = $(am__recursive_targets:-recursive=) TAGS CTAGS \
-	distdir distdir-am
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
 # Read a list of newline-separated strings from the standard input,
 # and print each of them once, without duplicates.  Input order is
@@ -180,35 +164,9 @@ am__define_uniq_tagged_files = \
   done | $(am__uniquify_input)`
 ETAGS = etags
 CTAGS = ctags
-DIST_SUBDIRS = $(SUBDIRS)
 am__DIST_COMMON = $(srcdir)/Makefile.in
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
-am__relativize = \
-  dir0=`pwd`; \
-  sed_first='s,^\([^/]*\)/.*$$,\1,'; \
-  sed_rest='s,^[^/]*/*,,'; \
-  sed_last='s,^.*/\([^/]*\)$$,\1,'; \
-  sed_butlast='s,/*[^/]*$$,,'; \
-  while test -n "$$dir1"; do \
-    first=`echo "$$dir1" | sed -e "$$sed_first"`; \
-    if test "$$first" != "."; then \
-      if test "$$first" = ".."; then \
-        dir2=`echo "$$dir0" | sed -e "$$sed_last"`/"$$dir2"; \
-        dir0=`echo "$$dir0" | sed -e "$$sed_butlast"`; \
-      else \
-        first2=`echo "$$dir2" | sed -e "$$sed_first"`; \
-        if test "$$first2" = "$$first"; then \
-          dir2=`echo "$$dir2" | sed -e "$$sed_rest"`; \
-        else \
-          dir2="../$$dir2"; \
-        fi; \
-        dir0="$$dir0"/"$$first"; \
-      fi; \
-    fi; \
-    dir1=`echo "$$dir1" | sed -e "$$sed_rest"`; \
-  done; \
-  reldir="$$dir2"
-pkgincludedir = $(prefix)/include/fwdpp/ts
+pkgincludedir = $(prefix)/include/fwdpp/ts/simplification
 ACLOCAL = @ACLOCAL@
 AMTAR = @AMTAR@
 AM_DEFAULT_VERBOSITY = @AM_DEFAULT_VERBOSITY@
@@ -307,35 +265,10 @@ target_alias = @target_alias@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
-SUBDIRS = simplification
-pkginclude_HEADERS = definitions.hpp \
-			node.hpp \
-			edge.hpp \
-			site.hpp \
-			table_collection.hpp \
-			table_simplifier.hpp \
-			get_parent_ids.hpp \
-			generate_data_matrix.hpp \
-			indexed_edge.hpp \
-			marginal_tree.hpp \
-			tree_visitor.hpp \
-			mark_multiple_roots.hpp \
-			mutate_tables.hpp \
-			count_mutations.hpp \
-			mutation_record.hpp \
-			remove_fixations_from_gametes.hpp \
-			recycling.hpp \
-			serialization_version.hpp \
-			serialization.hpp \
-			marginal_tree_functions.hpp \
-			decapitate.hpp \
-			exceptions.hpp \
-			mutation_tools.hpp \
-			table_types.hpp \
-			visit_sites.hpp \
-			site_visitor.hpp
+pkginclude_HEADERS = segment.hpp \
+				   ancestry_list.hpp
 
-all: all-recursive
+all: all-am
 
 .SUFFIXES:
 $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__configure_deps)
@@ -347,9 +280,9 @@ $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__confi
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu fwdpp/ts/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu fwdpp/ts/simplification/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu fwdpp/ts/Makefile
+	  $(AUTOMAKE) --gnu fwdpp/ts/simplification/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \
@@ -389,61 +322,14 @@ uninstall-pkgincludeHEADERS:
 	files=`for p in $$list; do echo $$p; done | sed -e 's|^.*/||'`; \
 	dir='$(DESTDIR)$(pkgincludedir)'; $(am__uninstall_files_from_dir)
 
-# This directory's subdirectories are mostly independent; you can cd
-# into them and run 'make' without going through this Makefile.
-# To change the values of 'make' variables: instead of editing Makefiles,
-# (1) if the variable is set in 'config.status', edit 'config.status'
-#     (which will cause the Makefiles to be regenerated when you run 'make');
-# (2) otherwise, pass the desired values on the 'make' command line.
-$(am__recursive_targets):
-	@fail=; \
-	if $(am__make_keepgoing); then \
-	  failcom='fail=yes'; \
-	else \
-	  failcom='exit 1'; \
-	fi; \
-	dot_seen=no; \
-	target=`echo $@ | sed s/-recursive//`; \
-	case "$@" in \
-	  distclean-* | maintainer-clean-*) list='$(DIST_SUBDIRS)' ;; \
-	  *) list='$(SUBDIRS)' ;; \
-	esac; \
-	for subdir in $$list; do \
-	  echo "Making $$target in $$subdir"; \
-	  if test "$$subdir" = "."; then \
-	    dot_seen=yes; \
-	    local_target="$$target-am"; \
-	  else \
-	    local_target="$$target"; \
-	  fi; \
-	  ($(am__cd) $$subdir && $(MAKE) $(AM_MAKEFLAGS) $$local_target) \
-	  || eval $$failcom; \
-	done; \
-	if test "$$dot_seen" = "no"; then \
-	  $(MAKE) $(AM_MAKEFLAGS) "$$target-am" || exit 1; \
-	fi; test -z "$$fail"
-
 ID: $(am__tagged_files)
 	$(am__define_uniq_tagged_files); mkid -fID $$unique
-tags: tags-recursive
+tags: tags-am
 TAGS: tags
 
 tags-am: $(TAGS_DEPENDENCIES) $(am__tagged_files)
 	set x; \
 	here=`pwd`; \
-	if ($(ETAGS) --etags-include --version) >/dev/null 2>&1; then \
-	  include_option=--etags-include; \
-	  empty_fix=.; \
-	else \
-	  include_option=--include; \
-	  empty_fix=; \
-	fi; \
-	list='$(SUBDIRS)'; for subdir in $$list; do \
-	  if test "$$subdir" = .; then :; else \
-	    test ! -f $$subdir/TAGS || \
-	      set "$$@" "$$include_option=$$here/$$subdir/TAGS"; \
-	  fi; \
-	done; \
 	$(am__define_uniq_tagged_files); \
 	shift; \
 	if test -z "$(ETAGS_ARGS)$$*$$unique"; then :; else \
@@ -456,7 +342,7 @@ tags-am: $(TAGS_DEPENDENCIES) $(am__tagged_files)
 	      $$unique; \
 	  fi; \
 	fi
-ctags: ctags-recursive
+ctags: ctags-am
 
 CTAGS: ctags
 ctags-am: $(TAGS_DEPENDENCIES) $(am__tagged_files)
@@ -469,7 +355,7 @@ GTAGS:
 	here=`$(am__cd) $(top_builddir) && pwd` \
 	  && $(am__cd) $(top_srcdir) \
 	  && gtags -i $(GTAGS_ARGS) "$$here"
-cscopelist: cscopelist-recursive
+cscopelist: cscopelist-am
 
 cscopelist-am: $(am__tagged_files)
 	list='$(am__tagged_files)'; \
@@ -521,48 +407,22 @@ distdir-am: $(DISTFILES)
 	    || exit 1; \
 	  fi; \
 	done
-	@list='$(DIST_SUBDIRS)'; for subdir in $$list; do \
-	  if test "$$subdir" = .; then :; else \
-	    $(am__make_dryrun) \
-	      || test -d "$(distdir)/$$subdir" \
-	      || $(MKDIR_P) "$(distdir)/$$subdir" \
-	      || exit 1; \
-	    dir1=$$subdir; dir2="$(distdir)/$$subdir"; \
-	    $(am__relativize); \
-	    new_distdir=$$reldir; \
-	    dir1=$$subdir; dir2="$(top_distdir)"; \
-	    $(am__relativize); \
-	    new_top_distdir=$$reldir; \
-	    echo " (cd $$subdir && $(MAKE) $(AM_MAKEFLAGS) top_distdir="$$new_top_distdir" distdir="$$new_distdir" \\"; \
-	    echo "     am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)"; \
-	    ($(am__cd) $$subdir && \
-	      $(MAKE) $(AM_MAKEFLAGS) \
-	        top_distdir="$$new_top_distdir" \
-	        distdir="$$new_distdir" \
-		am__remove_distdir=: \
-		am__skip_length_check=: \
-		am__skip_mode_fix=: \
-	        distdir) \
-	      || exit 1; \
-	  fi; \
-	done
 check-am: all-am
-check: check-recursive
+check: check-am
 all-am: Makefile $(HEADERS)
-installdirs: installdirs-recursive
-installdirs-am:
+installdirs:
 	for dir in "$(DESTDIR)$(pkgincludedir)"; do \
 	  test -z "$$dir" || $(MKDIR_P) "$$dir"; \
 	done
-install: install-recursive
-install-exec: install-exec-recursive
-install-data: install-data-recursive
-uninstall: uninstall-recursive
+install: install-am
+install-exec: install-exec-am
+install-data: install-data-am
+uninstall: uninstall-am
 
 install-am: all-am
 	@$(MAKE) $(AM_MAKEFLAGS) install-exec-am install-data-am
 
-installcheck: installcheck-recursive
+installcheck: installcheck-am
 install-strip:
 	if test -z '$(STRIP)'; then \
 	  $(MAKE) $(AM_MAKEFLAGS) INSTALL_PROGRAM="$(INSTALL_STRIP_PROGRAM)" \
@@ -584,86 +444,86 @@ distclean-generic:
 maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
 	@echo "it deletes files that may require special tools to rebuild."
-clean: clean-recursive
+clean: clean-am
 
 clean-am: clean-generic mostlyclean-am
 
-distclean: distclean-recursive
+distclean: distclean-am
 	-rm -f Makefile
 distclean-am: clean-am distclean-generic distclean-tags
 
-dvi: dvi-recursive
+dvi: dvi-am
 
 dvi-am:
 
-html: html-recursive
+html: html-am
 
 html-am:
 
-info: info-recursive
+info: info-am
 
 info-am:
 
 install-data-am: install-pkgincludeHEADERS
 
-install-dvi: install-dvi-recursive
+install-dvi: install-dvi-am
 
 install-dvi-am:
 
 install-exec-am:
 
-install-html: install-html-recursive
+install-html: install-html-am
 
 install-html-am:
 
-install-info: install-info-recursive
+install-info: install-info-am
 
 install-info-am:
 
 install-man:
 
-install-pdf: install-pdf-recursive
+install-pdf: install-pdf-am
 
 install-pdf-am:
 
-install-ps: install-ps-recursive
+install-ps: install-ps-am
 
 install-ps-am:
 
 installcheck-am:
 
-maintainer-clean: maintainer-clean-recursive
+maintainer-clean: maintainer-clean-am
 	-rm -f Makefile
 maintainer-clean-am: distclean-am maintainer-clean-generic
 
-mostlyclean: mostlyclean-recursive
+mostlyclean: mostlyclean-am
 
 mostlyclean-am: mostlyclean-generic
 
-pdf: pdf-recursive
+pdf: pdf-am
 
 pdf-am:
 
-ps: ps-recursive
+ps: ps-am
 
 ps-am:
 
 uninstall-am: uninstall-pkgincludeHEADERS
 
-.MAKE: $(am__recursive_targets) install-am install-strip
+.MAKE: install-am install-strip
 
-.PHONY: $(am__recursive_targets) CTAGS GTAGS TAGS all all-am check \
-	check-am clean clean-generic cscopelist-am ctags ctags-am \
-	distclean distclean-generic distclean-tags distdir dvi dvi-am \
-	html html-am info info-am install install-am install-data \
-	install-data-am install-dvi install-dvi-am install-exec \
-	install-exec-am install-html install-html-am install-info \
-	install-info-am install-man install-pdf install-pdf-am \
-	install-pkgincludeHEADERS install-ps install-ps-am \
-	install-strip installcheck installcheck-am installdirs \
-	installdirs-am maintainer-clean maintainer-clean-generic \
-	mostlyclean mostlyclean-generic pdf pdf-am ps ps-am tags \
-	tags-am uninstall uninstall-am uninstall-pkgincludeHEADERS
+.PHONY: CTAGS GTAGS TAGS all all-am check check-am clean clean-generic \
+	cscopelist-am ctags ctags-am distclean distclean-generic \
+	distclean-tags distdir dvi dvi-am html html-am info info-am \
+	install install-am install-data install-data-am install-dvi \
+	install-dvi-am install-exec install-exec-am install-html \
+	install-html-am install-info install-info-am install-man \
+	install-pdf install-pdf-am install-pkgincludeHEADERS \
+	install-ps install-ps-am install-strip installcheck \
+	installcheck-am installdirs maintainer-clean \
+	maintainer-clean-generic mostlyclean mostlyclean-generic pdf \
+	pdf-am ps ps-am tags tags-am uninstall uninstall-am \
+	uninstall-pkgincludeHEADERS
 
 .PRECIOUS: Makefile
 

--- a/fwdpp/ts/simplification/ancestry_list.hpp
+++ b/fwdpp/ts/simplification/ancestry_list.hpp
@@ -60,6 +60,10 @@ namespace fwdpp
                 if (first[i] == -1)
                     {
                         first[i] = segments.size() - 1;
+                        if (segments.size() >= next.size())
+                            {
+                                next.push_back(-1);
+                            }
                     }
                 else
                     {

--- a/fwdpp/ts/simplification/ancestry_list.hpp
+++ b/fwdpp/ts/simplification/ancestry_list.hpp
@@ -1,0 +1,86 @@
+#ifndef FWDPP_TS_SIMPLIFICATION_ANCESTRY_LIST_HPP__
+#define FWDPP_TS_SIMPLIFICATION_ANCESTRY_LIST_HPP__
+
+#include <cstdint>
+#include <algorithm>
+#include <vector>
+#include "segment.hpp"
+
+namespace fwdpp
+{
+    namespace ts
+    {
+        class ancestry_list
+        {
+          private:
+            void
+            resize_and_fill(std::vector<std::int32_t>& v, std::size_t n)
+            {
+                v.resize(n);
+                std::fill(begin(v), end(v), -1);
+            }
+
+          public:
+            std::vector<segment> segments;
+            std::vector<std::int32_t> first, next;
+
+            ancestry_list() : segments(), first(), next() {}
+
+            void
+            init(std::size_t n)
+            {
+                segments.clear();
+                resize_and_fill(first, n);
+                resize_and_fill(next, n);
+            }
+
+            std::int32_t
+            get_chain_tail(std::size_t i) const
+            {
+                if (i >= first.size())
+                    {
+                        throw std::runtime_error("index out of range");
+                    }
+                auto f = first[i];
+                while (f != -1 && next[f] != -1)
+                    {
+                        f = next[f];
+                    }
+                return f;
+            }
+
+            void
+            add_record(std::size_t i, double l, double r, TS_NODE_INT n)
+            {
+                if (i >= first.size())
+                    {
+                        throw std::runtime_error("index out of range");
+                    }
+                segments.emplace_back(l, r, n);
+                if (first[i] == -1)
+                    {
+                        first[i] = segments.size() - 1;
+                    }
+                else
+                    {
+                        next.push_back(-1);
+                        auto l = get_chain_tail(i);
+                        next[l] = segments.size() - 1;
+                    }
+            }
+
+            void
+            nullify_chain(std::size_t i)
+            {
+                if (i >= first.size())
+                    {
+                        throw std::runtime_error("index out of range");
+                    }
+                first[i] = -1;
+            }
+        };
+
+    } // namespace ts
+} // namespace fwdpp
+
+#endif

--- a/fwdpp/ts/simplification/segment.hpp
+++ b/fwdpp/ts/simplification/segment.hpp
@@ -1,0 +1,28 @@
+#ifndef FWDPP_TS_SIMPLIFICATION_SEGMENT_HPP__
+#define FWDPP_TS_SIMPLIFICATION_SEGMENT_HPP__
+
+#include <fwdpp/ts/definitions.hpp>
+#include <stdexcept>
+
+namespace fwdpp
+{
+    namespace ts
+    {
+        struct segment
+        {
+            double left, right;
+            TS_NODE_INT node;
+            segment(double l, double r, TS_NODE_INT n)
+                : left{ l }, right{ r }, node{ n }
+            {
+                if (right <= left)
+                    {
+                        throw std::invalid_argument("right must be > left");
+                    }
+            }
+        };
+
+    } // namespace ts
+} // namespace fwdpp
+
+#endif

--- a/fwdpp/ts/table_simplifier.hpp
+++ b/fwdpp/ts/table_simplifier.hpp
@@ -31,6 +31,7 @@ namespace fwdpp
          *  without notice.
          *
          *  \version 0.7.0 Added to fwdpp
+         *  \version 0.8.0 Added AncestryList, which greatly reduces memory overhead.
          */
         {
           private:

--- a/fwdpp/ts/table_simplifier.hpp
+++ b/fwdpp/ts/table_simplifier.hpp
@@ -13,6 +13,8 @@
 #include "node.hpp"
 #include "edge.hpp"
 #include "table_collection.hpp"
+#include "simplification/segment.hpp"
+#include "simplification/ancestry_list.hpp"
 
 namespace fwdpp
 {
@@ -36,90 +38,6 @@ namespace fwdpp
          */
         {
           private:
-            struct segment
-            {
-                double left, right;
-                TS_NODE_INT node;
-                segment(double l, double r, TS_NODE_INT n)
-                    : left{ l }, right{ r }, node{ n }
-                {
-                    if (right <= left)
-                        {
-                            throw std::invalid_argument(
-                                "right must be > left");
-                        }
-                }
-            };
-
-            class ancestry_list
-            {
-              private:
-                void
-                resize_and_fill(std::vector<std::int32_t>& v, std::size_t n)
-                {
-                    v.resize(n);
-                    std::fill(begin(v), end(v), -1);
-                }
-
-              public:
-                std::vector<segment> segments;
-                std::vector<std::int32_t> first, next;
-
-                ancestry_list() : segments(), first(), next() {}
-
-                void
-                init(std::size_t n)
-                {
-                    segments.clear();
-                    resize_and_fill(first, n);
-                    resize_and_fill(next, n);
-                }
-
-                std::int32_t
-                get_chain_tail(std::size_t i) const
-                {
-                    if (i >= first.size())
-                        {
-                            throw std::runtime_error("index out of range");
-                        }
-                    auto f = first[i];
-                    while (f != -1 && next[f] != -1)
-                        {
-                            f = next[f];
-                        }
-                    return f;
-                }
-
-                void
-                add_record(std::size_t i, double l, double r, TS_NODE_INT n)
-                {
-                    if (i >= first.size())
-                        {
-                            throw std::runtime_error("index out of range");
-                        }
-                    segments.emplace_back(l, r, n);
-                    if (first[i] == -1)
-                        {
-                            first[i] = segments.size() - 1;
-                        }
-                    else
-                        {
-                            next.push_back(-1);
-                            auto l = get_chain_tail(i);
-                            next[l] = segments.size() - 1;
-                        }
-                }
-
-                void
-                nullify_chain(std::size_t i)
-                {
-                    if (i >= first.size())
-                        {
-                            throw std::runtime_error("index out of range");
-                        }
-                    first[i] = -1;
-                }
-            };
 
             struct mutation_node_map_entry
             {

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -53,7 +53,8 @@ tree_sequences_tree_sequence_tests_SOURCES=tree_sequences/tree_sequence_tests.cc
 										tree_sequences/test_table_collection.cc \
 										tree_sequences/test_visit_sites.cc \
 										tree_sequences/test_site_visitor.cc \
-										tree_sequences/test_marginal_tree.cc
+										tree_sequences/test_marginal_tree.cc \
+										tree_sequences/test_ancestry_list.cc
 
 AM_CXXFLAGS=-W -Wall
 

--- a/testsuite/Makefile.in
+++ b/testsuite/Makefile.in
@@ -133,7 +133,8 @@ am__tree_sequences_tree_sequence_tests_SOURCES_DIST =  \
 	tree_sequences/test_table_collection.cc \
 	tree_sequences/test_visit_sites.cc \
 	tree_sequences/test_site_visitor.cc \
-	tree_sequences/test_marginal_tree.cc
+	tree_sequences/test_marginal_tree.cc \
+	tree_sequences/test_ancestry_list.cc
 @BUNIT_TEST_PRESENT_TRUE@am_tree_sequences_tree_sequence_tests_OBJECTS = tree_sequences/tree_sequence_tests.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_generate_offspring.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_preorder_node_traversal.$(OBJEXT) \
@@ -149,7 +150,8 @@ am__tree_sequences_tree_sequence_tests_SOURCES_DIST =  \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_table_collection.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_visit_sites.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_site_visitor.$(OBJEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_marginal_tree.$(OBJEXT)
+@BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_marginal_tree.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_ancestry_list.$(OBJEXT)
 tree_sequences_tree_sequence_tests_OBJECTS =  \
 	$(am_tree_sequences_tree_sequence_tests_OBJECTS)
 tree_sequences_tree_sequence_tests_LDADD = $(LDADD)
@@ -230,6 +232,7 @@ am__depfiles_remade = fixtures/$(DEPDIR)/sugar_fixtures.Po \
 	integration/$(DEPDIR)/sugar_singlepopTest.Po \
 	integration/$(DEPDIR)/sugar_singlepop_custom_diploidTest.Po \
 	tree_sequences/$(DEPDIR)/independent_implementations.Po \
+	tree_sequences/$(DEPDIR)/test_ancestry_list.Po \
 	tree_sequences/$(DEPDIR)/test_decapitate.Po \
 	tree_sequences/$(DEPDIR)/test_generate_data_matrix.Po \
 	tree_sequences/$(DEPDIR)/test_generate_offspring.Po \
@@ -674,7 +677,8 @@ top_srcdir = @top_srcdir@
 @BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_table_collection.cc \
 @BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_visit_sites.cc \
 @BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_site_visitor.cc \
-@BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_marginal_tree.cc
+@BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_marginal_tree.cc \
+@BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_ancestry_list.cc
 
 @BUNIT_TEST_PRESENT_TRUE@AM_CXXFLAGS = -W -Wall
 all: all-am
@@ -794,6 +798,9 @@ tree_sequences/test_site_visitor.$(OBJEXT):  \
 tree_sequences/test_marginal_tree.$(OBJEXT):  \
 	tree_sequences/$(am__dirstamp) \
 	tree_sequences/$(DEPDIR)/$(am__dirstamp)
+tree_sequences/test_ancestry_list.$(OBJEXT):  \
+	tree_sequences/$(am__dirstamp) \
+	tree_sequences/$(DEPDIR)/$(am__dirstamp)
 
 tree_sequences/tree_sequence_tests$(EXEEXT): $(tree_sequences_tree_sequence_tests_OBJECTS) $(tree_sequences_tree_sequence_tests_DEPENDENCIES) $(EXTRA_tree_sequences_tree_sequence_tests_DEPENDENCIES) tree_sequences/$(am__dirstamp)
 	@rm -f tree_sequences/tree_sequence_tests$(EXEEXT)
@@ -886,6 +893,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@integration/$(DEPDIR)/sugar_singlepopTest.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@integration/$(DEPDIR)/sugar_singlepop_custom_diploidTest.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/independent_implementations.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_ancestry_list.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_decapitate.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_generate_data_matrix.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_generate_offspring.Po@am__quote@ # am--include-marker
@@ -1288,6 +1296,7 @@ distclean: distclean-am
 	-rm -f integration/$(DEPDIR)/sugar_singlepopTest.Po
 	-rm -f integration/$(DEPDIR)/sugar_singlepop_custom_diploidTest.Po
 	-rm -f tree_sequences/$(DEPDIR)/independent_implementations.Po
+	-rm -f tree_sequences/$(DEPDIR)/test_ancestry_list.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_decapitate.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_generate_data_matrix.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_generate_offspring.Po
@@ -1378,6 +1387,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f integration/$(DEPDIR)/sugar_singlepopTest.Po
 	-rm -f integration/$(DEPDIR)/sugar_singlepop_custom_diploidTest.Po
 	-rm -f tree_sequences/$(DEPDIR)/independent_implementations.Po
+	-rm -f tree_sequences/$(DEPDIR)/test_ancestry_list.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_decapitate.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_generate_data_matrix.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_generate_offspring.Po

--- a/testsuite/tree_sequences/test_ancestry_list.cc
+++ b/testsuite/tree_sequences/test_ancestry_list.cc
@@ -1,0 +1,56 @@
+#include <iostream>
+#include <boost/test/unit_test.hpp>
+#include <fwdpp/ts/simplification/ancestry_list.hpp>
+
+namespace
+{
+    int
+    get_chain_length(const fwdpp::ts::ancestry_list& al, std::size_t i)
+    {
+        int len = 0;
+        auto f = al.first[i];
+
+        while (f != -1)
+            {
+                ++len;
+                f = al.next[f];
+            }
+        return len;
+    }
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(test_ancestry_list)
+
+BOOST_AUTO_TEST_CASE(test_construct_and_fill)
+// The data added don't refer to valid
+// tree sequences and are just for testing
+{
+    fwdpp::ts::ancestry_list al;
+    al.init(4);
+    al.add_record(0, 0, 1, 3);
+    al.add_record(1, 0, 0.5, 3);
+    al.add_record(0, 0, 0.5, 4);
+
+    BOOST_REQUIRE_EQUAL(get_chain_length(al, 0), 2);
+    BOOST_REQUIRE_EQUAL(get_chain_length(al, 1), 1);
+}
+
+BOOST_AUTO_TEST_CASE(test_fill_nullify_once_fill)
+{
+    fwdpp::ts::ancestry_list al;
+    al.init(4);
+    al.add_record(0, 0, 1, 3);
+    al.add_record(1, 0, 0.5, 3);
+    al.add_record(0, 0, 0.5, 4);
+    BOOST_REQUIRE_EQUAL(get_chain_length(al, 0), 2);
+    BOOST_REQUIRE_EQUAL(al.get_chain_tail(0), 2);
+    al.nullify_chain(0);
+    BOOST_REQUIRE_EQUAL(get_chain_length(al, 0), 0);
+    BOOST_REQUIRE_EQUAL(al.get_chain_tail(0), -1);
+
+    al.add_record(0, 0, 1, 2);
+    BOOST_REQUIRE_EQUAL(get_chain_length(al, 0), 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+


### PR DESCRIPTION
Ancestry segments are currently stored as a `vector<vector<segment>>`.  This PR replaces that data structure with ancestry_list, with stores a vector<segment> and index vectors to model a forward list of ancestry chains.

Also emits output edges back into the original input edge table during simplification.  This change also results in substantial RAM savings.

Add examples/load_table_collection, which also helped testing the outputs of this branch vs. dev.