### PR TITLE
Remove preprocessor guard around template type trait variables.

### DIFF
--- a/fwdpp/fitness_models.hpp
+++ b/fwdpp/fitness_models.hpp
@@ -370,8 +370,7 @@ namespace fwdpp
         ///\return dpol( hpol(g1,mutations), hpol(g2,mutations) )
         ///
         {
-            static_assert(typename traits::is_haploid_genome<
-                              haploid_genome_type>::type(),
+            static_assert(traits::is_haploid_genome_v<haploid_genome_type>,
                           "haploid_genome_type must be a haploid_genome type");
             static_assert(
                 traits::is_mutation<typename mcont_t::value_type>::value,

--- a/fwdpp/io/mutation.hpp
+++ b/fwdpp/io/mutation.hpp
@@ -73,7 +73,7 @@ namespace fwdpp
         /// Works via specialization of serialize_mutation.
         {
             static_assert(
-                traits::is_mutation<typename mcont_t::value_type>::value,
+                traits::is_mutation_v<typename mcont_t::value_type>,
                 "mcont_t must be a container of mutations");
             std::size_t MUTNO = mutations.size();
             fwdpp::io::scalar_writer()(buffer, &MUTNO);
@@ -91,7 +91,7 @@ namespace fwdpp
         /// Works via specialization of deserialize_mutation.
         {
             static_assert(
-                traits::is_mutation<typename mcont_t::value_type>::value,
+                traits::is_mutation_v<typename mcont_t::value_type>,
                 "mcont_t must be a container of mutations");
             std::size_t NMUTS;
             fwdpp::io::scalar_reader()(in, &NMUTS);

--- a/fwdpp/poptypes/popbase.hpp
+++ b/fwdpp/poptypes/popbase.hpp
@@ -21,11 +21,10 @@ namespace fwdpp
           \version 0.9.0 Remove construction from containers of low-level types
          */
         {
-            static_assert(typename fwdpp::traits::is_haploid_genome<
-                              typename gcont::value_type>::type(),
+            static_assert(fwdpp::traits::is_haploid_genome_v<typename gcont::value_type>,
                           "gcont::value_type must be a haploid_genome type");
             static_assert(
-                typename fwdpp::traits::is_mutation<typename mcont::value_type>::type(),
+                fwdpp::traits::is_mutation_v<typename mcont::value_type>,
                 "mcont::value_type must be a mutation type");
 
           public:

--- a/fwdpp/type_traits.hpp
+++ b/fwdpp/type_traits.hpp
@@ -12,17 +12,16 @@ namespace fwdpp
     namespace traits
     {
         //! Wraps a static constant allowing a test that T is a haploid_genome
-        template <typename T, typename = void>
-        struct is_haploid_genome : std::false_type
+        template <typename T, typename = void> struct is_haploid_genome : std::false_type
         {
         };
 
         template <typename T>
-        struct is_haploid_genome<T, typename traits::internal::void_t<
-                                        typename T::mutation_container>::type>
+        struct is_haploid_genome<
+            T, typename traits::internal::void_t<typename T::mutation_container>::type>
             : std::integral_constant<
-                  bool, std::is_integral<
-                            typename T::mutation_container::value_type>::value>
+                  bool,
+                  std::is_integral<typename T::mutation_container::value_type>::value>
         {
         };
 
@@ -33,14 +32,13 @@ namespace fwdpp
         //! Wraps a static constant allowing a test that T is a mutation
         template <typename T>
         struct is_mutation
-            : std::integral_constant<
-                  bool, std::is_base_of<fwdpp::mutation_base, T>::value>
+            : std::integral_constant<bool,
+                                     std::is_base_of<fwdpp::mutation_base, T>::value>
         {
         };
 
         //! Convenience wrapper for fwdpp::traits::is_mutation<T>::Type.
-        template <typename T>
-        using is_mutation_t = typename is_mutation<T>::type;
+        template <typename T> using is_mutation_t = typename is_mutation<T>::type;
     } // namespace traits
 } // namespace fwdpp
 
@@ -51,16 +49,14 @@ namespace fwdpp
     namespace traits
     {
         //! Wraps a static constant allowing a test that T is a diploid
-        template <typename T>
-        using is_diploid = traits::internal::is_diploid<T>;
+        template <typename T> using is_diploid = traits::internal::is_diploid<T>;
 
         //! Wraps a static constant allowing a test that T is a custom diploid
         template <typename T>
         using is_custom_diploid = traits::internal::is_custom_diploid<T>;
 
         //! Convenience wrapper for fwdpp::traits::is_diploid<T>::type
-        template <typename T>
-        using is_diploid_t = typename is_diploid<T>::type;
+        template <typename T> using is_diploid_t = typename is_diploid<T>::type;
 
         //! Convenience wrapper for fwdpp::traits::is_custom_diploid<T>::type
         template <typename T>
@@ -86,21 +82,19 @@ namespace fwdpp
          * Wraps a static constant to test that recmodel_t is a valid
          * recombination function/policy
          */
-        template <typename recmodel_t, typename diploid_t,
-                  typename haploid_genome_t, typename mcont_t>
-        using is_rec_model
-            = traits::internal::is_rec_model<recmodel_t, diploid_t,
-                                             haploid_genome_t, mcont_t>;
+        template <typename recmodel_t, typename diploid_t, typename haploid_genome_t,
+                  typename mcont_t>
+        using is_rec_model = traits::internal::is_rec_model<recmodel_t, diploid_t,
+                                                            haploid_genome_t, mcont_t>;
 
         /*!
          * Convenience wrapper for
          * fwdpp::traits::is_rec_model<recmodel_t,haploid_genome_c,mcont_t>::type
          */
-        template <typename recmodel_t, typename diploid_t,
-                  typename haploid_genome_t, typename mcont_t>
-        using is_rec_model_t =
-            typename is_rec_model<recmodel_t, diploid_t, haploid_genome_t,
-                                  mcont_t>::type;
+        template <typename recmodel_t, typename diploid_t, typename haploid_genome_t,
+                  typename mcont_t>
+        using is_rec_model_t = typename is_rec_model<recmodel_t, diploid_t,
+                                                     haploid_genome_t, mcont_t>::type;
 
         /*!
          * Defines a struct with a single member typedef called type.
@@ -111,32 +105,27 @@ namespace fwdpp
          * mcont_t)>
          */
         template <typename dipvector_t, typename gcont_t, typename mcont_t>
-        using fitness_fxn
-            = traits::internal::fitness_fxn<dipvector_t, gcont_t, mcont_t>;
+        using fitness_fxn = traits::internal::fitness_fxn<dipvector_t, gcont_t, mcont_t>;
 
         //! Convenience wrapper for
         //! fitness_fxn<dipvector_t,gcont_t,mcont_t>::type
         template <typename dipvector_t, typename gcont_t, typename mcont_t>
-        using fitness_fxn_t =
-            typename fitness_fxn<dipvector_t, gcont_t, mcont_t>::type;
+        using fitness_fxn_t = typename fitness_fxn<dipvector_t, gcont_t, mcont_t>::type;
 
         /*!
          * Wrap a static constant if ff is a valid fitness function
          * whose argument types are const references to the other
          * three template parameters
          */
-        template <typename ff, typename dipvector_t, typename gcont_t,
-                  typename mcont_t>
+        template <typename ff, typename dipvector_t, typename gcont_t, typename mcont_t>
         using is_fitness_fxn
-            = traits::internal::is_fitness_fxn<ff, dipvector_t, gcont_t,
-                                               mcont_t>;
+            = traits::internal::is_fitness_fxn<ff, dipvector_t, gcont_t, mcont_t>;
 
         /*!
          * Conveneince wrapper for
          * fwdpp::traits::is_fitness_fxn<ff,dipvector_t,gcont_t,mcont_t>::type
          */
-        template <typename ff, typename dipvector_t, typename gcont_t,
-                  typename mcont_t>
+        template <typename ff, typename dipvector_t, typename gcont_t, typename mcont_t>
         using is_fitness_fxn_t =
             typename is_fitness_fxn<ff, dipvector_t, gcont_t, mcont_t>::type;
 
@@ -157,8 +146,7 @@ namespace fwdpp
          */
         // clang-format on
         template <typename mcont_t>
-        using mutation_model =
-            typename traits::internal::mutation_model<mcont_t>::type;
+        using mutation_model = typename traits::internal::mutation_model<mcont_t>::type;
 
         // clang-format off
 		/*!
@@ -178,8 +166,8 @@ namespace fwdpp
         // clang-format on
         template <typename mcont_t, typename gcont_t>
         using mutation_model_haploid_genome =
-            typename traits::internal::mutation_model_haploid_genome<
-                mcont_t, gcont_t>::type;
+            typename traits::internal::mutation_model_haploid_genome<mcont_t,
+                                                                     gcont_t>::type;
 
         // clang-format off
 		/*!
@@ -199,29 +187,26 @@ namespace fwdpp
         // clang-format on
         template <typename diploid_t, typename mcont_t, typename gcont_t>
         using mutation_model_diploid =
-            typename traits::internal::mutation_model_diploid<
-                diploid_t, mcont_t, gcont_t>::type;
+            typename traits::internal::mutation_model_diploid<diploid_t, mcont_t,
+                                                              gcont_t>::type;
 
-/*! \defgroup Cpp14 C++14 features
- * \brief C++14 features
- */
+        /*! \defgroup Cpp14 C++14 features
+         * \brief C++14 features
+         */
 
-/* Template variables are provided for easier type trait
- * checking.  This feature requires compiling with the C++14
- * standard
- */
-#if __cplusplus >= 201402L
+        /* Template variables are provided for easier type trait
+         * checking.  This feature requires compiling with the C++14
+         * standard.
+         */
         //! \ingroup Cpp14
-        template <typename T>
-        constexpr bool is_diploid_v = is_diploid<T>::value;
+        template <typename T> constexpr bool is_diploid_v = is_diploid<T>::value;
 
         //! \ingroup Cpp14
         template <typename T>
         constexpr bool is_custom_diploid_v = is_custom_diploid<T>::value;
 
         //! \ingroup Cpp14
-        template <typename T>
-        constexpr bool is_mutation_v = is_mutation<T>::value;
+        template <typename T> constexpr bool is_mutation_v = is_mutation<T>::value;
 
         //! \ingroup Cpp14
         template <typename T>
@@ -233,18 +218,15 @@ namespace fwdpp
             = is_mutation_model<mmodel_t, mcont_t, gcont_t>::value;
 
         //! \ingroup Cpp14
-        template <typename recmodel_t, typename diploid_t,
-                  typename haploid_genome_t, typename mcont_t>
+        template <typename recmodel_t, typename diploid_t, typename haploid_genome_t,
+                  typename mcont_t>
         constexpr bool is_rec_model_v
-            = is_rec_model<recmodel_t, diploid_t, haploid_genome_t,
-                           mcont_t>::value;
+            = is_rec_model<recmodel_t, diploid_t, haploid_genome_t, mcont_t>::value;
 
         //! \ingroup Cpp14
-        template <typename ff, typename dipvector_t, typename gcont_t,
-                  typename mcont_t>
+        template <typename ff, typename dipvector_t, typename gcont_t, typename mcont_t>
         constexpr bool is_fitness_fxn_v
             = is_fitness_fxn<ff, dipvector_t, gcont_t, mcont_t>::value;
-#endif
     } // namespace traits
 } // namespace fwdpp
 #endif

--- a/fwdpp/util.hpp
+++ b/fwdpp/util.hpp
@@ -39,7 +39,7 @@ namespace fwdpp
                      std::vector<uint_t> &mcounts, const unsigned twoN)
     {
         static_assert(
-            typename traits::is_mutation<typename mcont_t::value_type>::type(),
+            traits::is_mutation_v<typename mcont_t::value_type>,
             "mutation_type must be derived from fwdpp::mutation_base");
 #ifndef NDEBUG
         if (mcounts.size() != mutations.size())
@@ -86,7 +86,7 @@ namespace fwdpp
 
     {
         static_assert(
-            typename traits::is_mutation<typename mcont_t::value_type>::type(),
+            traits::is_mutation_v<typename mcont_t::value_type>,
             "mutation_type must be derived from fwdpp::mutation_base");
         for (std::size_t i = 0; i < mcounts.size(); ++i)
             {
@@ -125,7 +125,7 @@ namespace fwdpp
                      const unsigned &twoN)
     {
         static_assert(
-            typename traits::is_mutation<typename mcont_t::value_type>::type(),
+            traits::is_mutation_v<typename mcont_t::value_type>,
             "mutation_type must be derived from fwdpp::mutation_base");
 #ifndef NDEBUG
         if (mcounts.size() != mutations.size())
@@ -197,7 +197,7 @@ namespace fwdpp
                        const unsigned &generation, const unsigned &twoN)
     {
         static_assert(
-            typename traits::is_mutation<typename mcont_t::value_type>::type(),
+            traits::is_mutation_v<typename mcont_t::value_type>,
             "mutation_type must be derived from "
             "fwdpp::mutation_base");
 #ifndef NDEBUG


### PR DESCRIPTION
Now that C++14 is the minimum requirement, we no longer need the preprocessor to hide these types for a C++11 compiler.