### PR TITLE
Move diploid recording code out of table collection.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -87,7 +87,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 subdir = .
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -230,7 +230,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@

--- a/examples/Makefile.in
+++ b/examples/Makefile.in
@@ -100,7 +100,7 @@ noinst_PROGRAMS = diploid_ind$(EXEEXT) diploid_fixed_sh_ind$(EXEEXT) \
 @DEBUG_FALSE@am__append_3 = -DNDEBUG
 subdir = examples
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -320,7 +320,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@

--- a/examples/edge_buffering.cc
+++ b/examples/edge_buffering.cc
@@ -183,18 +183,18 @@ generate_births(const fwdpp::GSLrng_mt& rng, const std::vector<birth>& births,
                 {
                     recombination_breakpoints(rng, littler, tables.genome_length(),
                                               breakpoints);
-                    new_node_0 = fwdpp::ts::register_diploid_offspring(
+                    new_node_0 = fwdpp::ts::record_diploid_offspring(
                         breakpoints, std::tie(p0n0, p0n1), 0, birth_time, tables);
                     recombination_breakpoints(rng, littler, tables.genome_length(),
                                               breakpoints);
-                    new_node_1 = fwdpp::ts::register_diploid_offspring(
+                    new_node_1 = fwdpp::ts::record_diploid_offspring(
                         breakpoints, std::tie(p1n0, p1n1), 0, birth_time, tables);
                 }
             else
                 {
                     recombination_breakpoints(rng, littler, tables.genome_length(),
                                               breakpoints);
-                    new_node_0 = fwdpp::ts::register_diploid_offspring(
+                    new_node_0 = fwdpp::ts::record_diploid_offspring(
                         breakpoints, std::tie(p0n0, p0n1), 0, birth_time, tables,
                         new_edges);
                     double ptime = tables.nodes[p0n0].time;
@@ -205,7 +205,7 @@ generate_births(const fwdpp::GSLrng_mt& rng, const std::vector<birth>& births,
                         }
                     recombination_breakpoints(rng, littler, tables.genome_length(),
                                               breakpoints);
-                    new_node_1 = fwdpp::ts::register_diploid_offspring(
+                    new_node_1 = fwdpp::ts::record_diploid_offspring(
                         breakpoints, std::tie(p1n0, p1n1), 0, birth_time, tables,
                         new_edges);
                     ptime = tables.nodes[p1n0].time;

--- a/examples/edge_buffering.cc
+++ b/examples/edge_buffering.cc
@@ -8,6 +8,7 @@
 #include <fwdpp/GSLrng_t.hpp>
 #include <fwdpp/ts/std_table_collection.hpp>
 #include <fwdpp/ts/recording.hpp>
+#include <fwdpp/ts/recording/diploid_offspring.hpp>
 #include <fwdpp/ts/simplify_tables.hpp>
 
 #include <tskit.h>
@@ -89,7 +90,8 @@ generate_main_options(command_line_options& o)
         "buffer", po::bool_switch(&o.buffer_new_edges),
         "If true, use edge buffering algorithm. If not, sort and simplify. Default = "
         "false");
-    options.add_options()("simplify_from_buffer", po::bool_switch(&o.simplify_from_buffer),
+    options.add_options()("simplify_from_buffer",
+                          po::bool_switch(&o.simplify_from_buffer),
                           "If true, and if using the edge buffering algorithm "
                           "(--buffer), then simplify from the buffer");
     options.add_options()("seed",
@@ -149,73 +151,11 @@ recombination_breakpoints(const fwdpp::GSLrng_mt& rng, double littler, double ma
             breakpoints.push_back(gsl_ran_flat(rng.get(), 0., maxlen));
         }
     std::sort(begin(breakpoints), end(breakpoints));
-
-    // Remove all values that do not exist an odd number of times
-    auto itr = std::adjacent_find(begin(breakpoints), end(breakpoints));
-    if (itr != end(breakpoints))
+    if (!breakpoints.empty())
         {
-            std::vector<double> temp;
-            auto start = begin(breakpoints);
-            while (itr < end(breakpoints))
-                {
-                    auto not_equal
-                        = std::find_if(itr, breakpoints.end(),
-                                       [itr](const double d) { return d != *itr; });
-                    int even = (std::distance(itr, not_equal) % 2 == 0.0);
-                    temp.insert(temp.end(), start, itr + 1 - even);
-                    start = not_equal;
-                    itr = std::adjacent_find(start, std::end(breakpoints));
-                }
-            temp.insert(end(temp), start, breakpoints.end());
-            breakpoints.swap(temp);
+            breakpoints.emplace_back(std::numeric_limits<double>::max());
         }
-}
-
-void
-recombine_and_record_edges(const fwdpp::GSLrng_mt& rng, double littler,
-                           std::vector<double>& breakpoints,
-                           fwdpp::ts::TS_NODE_INT parental_node0,
-                           fwdpp::ts::TS_NODE_INT parental_node1,
-                           fwdpp::ts::TS_NODE_INT child,
-                           fwdpp::ts::std_table_collection& tables)
-// NOTE: this is an improvement on what I do in fwdpp?
-{
-    recombination_breakpoints(rng, littler, tables.genome_length(), breakpoints);
-    double left = 0.;
-    std::size_t breakpoint = 1;
-    auto pnode0 = parental_node0;
-    auto pnode1 = parental_node1;
-    for (; breakpoint < breakpoints.size(); ++breakpoint)
-        {
-            auto rv
-                = tables.emplace_back_edge(left, breakpoints[breakpoint], pnode0, child);
-            std::swap(pnode0, pnode1);
-            left = breakpoints[breakpoint];
-        }
-    auto rv = tables.emplace_back_edge(left, tables.genome_length(), pnode0, child);
-}
-
-void
-recombine_and_buffer_edges(const fwdpp::GSLrng_mt& rng, double littler,
-                           std::vector<double>& breakpoints,
-                           fwdpp::ts::TS_NODE_INT parental_node0,
-                           fwdpp::ts::TS_NODE_INT parental_node1,
-                           fwdpp::ts::TS_NODE_INT child, double maxlen,
-                           fwdpp::ts::edge_buffer& new_edges)
-{
-    recombination_breakpoints(rng, littler, maxlen, breakpoints);
-    double left = 0.;
-    std::size_t breakpoint = 1;
-    auto pnode0 = parental_node0;
-    auto pnode1 = parental_node1;
-
-    for (; breakpoint < breakpoints.size(); ++breakpoint)
-        {
-            new_edges.extend(pnode0, left, breakpoints[breakpoint], child);
-            std::swap(pnode0, pnode1);
-            left = breakpoints[breakpoint];
-        }
-    new_edges.extend(pnode0, left, maxlen, child);
+    return;
 }
 
 void
@@ -224,10 +164,9 @@ generate_births(const fwdpp::GSLrng_mt& rng, const std::vector<birth>& births,
                 bool buffer_new_edges, fwdpp::ts::edge_buffer& new_edges,
                 std::vector<parent>& parents, fwdpp::ts::std_table_collection& tables)
 {
+    std::size_t new_node_0, new_node_1;
     for (auto& b : births)
         {
-            auto new_node_0 = tables.emplace_back_node(0, birth_time);
-            auto new_node_1 = tables.emplace_back_node(0, birth_time);
             auto p0n0 = b.p0node0;
             auto p0n1 = b.p0node1;
             if (gsl_rng_uniform(rng.get()) < 0.5)
@@ -242,31 +181,39 @@ generate_births(const fwdpp::GSLrng_mt& rng, const std::vector<birth>& births,
                 }
             if (buffer_new_edges == false)
                 {
-                    recombine_and_record_edges(rng, littler, breakpoints, p0n0, p0n1,
-                                               new_node_0, tables);
-                    recombine_and_record_edges(rng, littler, breakpoints, p1n0, p1n1,
-                                               new_node_1, tables);
+                    recombination_breakpoints(rng, littler, tables.genome_length(),
+                                              breakpoints);
+                    new_node_0 = fwdpp::ts::register_diploid_offspring(
+                        breakpoints, std::tie(p0n0, p0n1), 0, birth_time, tables);
+                    recombination_breakpoints(rng, littler, tables.genome_length(),
+                                              breakpoints);
+                    new_node_1 = fwdpp::ts::register_diploid_offspring(
+                        breakpoints, std::tie(p1n0, p1n1), 0, birth_time, tables);
                 }
             else
                 {
+                    recombination_breakpoints(rng, littler, tables.genome_length(),
+                                              breakpoints);
+                    new_node_0 = fwdpp::ts::register_diploid_offspring(
+                        breakpoints, std::tie(p0n0, p0n1), 0, birth_time, tables,
+                        new_edges);
                     double ptime = tables.nodes[p0n0].time;
                     double ctime = tables.nodes[new_node_0].time;
                     if (ctime <= ptime)
                         {
                             throw std::runtime_error("bad parent/child time");
                         }
-                    recombine_and_buffer_edges(rng, littler, breakpoints, p0n0, p0n1,
-                                               new_node_0, tables.genome_length(),
-                                               new_edges);
+                    recombination_breakpoints(rng, littler, tables.genome_length(),
+                                              breakpoints);
+                    new_node_1 = fwdpp::ts::register_diploid_offspring(
+                        breakpoints, std::tie(p1n0, p1n1), 0, birth_time, tables,
+                        new_edges);
                     ptime = tables.nodes[p1n0].time;
                     ctime = tables.nodes[new_node_1].time;
                     if (ctime <= ptime)
                         {
                             throw std::runtime_error("bad parent/child time");
                         }
-                    recombine_and_buffer_edges(rng, littler, breakpoints, p1n0, p1n1,
-                                               new_node_1, tables.genome_length(),
-                                               new_edges);
                 }
             parents[b.index] = parent(b.index, new_node_0, new_node_1);
         }
@@ -447,8 +394,8 @@ simulate(const command_line_options& options)
                     else
                         {
                             flush_buffer_n_simplify(
-                                    options.simplify_from_buffer,
-                                samples, alive_at_last_simplification, node_map, buffer,
+                                options.simplify_from_buffer, samples,
+                                alive_at_last_simplification, node_map, buffer,
                                 simplifier_state, edge_liftover, tables);
                         }
                     simplified = true;
@@ -489,9 +436,10 @@ simulate(const command_line_options& options)
                 }
             else
                 {
-                    flush_buffer_n_simplify(options.simplify_from_buffer,samples, alive_at_last_simplification,
-                                            node_map, buffer, simplifier_state,
-                                            edge_liftover, tables);
+                    flush_buffer_n_simplify(options.simplify_from_buffer, samples,
+                                            alive_at_last_simplification, node_map,
+                                            buffer, simplifier_state, edge_liftover,
+                                            tables);
                 }
         }
     dump_table_collection_to_tskit(tables, options.treefile, options.nsteps, options.N);

--- a/examples/evolve_generation_ts.hpp
+++ b/examples/evolve_generation_ts.hpp
@@ -15,6 +15,7 @@
 #include <fwdpp/ts/table_collection.hpp>
 #include <fwdpp/ts/table_simplifier.hpp>
 #include <fwdpp/ts/generate_offspring.hpp>
+#include <fwdpp/ts/recording/mutations.hpp>
 
 template <typename poptype, typename rng_t, typename genetic_param_holder>
 std::pair<fwdpp::ts::mut_rec_intermediates, fwdpp::ts::mut_rec_intermediates>

--- a/examples/evolve_generation_ts.hpp
+++ b/examples/evolve_generation_ts.hpp
@@ -16,6 +16,7 @@
 #include <fwdpp/ts/table_simplifier.hpp>
 #include <fwdpp/ts/generate_offspring.hpp>
 #include <fwdpp/ts/recording/mutations.hpp>
+#include <fwdpp/ts/recording/diploid_offspring.hpp>
 
 template <typename poptype, typename rng_t, typename genetic_param_holder>
 std::pair<fwdpp::ts::mut_rec_intermediates, fwdpp::ts::mut_rec_intermediates>
@@ -77,13 +78,13 @@ evolve_generation(const rng_t& rng, poptype& pop,
                 first_parental_index, p1, offspring_data.first.swapped);
             auto p2id = fwdpp::ts::get_parent_ids(
                 first_parental_index, p2, offspring_data.second.swapped);
-            next_index_local = tables.register_diploid_offspring(
-                offspring_data.first.breakpoints, p1id, 0, generation);
+            next_index_local = fwdpp::ts::register_diploid_offspring(
+                offspring_data.first.breakpoints, p1id, 0, generation, tables);
             fwdpp::ts::record_mutations_infinite_sites(
                 next_index_local, pop.mutations,
                 offspring_data.first.mutation_keys, tables);
-            next_index_local = tables.register_diploid_offspring(
-                offspring_data.second.breakpoints, p2id, 0, generation);
+            next_index_local = fwdpp::ts::register_diploid_offspring(
+                offspring_data.second.breakpoints, p2id, 0, generation, tables);
             fwdpp::ts::record_mutations_infinite_sites(
                 next_index_local, pop.mutations,
                 offspring_data.second.mutation_keys, tables);

--- a/examples/evolve_generation_ts.hpp
+++ b/examples/evolve_generation_ts.hpp
@@ -78,12 +78,12 @@ evolve_generation(const rng_t& rng, poptype& pop,
                 first_parental_index, p1, offspring_data.first.swapped);
             auto p2id = fwdpp::ts::get_parent_ids(
                 first_parental_index, p2, offspring_data.second.swapped);
-            next_index_local = fwdpp::ts::register_diploid_offspring(
+            next_index_local = fwdpp::ts::record_diploid_offspring(
                 offspring_data.first.breakpoints, p1id, 0, generation, tables);
             fwdpp::ts::record_mutations_infinite_sites(
                 next_index_local, pop.mutations,
                 offspring_data.first.mutation_keys, tables);
-            next_index_local = fwdpp::ts::register_diploid_offspring(
+            next_index_local = fwdpp::ts::record_diploid_offspring(
                 offspring_data.second.breakpoints, p2id, 0, generation, tables);
             fwdpp::ts::record_mutations_infinite_sites(
                 next_index_local, pop.mutations,

--- a/examples/wfevolvets.cc
+++ b/examples/wfevolvets.cc
@@ -80,11 +80,11 @@ births(const GSLrng& rng, const unsigned birth_time,
         {
             auto parental_nodes = pick_parent(rng, parental_metadata);
             generate_recombination_breakpoints(rng, recombination, breakpoints);
-            auto offspring_first_node = fwdpp::ts::register_diploid_offspring(
+            auto offspring_first_node = fwdpp::ts::record_diploid_offspring(
                 breakpoints, parental_nodes, 0, birth_time, tables);
             parental_nodes = pick_parent(rng, parental_metadata);
             generate_recombination_breakpoints(rng, recombination, breakpoints);
-            auto offspring_second_node = fwdpp::ts::register_diploid_offspring(
+            auto offspring_second_node = fwdpp::ts::record_diploid_offspring(
                 breakpoints, parental_nodes, 0, birth_time, tables);
 
             // Take a reference to the metadata for the individual

--- a/examples/wfevolvets.cc
+++ b/examples/wfevolvets.cc
@@ -10,6 +10,7 @@
 #include <fwdpp/ts/exceptions.hpp>
 #include <fwdpp/ts/tree_visitor.hpp>
 #include <fwdpp/ts/marginal_tree_functions.hpp>
+#include <fwdpp/ts/recording/diploid_offspring.hpp>
 #include <fwdpp/genetic_map/poisson_interval.hpp>
 
 std::vector<fwdpp::ts::TS_NODE_INT>
@@ -79,12 +80,12 @@ births(const GSLrng& rng, const unsigned birth_time,
         {
             auto parental_nodes = pick_parent(rng, parental_metadata);
             generate_recombination_breakpoints(rng, recombination, breakpoints);
-            auto offspring_first_node = tables.register_diploid_offspring(
-                breakpoints, parental_nodes, 0, birth_time);
+            auto offspring_first_node = fwdpp::ts::register_diploid_offspring(
+                breakpoints, parental_nodes, 0, birth_time, tables);
             parental_nodes = pick_parent(rng, parental_metadata);
             generate_recombination_breakpoints(rng, recombination, breakpoints);
-            auto offspring_second_node = tables.register_diploid_offspring(
-                breakpoints, parental_nodes, 0, birth_time);
+            auto offspring_second_node = fwdpp::ts::register_diploid_offspring(
+                breakpoints, parental_nodes, 0, birth_time, tables);
 
             // Take a reference to the metadata for the individual
             // we are replacing.  This reference streamlines the

--- a/fwdpp/Makefile.in
+++ b/fwdpp/Makefile.in
@@ -87,7 +87,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 subdir = fwdpp
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -237,7 +237,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@

--- a/fwdpp/algorithm/Makefile.in
+++ b/fwdpp/algorithm/Makefile.in
@@ -87,7 +87,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 subdir = fwdpp/algorithm
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -195,7 +195,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@

--- a/fwdpp/extensions/Makefile.in
+++ b/fwdpp/extensions/Makefile.in
@@ -87,7 +87,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 subdir = fwdpp/extensions
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -195,7 +195,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@

--- a/fwdpp/genetic_map/Makefile.in
+++ b/fwdpp/genetic_map/Makefile.in
@@ -87,7 +87,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 subdir = fwdpp/genetic_map
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -195,7 +195,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@

--- a/fwdpp/gsl/Makefile.in
+++ b/fwdpp/gsl/Makefile.in
@@ -87,7 +87,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 subdir = fwdpp/gsl
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -195,7 +195,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@

--- a/fwdpp/internal/Makefile.in
+++ b/fwdpp/internal/Makefile.in
@@ -87,7 +87,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 subdir = fwdpp/internal
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -195,7 +195,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@

--- a/fwdpp/io/Makefile.in
+++ b/fwdpp/io/Makefile.in
@@ -87,7 +87,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 subdir = fwdpp/io
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -237,7 +237,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@

--- a/fwdpp/io/detail/Makefile.in
+++ b/fwdpp/io/detail/Makefile.in
@@ -87,7 +87,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 subdir = fwdpp/io/detail
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -195,7 +195,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@

--- a/fwdpp/meta/Makefile.in
+++ b/fwdpp/meta/Makefile.in
@@ -87,7 +87,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 subdir = fwdpp/meta
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -195,7 +195,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@

--- a/fwdpp/poptypes/Makefile.in
+++ b/fwdpp/poptypes/Makefile.in
@@ -87,7 +87,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 subdir = fwdpp/poptypes
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -195,7 +195,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@

--- a/fwdpp/simfunctions/Makefile.in
+++ b/fwdpp/simfunctions/Makefile.in
@@ -87,7 +87,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 subdir = fwdpp/simfunctions
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -195,7 +195,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@

--- a/fwdpp/sugar/Makefile.in
+++ b/fwdpp/sugar/Makefile.in
@@ -87,7 +87,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 subdir = fwdpp/sugar
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -237,7 +237,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@

--- a/fwdpp/tags/Makefile.in
+++ b/fwdpp/tags/Makefile.in
@@ -87,7 +87,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 subdir = fwdpp/tags
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -195,7 +195,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@

--- a/fwdpp/ts/Makefile.in
+++ b/fwdpp/ts/Makefile.in
@@ -87,7 +87,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 subdir = fwdpp/ts
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -237,7 +237,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@

--- a/fwdpp/ts/detail/Makefile.in
+++ b/fwdpp/ts/detail/Makefile.in
@@ -87,7 +87,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 subdir = fwdpp/ts/detail
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -195,7 +195,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@

--- a/fwdpp/ts/marginal_tree_functions/Makefile.in
+++ b/fwdpp/ts/marginal_tree_functions/Makefile.in
@@ -87,7 +87,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 subdir = fwdpp/ts/marginal_tree_functions
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -195,7 +195,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@

--- a/fwdpp/ts/recording/Makefile.am
+++ b/fwdpp/ts/recording/Makefile.am
@@ -1,5 +1,6 @@
 pkgincludedir=$(prefix)/include/fwdpp/ts/recording
 
 pkginclude_HEADERS=edge_buffer.hpp \
-				   mutations.hpp
+				   mutations.hpp \
+				   diploid_offspring.hpp
 

--- a/fwdpp/ts/recording/Makefile.am
+++ b/fwdpp/ts/recording/Makefile.am
@@ -1,4 +1,5 @@
 pkgincludedir=$(prefix)/include/fwdpp/ts/recording
 
-pkginclude_HEADERS=edge_buffer.hpp
+pkginclude_HEADERS=edge_buffer.hpp \
+				   mutations.hpp
 

--- a/fwdpp/ts/recording/Makefile.in
+++ b/fwdpp/ts/recording/Makefile.in
@@ -267,7 +267,8 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 pkginclude_HEADERS = edge_buffer.hpp \
-				   mutations.hpp
+				   mutations.hpp \
+				   diploid_offspring.hpp
 
 all: all-am
 

--- a/fwdpp/ts/recording/Makefile.in
+++ b/fwdpp/ts/recording/Makefile.in
@@ -87,7 +87,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 subdir = fwdpp/ts/recording
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -195,7 +195,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@
@@ -265,7 +266,9 @@ target_alias = @target_alias@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
-pkginclude_HEADERS = edge_buffer.hpp
+pkginclude_HEADERS = edge_buffer.hpp \
+				   mutations.hpp
+
 all: all-am
 
 .SUFFIXES:

--- a/fwdpp/ts/recording/diploid_offspring.hpp
+++ b/fwdpp/ts/recording/diploid_offspring.hpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <stdexcept>
 #include <fwdpp/ts/definitions.hpp>
+#include "edge_buffer.hpp"
 
 namespace fwdpp
 {
@@ -116,6 +117,30 @@ namespace fwdpp
                 tables.genome_length());
             return next_index;
         }
+
+        template <typename TableCollectionType>
+        inline std::size_t
+        register_diploid_offspring(const std::vector<double>& breakpoints,
+                                   const std::tuple<TS_NODE_INT, TS_NODE_INT>& parents,
+                                   const std::int32_t population, const double time,
+                                   TableCollectionType& tables,
+								   edge_buffer & buffer)
+        {
+            // TODO: carefully document how to index node times.
+            auto next_index = tables.emplace_back_node(population, time);
+            if (next_index >= std::numeric_limits<TS_NODE_INT>::max())
+                {
+                    throw std::invalid_argument("node index too large");
+                }
+            split_breakpoints(
+                breakpoints, parents, next_index,
+                [&buffer](double l, double r, TS_NODE_INT p, TS_NODE_INT c) {
+                    buffer.extend(p, l, r, c);
+                },
+                tables.genome_length());
+            return next_index;
+        }
+
     }
 }
 

--- a/fwdpp/ts/recording/diploid_offspring.hpp
+++ b/fwdpp/ts/recording/diploid_offspring.hpp
@@ -1,0 +1,120 @@
+#ifndef FWDPP_TS_RECORDING_DIPLOID_OFFSPRING_HPP
+#define FWDPP_TS_RECORDING_DIPLOID_OFFSPRING_HPP
+
+#include <tuple>
+#include <limits>
+#include <vector>
+#include <cstdint>
+#include <cassert>
+#include <algorithm>
+#include <stdexcept>
+#include <fwdpp/ts/definitions.hpp>
+
+namespace fwdpp
+{
+    namespace ts
+    {
+        template <typename TableCollectionType>
+        inline void
+        split_breakpoints_add_edges(const std::vector<double>& breakpoints,
+                                    const std::tuple<TS_NODE_INT, TS_NODE_INT>& parents,
+                                    const TS_NODE_INT next_index,
+                                    TableCollectionType& tables)
+        {
+            if (breakpoints.front() != 0.0)
+                {
+                    tables.push_back_edge(0., breakpoints.front(), std::get<0>(parents),
+                                          next_index);
+                }
+            // TODO: replace with exception via a debug mode
+            assert(std::count(begin(breakpoints), end(breakpoints),
+                              std::numeric_limits<double>::max())
+                   == 1);
+            assert(breakpoints.back() == std::numeric_limits<double>::max());
+            for (unsigned j = 1; j < breakpoints.size(); ++j)
+                {
+                    double a = breakpoints[j - 1];
+                    double b = (j < breakpoints.size() - 1) ? breakpoints[j]
+                                                            : tables.genome_length();
+                    if (b <= a)
+                        {
+                            throw std::invalid_argument("right must be > left");
+                        }
+                    if (j % 2 == 0.)
+                        {
+                            tables.push_back_edge(a, b, std::get<0>(parents),
+                                                  next_index);
+                        }
+                    else
+                        {
+                            tables.push_back_edge(a, b, std::get<1>(parents),
+                                                  next_index);
+                        }
+                }
+        }
+
+        template <typename TableCollectionType>
+        inline void
+        split_breakpoints(const std::vector<double>& breakpoints,
+                          const std::tuple<TS_NODE_INT, TS_NODE_INT>& parents,
+                          const TS_NODE_INT next_index, TableCollectionType& tables)
+        {
+            if (breakpoints.empty())
+                {
+                    tables.push_back_edge(0., tables.genome_length(),
+                                          std::get<0>(parents), next_index);
+                    return;
+                }
+            auto itr
+                = std::adjacent_find(std::begin(breakpoints), std::end(breakpoints));
+            if (itr == std::end(breakpoints))
+                {
+                    split_breakpoints_add_edges(breakpoints, parents, next_index, tables);
+                }
+            else
+                {
+                    // Here, we need to reduce the input
+                    // breakpoints to only those seen
+                    // an odd number of times.
+                    // Even numbers of the same breakpoint
+                    // are "double x-overs" and thus
+                    // cannot affect the genealogy.
+                    std::vector<double> odd_breakpoints;
+                    auto start = breakpoints.begin();
+                    while (itr < breakpoints.end())
+                        {
+                            auto not_equal = std::find_if(
+                                itr, breakpoints.end(),
+                                [itr](const double d) { return d != *itr; });
+                            int even = (std::distance(itr, not_equal) % 2 == 0.0);
+                            odd_breakpoints.insert(odd_breakpoints.end(), start,
+                                                   itr + 1 - even);
+                            start = not_equal;
+                            itr = std::adjacent_find(start, std::end(breakpoints));
+                        }
+                    odd_breakpoints.insert(odd_breakpoints.end(), start,
+                                           breakpoints.end());
+                    split_breakpoints_add_edges(odd_breakpoints, parents, next_index, tables);
+                }
+        }
+
+        template <typename TableCollectionType>
+        inline std::size_t
+        register_diploid_offspring(const std::vector<double>& breakpoints,
+                                   const std::tuple<TS_NODE_INT, TS_NODE_INT>& parents,
+                                   const std::int32_t population, const double time,
+                                   TableCollectionType& tables)
+        {
+            // TODO: carefully document how to index node times.
+            auto next_index = tables.emplace_back_node(population, time);
+            if (next_index >= std::numeric_limits<TS_NODE_INT>::max())
+                {
+                    throw std::invalid_argument("node index too large");
+                }
+            split_breakpoints(breakpoints, parents, next_index, tables);
+            return next_index;
+        }
+    }
+}
+
+#endif

--- a/fwdpp/ts/recording/diploid_offspring.hpp
+++ b/fwdpp/ts/recording/diploid_offspring.hpp
@@ -101,7 +101,7 @@ namespace fwdpp
         }
 
         template <typename TableCollectionType>
-        inline std::size_t
+        inline TS_NODE_INT
         record_diploid_offspring(const std::vector<double>& breakpoints,
                                  const std::tuple<TS_NODE_INT, TS_NODE_INT>& parents,
                                  const std::int32_t population, const double time,
@@ -123,7 +123,7 @@ namespace fwdpp
         }
 
         template <typename TableCollectionType>
-        inline std::size_t
+        inline TS_NODE_INT
         record_diploid_offspring(const std::vector<double>& breakpoints,
                                  const std::tuple<TS_NODE_INT, TS_NODE_INT>& parents,
                                  const std::int32_t population, const double time,

--- a/fwdpp/ts/recording/diploid_offspring.hpp
+++ b/fwdpp/ts/recording/diploid_offspring.hpp
@@ -30,7 +30,11 @@ namespace fwdpp
             assert(std::count(begin(breakpoints), end(breakpoints),
                               std::numeric_limits<double>::max())
                    == 1);
-            assert(breakpoints.back() == std::numeric_limits<double>::max());
+            if (breakpoints.back() != std::numeric_limits<double>::max())
+                {
+                    throw std::invalid_argument(
+                        "breakpoints.back != std::numeric_limits<double>::max()");
+                }
             for (unsigned j = 1; j < breakpoints.size(); ++j)
                 {
                     double a = breakpoints[j - 1];
@@ -99,9 +103,9 @@ namespace fwdpp
         template <typename TableCollectionType>
         inline std::size_t
         record_diploid_offspring(const std::vector<double>& breakpoints,
-                                   const std::tuple<TS_NODE_INT, TS_NODE_INT>& parents,
-                                   const std::int32_t population, const double time,
-                                   TableCollectionType& tables)
+                                 const std::tuple<TS_NODE_INT, TS_NODE_INT>& parents,
+                                 const std::int32_t population, const double time,
+                                 TableCollectionType& tables)
         {
             // TODO: carefully document how to index node times.
             auto next_index = tables.emplace_back_node(population, time);
@@ -121,10 +125,9 @@ namespace fwdpp
         template <typename TableCollectionType>
         inline std::size_t
         record_diploid_offspring(const std::vector<double>& breakpoints,
-                                   const std::tuple<TS_NODE_INT, TS_NODE_INT>& parents,
-                                   const std::int32_t population, const double time,
-                                   TableCollectionType& tables,
-								   edge_buffer & buffer)
+                                 const std::tuple<TS_NODE_INT, TS_NODE_INT>& parents,
+                                 const std::int32_t population, const double time,
+                                 TableCollectionType& tables, edge_buffer& buffer)
         {
             // TODO: carefully document how to index node times.
             auto next_index = tables.emplace_back_node(population, time);

--- a/fwdpp/ts/recording/diploid_offspring.hpp
+++ b/fwdpp/ts/recording/diploid_offspring.hpp
@@ -98,7 +98,7 @@ namespace fwdpp
 
         template <typename TableCollectionType>
         inline std::size_t
-        register_diploid_offspring(const std::vector<double>& breakpoints,
+        record_diploid_offspring(const std::vector<double>& breakpoints,
                                    const std::tuple<TS_NODE_INT, TS_NODE_INT>& parents,
                                    const std::int32_t population, const double time,
                                    TableCollectionType& tables)
@@ -120,7 +120,7 @@ namespace fwdpp
 
         template <typename TableCollectionType>
         inline std::size_t
-        register_diploid_offspring(const std::vector<double>& breakpoints,
+        record_diploid_offspring(const std::vector<double>& breakpoints,
                                    const std::tuple<TS_NODE_INT, TS_NODE_INT>& parents,
                                    const std::int32_t population, const double time,
                                    TableCollectionType& tables,

--- a/fwdpp/ts/recording/mutations.hpp
+++ b/fwdpp/ts/recording/mutations.hpp
@@ -1,0 +1,38 @@
+#ifndef FWDPP_TS_RECORDING_MUTATIONS_HPP
+#define FWDPP_TS_RECORDING_MUTATIONS_HPP
+
+#include <limits>
+#include <vector>
+#include <stdexcept>
+#include <fwdpp/ts/definitions.hpp>
+
+namespace fwdpp
+{
+    namespace ts
+    {
+        template <typename TableCollectionType, typename mcont_t>
+        void
+        record_mutations_infinite_sites(
+            const TS_NODE_INT u, const mcont_t& mutations,
+            const std::vector<std::uint32_t>& new_mutation_keys,
+            TableCollectionType& tables)
+        /// \version Added in 0.8.0
+        /// FIXME: move this to a tree seq recording header
+        {
+            std::int8_t ancestral_state = 0, derived_state = 1;
+            for (auto& k : new_mutation_keys)
+                {
+                    auto site
+                        = tables.emplace_back_site(mutations[k].pos, ancestral_state);
+                    if (site >= std::numeric_limits<TS_NODE_INT>::max())
+                        {
+                            throw std::invalid_argument("site index out of range");
+                        }
+                    tables.push_back_mutation(u, k, site, derived_state,
+                                              mutations[k].neutral);
+                }
+        }
+    }
+}
+
+#endif

--- a/fwdpp/ts/simplification/Makefile.in
+++ b/fwdpp/ts/simplification/Makefile.in
@@ -87,7 +87,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 subdir = fwdpp/ts/simplification
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -195,7 +195,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@

--- a/fwdpp/ts/table_collection.hpp
+++ b/fwdpp/ts/table_collection.hpp
@@ -261,19 +261,19 @@ namespace fwdpp
                     }
             }
 
-            std::size_t
+            TS_NODE_INT
             push_back_node(double time, std::int32_t pop)
             {
                 nodes.push_back(node_t{pop, time});
-                return nodes.size() - 1;
+                return static_cast<TS_NODE_INT>(nodes.size() - 1);
             }
 
             template <typename... args>
-            std::size_t
+            TS_NODE_INT
             emplace_back_node(args&&... Args)
             {
                 nodes.emplace_back(node_t{std::forward<args>(Args)...});
-                return nodes.size() - 1;
+                return static_cast<TS_NODE_INT>(nodes.size() - 1);
             }
 
             std::size_t

--- a/fwdpp/ts/table_collection.hpp
+++ b/fwdpp/ts/table_collection.hpp
@@ -508,29 +508,6 @@ namespace fwdpp
                 return !(*this == b);
             }
         };
-
-        template <typename TableCollectionType, typename mcont_t>
-        void
-        record_mutations_infinite_sites(
-            const TS_NODE_INT u, const mcont_t& mutations,
-            const std::vector<std::uint32_t>& new_mutation_keys,
-            TableCollectionType& tables)
-        /// \version Added in 0.8.0
-        /// FIXME: move this to a tree seq recording header
-        {
-            std::int8_t ancestral_state = 0, derived_state = 1;
-            for (auto& k : new_mutation_keys)
-                {
-                    auto site
-                        = tables.emplace_back_site(mutations[k].pos, ancestral_state);
-                    if (site >= std::numeric_limits<TS_NODE_INT>::max())
-                        {
-                            throw std::invalid_argument("site index out of range");
-                        }
-                    tables.push_back_mutation(u, k, site, derived_state,
-                                              mutations[k].neutral);
-                }
-        }
     } // namespace ts
 } // namespace fwdpp
 

--- a/fwdpp/ts/table_collection.hpp
+++ b/fwdpp/ts/table_collection.hpp
@@ -32,86 +32,6 @@ namespace fwdpp
           private:
             /// Length of the genomic region.
             double L;
-            void
-            split_breakpoints_add_edges(
-                const std::vector<double>& breakpoints,
-                const std::tuple<TS_NODE_INT, TS_NODE_INT>& parents,
-                const TS_NODE_INT next_index)
-            {
-                if (breakpoints.front() != 0.0)
-                    {
-                        this->push_back_edge(0., breakpoints.front(),
-                                             std::get<0>(parents), next_index);
-                    }
-                // TODO: replace with exception via a debug mode
-                assert(std::count(begin(breakpoints), end(breakpoints),
-                                  std::numeric_limits<double>::max())
-                       == 1);
-                assert(breakpoints.back() == std::numeric_limits<double>::max());
-                for (unsigned j = 1; j < breakpoints.size(); ++j)
-                    {
-                        double a = breakpoints[j - 1];
-                        double b = (j < breakpoints.size() - 1) ? breakpoints[j] : L;
-                        if (b <= a)
-                            {
-                                throw std::invalid_argument("right must be > left");
-                            }
-                        if (j % 2 == 0.)
-                            {
-                                this->push_back_edge(a, b, std::get<0>(parents),
-                                                     next_index);
-                            }
-                        else
-                            {
-                                this->push_back_edge(a, b, std::get<1>(parents),
-                                                     next_index);
-                            }
-                    }
-            }
-
-            void
-            split_breakpoints(const std::vector<double>& breakpoints,
-                              const std::tuple<TS_NODE_INT, TS_NODE_INT>& parents,
-                              const TS_NODE_INT next_index)
-            {
-                if (breakpoints.empty())
-                    {
-                        this->push_back_edge(0., L, std::get<0>(parents), next_index);
-                        return;
-                    }
-                auto itr
-                    = std::adjacent_find(std::begin(breakpoints), std::end(breakpoints));
-                if (itr == std::end(breakpoints))
-                    {
-                        split_breakpoints_add_edges(breakpoints, parents, next_index);
-                    }
-                else
-                    {
-                        // Here, we need to reduce the input
-                        // breakpoints to only those seen
-                        // an odd number of times.
-                        // Even numbers of the same breakpoint
-                        // are "double x-overs" and thus
-                        // cannot affect the genealogy.
-                        std::vector<double> odd_breakpoints;
-                        auto start = breakpoints.begin();
-                        while (itr < breakpoints.end())
-                            {
-                                auto not_equal = std::find_if(
-                                    itr, breakpoints.end(),
-                                    [itr](const double d) { return d != *itr; });
-                                int even = (std::distance(itr, not_equal) % 2 == 0.0);
-                                odd_breakpoints.insert(odd_breakpoints.end(), start,
-                                                       itr + 1 - even);
-                                start = not_equal;
-                                itr = std::adjacent_find(start, std::end(breakpoints));
-                            }
-                        odd_breakpoints.insert(odd_breakpoints.end(), start,
-                                               breakpoints.end());
-                        split_breakpoints_add_edges(odd_breakpoints, parents,
-                                                    next_index);
-                    }
-            }
 
             template <typename site_like, typename mutation_record_like>
             void
@@ -422,23 +342,6 @@ namespace fwdpp
                     }
                 std::sort(input_left.begin(), input_left.end());
                 std::sort(output_right.begin(), output_right.end());
-            }
-
-            std::size_t
-            register_diploid_offspring(
-                const std::vector<double>& breakpoints,
-                const std::tuple<TS_NODE_INT, TS_NODE_INT>& parents,
-                const std::int32_t population, const double time)
-            /// FIXME: having this here violates ORP
-            {
-                // TODO: carefully document how to index node times.
-                auto next_index = emplace_back_node(population, time);
-                if (next_index >= std::numeric_limits<TS_NODE_INT>::max())
-                    {
-                        throw std::invalid_argument("node index too large");
-                    }
-                split_breakpoints(breakpoints, parents, next_index);
-                return next_index;
             }
 
             void

--- a/fwdpp/util/Makefile.in
+++ b/fwdpp/util/Makefile.in
@@ -87,7 +87,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 subdir = fwdpp/util
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -195,7 +195,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -89,7 +89,7 @@ POST_UNINSTALL = :
 bin_PROGRAMS = fwdppConfig$(EXEEXT)
 subdir = src
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -189,7 +189,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -53,7 +53,8 @@ tree_sequences_tree_sequence_tests_SOURCES=tree_sequences/tree_sequence_tests.cc
 										tree_sequences/test_visit_sites.cc \
 										tree_sequences/test_site_visitor.cc \
 										tree_sequences/test_marginal_tree.cc \
-										tree_sequences/test_ancestry_list.cc
+										tree_sequences/test_ancestry_list.cc \
+										tree_sequences/test_diploid_recording.cc
 
 AM_CXXFLAGS=-W -Wall
 

--- a/testsuite/Makefile.in
+++ b/testsuite/Makefile.in
@@ -134,7 +134,8 @@ am__tree_sequences_tree_sequence_tests_SOURCES_DIST =  \
 	tree_sequences/test_visit_sites.cc \
 	tree_sequences/test_site_visitor.cc \
 	tree_sequences/test_marginal_tree.cc \
-	tree_sequences/test_ancestry_list.cc
+	tree_sequences/test_ancestry_list.cc \
+	tree_sequences/test_diploid_recording.cc
 @BUNIT_TEST_PRESENT_TRUE@am_tree_sequences_tree_sequence_tests_OBJECTS = tree_sequences/tree_sequence_tests.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_generate_offspring.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_preorder_node_traversal.$(OBJEXT) \
@@ -151,7 +152,8 @@ am__tree_sequences_tree_sequence_tests_SOURCES_DIST =  \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_visit_sites.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_site_visitor.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_marginal_tree.$(OBJEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_ancestry_list.$(OBJEXT)
+@BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_ancestry_list.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	tree_sequences/test_diploid_recording.$(OBJEXT)
 tree_sequences_tree_sequence_tests_OBJECTS =  \
 	$(am_tree_sequences_tree_sequence_tests_OBJECTS)
 tree_sequences_tree_sequence_tests_LDADD = $(LDADD)
@@ -230,6 +232,7 @@ am__depfiles_remade = fixtures/$(DEPDIR)/sugar_fixtures.Po \
 	tree_sequences/$(DEPDIR)/independent_implementations.Po \
 	tree_sequences/$(DEPDIR)/test_ancestry_list.Po \
 	tree_sequences/$(DEPDIR)/test_decapitate.Po \
+	tree_sequences/$(DEPDIR)/test_diploid_recording.Po \
 	tree_sequences/$(DEPDIR)/test_generate_data_matrix.Po \
 	tree_sequences/$(DEPDIR)/test_generate_offspring.Po \
 	tree_sequences/$(DEPDIR)/test_marginal_tree.Po \
@@ -671,7 +674,8 @@ top_srcdir = @top_srcdir@
 @BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_visit_sites.cc \
 @BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_site_visitor.cc \
 @BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_marginal_tree.cc \
-@BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_ancestry_list.cc
+@BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_ancestry_list.cc \
+@BUNIT_TEST_PRESENT_TRUE@										tree_sequences/test_diploid_recording.cc
 
 @BUNIT_TEST_PRESENT_TRUE@AM_CXXFLAGS = -W -Wall
 all: all-am
@@ -794,6 +798,9 @@ tree_sequences/test_marginal_tree.$(OBJEXT):  \
 tree_sequences/test_ancestry_list.$(OBJEXT):  \
 	tree_sequences/$(am__dirstamp) \
 	tree_sequences/$(DEPDIR)/$(am__dirstamp)
+tree_sequences/test_diploid_recording.$(OBJEXT):  \
+	tree_sequences/$(am__dirstamp) \
+	tree_sequences/$(DEPDIR)/$(am__dirstamp)
 
 tree_sequences/tree_sequence_tests$(EXEEXT): $(tree_sequences_tree_sequence_tests_OBJECTS) $(tree_sequences_tree_sequence_tests_DEPENDENCIES) $(EXTRA_tree_sequences_tree_sequence_tests_DEPENDENCIES) tree_sequences/$(am__dirstamp)
 	@rm -f tree_sequences/tree_sequence_tests$(EXEEXT)
@@ -882,6 +889,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/independent_implementations.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_ancestry_list.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_decapitate.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_diploid_recording.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_generate_data_matrix.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_generate_offspring.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tree_sequences/$(DEPDIR)/test_marginal_tree.Po@am__quote@ # am--include-marker
@@ -1282,6 +1290,7 @@ distclean: distclean-am
 	-rm -f tree_sequences/$(DEPDIR)/independent_implementations.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_ancestry_list.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_decapitate.Po
+	-rm -f tree_sequences/$(DEPDIR)/test_diploid_recording.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_generate_data_matrix.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_generate_offspring.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_marginal_tree.Po
@@ -1370,6 +1379,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f tree_sequences/$(DEPDIR)/independent_implementations.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_ancestry_list.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_decapitate.Po
+	-rm -f tree_sequences/$(DEPDIR)/test_diploid_recording.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_generate_data_matrix.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_generate_offspring.Po
 	-rm -f tree_sequences/$(DEPDIR)/test_marginal_tree.Po

--- a/testsuite/Makefile.in
+++ b/testsuite/Makefile.in
@@ -95,7 +95,7 @@ POST_UNINSTALL = :
 @BUNIT_TEST_PRESENT_TRUE@	tree_sequences/tree_sequence_tests$(EXEEXT)
 subdir = testsuite
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx.m4 \
 	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
@@ -551,7 +551,8 @@ FWDPP_MINOR_VERSION = @FWDPP_MINOR_VERSION@
 FWDPP_REVISION_VERSION = @FWDPP_REVISION_VERSION@
 FWDPP_VERSION_STRING = @FWDPP_VERSION_STRING@
 GREP = @GREP@
-HAVE_CXX11 = @HAVE_CXX11@
+HAVE_CXX14 = @HAVE_CXX14@
+HAVE_CXX17 = @HAVE_CXX17@
 INSTALL = @INSTALL@
 INSTALL_DATA = @INSTALL_DATA@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@

--- a/testsuite/tree_sequences/test_diploid_recording.cc
+++ b/testsuite/tree_sequences/test_diploid_recording.cc
@@ -1,0 +1,25 @@
+#include <iostream>
+#include <limits>
+#include <boost/test/unit_test.hpp>
+#include <fwdpp/ts/recording/diploid_offspring.hpp>
+#include <fwdpp/ts/std_table_collection.hpp>
+
+BOOST_AUTO_TEST_SUITE(test_diploid_recording)
+
+BOOST_AUTO_TEST_CASE(test_first_breakpoint_at_zero)
+{
+	std::vector<double> breakpoints{0, 0.5, std::numeric_limits<double>::max()};
+	fwdpp::ts::std_table_collection tables{1.};
+	tables.emplace_back_node(0, 0.);
+
+	fwdpp::ts::record_diploid_offspring(breakpoints, std::make_tuple(0, 1),
+			0, 1., tables);
+	BOOST_REQUIRE_EQUAL(tables.num_edges(), 2);
+	BOOST_REQUIRE_EQUAL(tables.edges[0].parent, 1);
+	BOOST_REQUIRE_EQUAL(tables.edges[0].left, 0);
+	BOOST_REQUIRE_EQUAL(tables.edges[1].parent, 0);
+	BOOST_REQUIRE_EQUAL(tables.edges[1].left, 0.5);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+


### PR DESCRIPTION
This will fix #258 by removing some "recording" functions from the table collection to standalone headers.