### PR TITLE
Improve behavior of simplifying from an edge buffer.

### DIFF
--- a/examples/edge_buffering.cc
+++ b/examples/edge_buffering.cc
@@ -270,13 +270,18 @@ flush_buffer_n_simplify(
             stitch_together_edges(alive_at_last_simplification, max_time, new_edges,
                                   edge_liftover, tables);
             fwdpp::ts::simplify_tables(samples, state, tables, node_map, temp);
+            // stitch_together_edges doesn't know about what happens during
+            // simplify, so we need to manually reset the buffer's head/tail
+            // sizes
+            new_edges.reset(tables.num_nodes());
         }
     else
         {
+            // Simplifying right from the buffer automatically
+            // resets new_edges
             fwdpp::ts::simplify_tables(samples, alive_at_last_simplification, state,
                                        tables, new_edges, node_map, temp);
         }
-    new_edges.reset(tables.num_nodes());
 }
 
 using table_collection_ptr

--- a/fwdpp/ts/simplify_tables.hpp
+++ b/fwdpp/ts/simplify_tables.hpp
@@ -302,6 +302,7 @@ namespace fwdpp
             std::move(begin(state.new_node_table), end(state.new_node_table),
                       begin(input_tables.nodes));
             input_tables.update_offset();
+            buffer.reset(input_tables.num_nodes());
         }
     }
 }


### PR DESCRIPTION
The overload of ts::simplify_tables introduced in #260 has an unfortunate quirk.  The buffer's `.reset` function is *not* called before exit, which can lead to bizarre errors.  This PR fixes that behavior and updates the example program accordingly w/comments.