### PR TITLE
Fix edge transfer during simplification

### DIFF
--- a/fwdpp/ts/simplification/simplification.hpp
+++ b/fwdpp/ts/simplification/simplification.hpp
@@ -602,26 +602,6 @@ namespace fwdpp
                 tables.update_offset();
             }
 
-            template <typename Iterator, typename ConstIterator,
-                      typename SimplifierState>
-            inline Iterator
-            transfer_simplified_edges(Iterator new_edge_destination,
-                                      ConstIterator input_edge_table_location,
-                                      std::size_t minsize, SimplifierState& state)
-            {
-                if (state.new_edge_table.size() >= minsize
-                    && new_edge_destination + state.new_edge_table.size()
-                           < input_edge_table_location)
-                    {
-                        auto rv
-                            = std::copy(begin(state.new_edge_table),
-                                        end(state.new_edge_table), new_edge_destination);
-                        state.new_edge_table.clear();
-                        return rv;
-                    }
-                return new_edge_destination;
-            }
-
             inline void
             queue_children(TS_NODE_INT child, double left, double right,
                            ancestry_list& ancestry, segment_overlapper& overlapper)

--- a/fwdpp/ts/simplify_tables.hpp
+++ b/fwdpp/ts/simplify_tables.hpp
@@ -62,11 +62,21 @@ namespace fwdpp
                         input_tables.genome_length(), edge_ptr, edge_end, u, state);
                     simplification::merge_ancestors(input_tables.genome_length(),
                                                     input_tables.nodes, u, state, idmap);
-                    new_edge_destination = simplification::transfer_simplified_edges(
-                        new_edge_destination, edge_ptr, 1024ul, state);
+                    if (state.new_edge_table.size() >= 1024
+                        && new_edge_destination + state.new_edge_table.size() < edge_ptr)
+                        {
+                            new_edge_destination = std::copy(begin(state.new_edge_table),
+                                                             end(state.new_edge_table),
+                                                             new_edge_destination);
+                            state.new_edge_table.clear();
+                        }
                 }
-            new_edge_destination = simplification::transfer_simplified_edges(
-                new_edge_destination, edge_ptr, 0ul, state);
+            if (state.new_edge_table.empty() == false)
+                {
+                    new_edge_destination
+                        = std::copy(begin(state.new_edge_table),
+                                    end(state.new_edge_table), new_edge_destination);
+                }
 
             // When there are preserved nodes, we need to re map
             // their input ids to output ids


### PR DESCRIPTION
For the standard case of simplification, #259 added a function to help transfer new edges from the temp table to the output table.  Work on molpopgen/fwdpy11#523 found a corner case where an off-by-1 error resulted in zero-length edge tables after simplification.  This PR reverts the changes from #259 to the older/safer approach.