### PR TITLE
Streamline table collection API

### DIFF
--- a/examples/edge_buffering.cc
+++ b/examples/edge_buffering.cc
@@ -7,6 +7,7 @@
 #include <gsl/gsl_randist.h>
 #include <fwdpp/GSLrng_t.hpp>
 #include <fwdpp/ts/std_table_collection.hpp>
+#include <fwdpp/ts/table_collection_functions.hpp>
 #include <fwdpp/ts/recording.hpp>
 #include <fwdpp/ts/recording/diploid_offspring.hpp>
 #include <fwdpp/ts/simplify_tables.hpp>
@@ -225,25 +226,8 @@ sort_n_simplify(const std::vector<fwdpp::ts::TS_NODE_INT>& samples,
                 SimplificationState& state, fwdpp::ts::std_table_collection& tables,
                 std::vector<fwdpp::ts::TS_NODE_INT>& node_map)
 {
-    using edge_t = fwdpp::ts::std_table_collection::edge_t;
-    std::sort(begin(tables.edges), end(tables.edges),
-              [&tables](const edge_t& a, const edge_t& b) {
-                  auto ga = tables.nodes[a.parent].time;
-                  auto gb = tables.nodes[b.parent].time;
-                  if (ga == gb)
-                      {
-                          if (a.parent == b.parent)
-                              {
-                                  if (a.child == b.child)
-                                      {
-                                          return a.left < b.left;
-                                      }
-                                  return a.child < b.child;
-                              }
-                          return a.parent < b.parent;
-                      }
-                  return ga > gb;
-              });
+    auto cmp = fwdpp::ts::get_edge_sort_cmp(tables);
+    std::sort(begin(tables.edges), end(tables.edges), cmp);
     std::vector<std::size_t> temp{};
     fwdpp::ts::simplify_tables(samples, state, tables, node_map, temp);
 }

--- a/examples/simplify_tables.hpp
+++ b/examples/simplify_tables.hpp
@@ -3,7 +3,8 @@
 
 #include <cstdint>
 #include <vector>
-#include <fwdpp/ts/table_collection.hpp>
+#include <fwdpp/ts/std_table_collection.hpp>
+#include <fwdpp/ts/table_collection_functions.hpp>
 #include <fwdpp/ts/table_simplifier.hpp>
 #include <fwdpp/ts/count_mutations.hpp>
 #include <fwdpp/ts/remove_fixations_from_gametes.hpp>
@@ -20,7 +21,7 @@ simplify_tables(poptype &pop, const fwdpp::uint_t generation,
                 const std::size_t num_samples,
                 const bool preserve_fixations = false)
 {
-    tables.sort_tables_for_simplification();
+    fwdpp::ts::sort_tables_for_simplification(tables.edge_offset, tables);
     std::vector<std::int32_t> samples(num_samples);
     std::iota(samples.begin(), samples.end(), first_sample_node);
     auto rv = simplifier.simplify(tables, samples);
@@ -46,7 +47,7 @@ simplify_tables(poptype &pop, const fwdpp::uint_t generation,
             tables.mutations.erase(itr, tables.mutations.end());
             if (d)
                 {
-                    tables.rebuild_site_table();
+                    fwdpp::ts::rebuild_site_table(tables);
                 }
             confirm_mutation_counts(pop, tables);
             fwdpp::ts::remove_fixations_from_haploid_genomes(

--- a/examples/simplify_tables.hpp
+++ b/examples/simplify_tables.hpp
@@ -25,6 +25,7 @@ simplify_tables(poptype &pop, const fwdpp::uint_t generation,
     std::vector<std::int32_t> samples(num_samples);
     std::iota(samples.begin(), samples.end(), first_sample_node);
     auto rv = simplifier.simplify(tables, samples);
+    tables.edge_offset = tables.num_edges();
     tables.build_indexes();
     for (auto &s : samples)
         {

--- a/examples/wfevolvets.cc
+++ b/examples/wfevolvets.cc
@@ -6,6 +6,7 @@
 #include <gsl/gsl_randist.h>
 #include "tree_sequence_examples_types.hpp"
 #include <fwdpp/ts/std_table_collection.hpp>
+#include <fwdpp/ts/table_collection_functions.hpp>
 #include <fwdpp/ts/table_simplifier.hpp>
 #include <fwdpp/ts/exceptions.hpp>
 #include <fwdpp/ts/tree_visitor.hpp>
@@ -167,7 +168,7 @@ simplify_tables_remap_metadata(
             // NOTE: this is a workaround for GitHub issue #238
             tables.edge_offset = 0;
         }
-    tables.sort_tables_for_simplification();
+    fwdpp::ts::sort_tables(tables.edge_offset, tables);
     // Simplify
     auto x = simplifier.simplify(tables, samples);
 

--- a/examples/wfts_overlapping_generations.cc
+++ b/examples/wfts_overlapping_generations.cc
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <cstdlib>
 #include "wfevolvets.hpp"
+#include <fwdpp/ts/table_collection_functions.hpp>
 
 const double genome_length = 1.0;
 
@@ -41,7 +42,7 @@ main(int argc, char** argv)
     std::cout << tables.edges.size() << " edges\n"
               << tables.nodes.size() << " nodes\n"
               << "Edge table is sorted: "
-              << tables.edges_are_minimally_sorted() << '\n';
+              << fwdpp::ts::edge_table_minimally_sorted(tables) << '\n';
 
     // Get the age distribution, somewhat inefficiently
     std::vector<std::pair<double, unsigned>> ages;

--- a/fwdpp/ts/Makefile.am
+++ b/fwdpp/ts/Makefile.am
@@ -7,6 +7,7 @@ pkginclude_HEADERS= definitions.hpp \
 			edge.hpp \
 			site.hpp \
 			table_collection.hpp \
+			table_collection_functions.hpp \
 			std_table_collection.hpp \
 			table_simplifier.hpp \
 			simplify_tables.hpp \

--- a/fwdpp/ts/Makefile.in
+++ b/fwdpp/ts/Makefile.in
@@ -314,6 +314,7 @@ pkginclude_HEADERS = definitions.hpp \
 			edge.hpp \
 			site.hpp \
 			table_collection.hpp \
+			table_collection_functions.hpp \
 			std_table_collection.hpp \
 			table_simplifier.hpp \
 			simplify_tables.hpp \

--- a/fwdpp/ts/mutate_tables.hpp
+++ b/fwdpp/ts/mutate_tables.hpp
@@ -7,6 +7,7 @@
 #include "definitions.hpp"
 #include "mark_multiple_roots.hpp"
 #include "mutation_tools.hpp"
+#include "table_collection_functions.hpp"
 
 namespace fwdpp
 {
@@ -118,7 +119,7 @@ namespace fwdpp
                         }
                     nmuts += nm;
                 }
-            tables.sort_mutations_rebuild_site_table();
+            sort_mutation_table_and_rebuild_site_table(tables);
             return nmuts;
         }
     } // namespace ts

--- a/fwdpp/ts/simplification/simplification.hpp
+++ b/fwdpp/ts/simplification/simplification.hpp
@@ -11,6 +11,7 @@
 #include <fwdpp/ts/definitions.hpp>
 #include <fwdpp/ts/nested_forward_lists.hpp>
 #include <fwdpp/ts/recording/edge_buffer.hpp>
+#include <fwdpp/ts/table_collection_functions.hpp>
 
 namespace fwdpp
 {
@@ -597,7 +598,7 @@ namespace fwdpp
                 std::move(begin(state.new_node_table), end(state.new_node_table),
                           begin(tables.nodes));
                 // TODO: allow for exception instead of assert
-                assert(tables.edges_are_minimally_sorted());
+                assert(edge_table_minimally_sorted(tables));
                 // NOTE: this will be moot by removing edge sorting.
                 tables.update_offset();
             }

--- a/fwdpp/ts/simplification/simplification.hpp
+++ b/fwdpp/ts/simplification/simplification.hpp
@@ -599,8 +599,6 @@ namespace fwdpp
                           begin(tables.nodes));
                 // TODO: allow for exception instead of assert
                 assert(edge_table_minimally_sorted(tables));
-                // NOTE: this will be moot by removing edge sorting.
-                tables.update_offset();
             }
 
             inline void

--- a/fwdpp/ts/simplify_tables.hpp
+++ b/fwdpp/ts/simplify_tables.hpp
@@ -301,7 +301,6 @@ namespace fwdpp
             input_tables.nodes.resize(state.new_node_table.size());
             std::move(begin(state.new_node_table), end(state.new_node_table),
                       begin(input_tables.nodes));
-            input_tables.update_offset();
             buffer.reset(input_tables.num_nodes());
         }
     }

--- a/fwdpp/ts/table_collection.hpp
+++ b/fwdpp/ts/table_collection.hpp
@@ -218,12 +218,6 @@ namespace fwdpp
                 return edges.size();
             }
 
-            void
-            update_offset()
-            {
-                edge_offset = edges.size();
-            }
-
             double
             genome_length() const
             {

--- a/fwdpp/ts/table_collection.hpp
+++ b/fwdpp/ts/table_collection.hpp
@@ -33,17 +33,6 @@ namespace fwdpp
             /// Length of the genomic region.
             double L;
 
-            template <typename site_like, typename mutation_record_like>
-            void
-            record_site_during_rebuild(const site_like& s, mutation_record_like& mr)
-            {
-                if (sites.empty() || sites.back().position != s.position)
-                    {
-                        sites.push_back(s);
-                    }
-                mr.site = sites.size() - 1;
-            }
-
           public:
             using node_table = NodeTableType;
             using edge_table = EdgeTableType;
@@ -100,133 +89,6 @@ namespace fwdpp
                     }
             }
 
-            void
-            sort_edges() noexcept
-            /// Sort the edge table.  On PARENT birth times.
-            /// The sorting differs from msprime here. The difference
-            /// is that we  assume that birth times are recorded forward in
-            /// time rather than backwards.
-            ///
-            /// In between simplifications, edges are appended to the table
-            /// starting at edge_offset.  edges prior to that point are,
-            /// by definition, sorted b/c they are the output of simplification.
-            /// Thus, we only sort the new edges and then perform a left rotate
-            /// w.r.to edge_offset to put the nodes in the correct final order.
-            /// The rotation is exactly edges.size() swaps.
-            {
-                std::sort(edges.begin() + edge_offset, edges.end(),
-                          [this](const edge_t& a, const edge_t& b) {
-                              auto ga = this->nodes[a.parent].time;
-                              auto gb = this->nodes[b.parent].time;
-                              if (ga == gb)
-                                  {
-                                      if (a.parent == b.parent)
-                                          {
-                                              if (a.child == b.child)
-                                                  {
-                                                      return a.left < b.left;
-                                                  }
-                                              return a.child < b.child;
-                                          }
-                                      return a.parent < b.parent;
-                                  }
-                              return ga > gb;
-                          });
-                if (edge_offset > 0)
-                    {
-                        std::rotate(edges.begin(), edges.begin() + edge_offset,
-                                    edges.end());
-                    }
-#ifndef NDEBUG
-                // TODO: allow for exceptions
-                // rather than assertions.
-                if (edge_offset == 0)
-                    {
-                        assert(edges_are_sorted());
-                    }
-                else if (preserved_nodes.empty())
-                    {
-                        assert(edges_are_sorted());
-                    }
-                else
-                    {
-                        assert(edges_are_minimally_sorted());
-                    }
-#endif
-            }
-
-            void
-            sort_mutations()
-            {
-                //mutations are sorted by increasing position
-                std::sort(mutations.begin(), mutations.end(),
-                          [this](const mutation_t& a, const mutation_t& b) {
-                              return sites[a.site].position < sites[b.site].position;
-                          });
-            }
-
-            void
-            sort_tables_for_simplification()
-            /// Sorts the tables for simplification, which means only
-            /// sorting edge and mutation tables, as the site table
-            /// will be rebuilt during simplification.
-            {
-                sort_edges();
-                sort_mutations();
-            }
-
-            void
-            sort_tables()
-            /// Sort all tables.  The site table is rebuilt.
-            {
-                sort_edges();
-                sort_mutations_rebuild_site_table();
-            }
-
-            bool
-            edges_are_sorted() const noexcept
-            /// Test that edges are in proper sort order for simiplification
-            /// \version 0.8.0 Change from testing minimal requirement to requirement
-            /// for simplification.
-            {
-                return std::is_sorted(edges.begin(), edges.end(),
-                                      [this](const edge_t& a, const edge_t& b) {
-                                          auto ga = this->nodes[a.parent].time;
-                                          auto gb = this->nodes[b.parent].time;
-                                          if (ga == gb)
-                                              {
-                                                  if (a.parent == b.parent)
-                                                      {
-                                                          if (a.child == b.child)
-                                                              {
-                                                                  return a.left < b.left;
-                                                              }
-                                                          return a.child < b.child;
-                                                      }
-                                                  return a.parent < b.parent;
-                                              }
-                                          return ga > gb;
-                                      });
-            }
-
-            bool
-            edges_are_minimally_sorted() const noexcept
-            /// Test the MINIMAL sorting requirement.
-            /// This minimal condition is important,
-            /// as ancient sample tracking will not
-            /// guarantee a sort order on the parental
-            /// node IDs.
-            /// \version 0.8.0 Added to library
-            {
-                return std::is_sorted(edges.begin(), edges.end(),
-                                      [this](const edge_t& a, const edge_t& b) {
-                                          auto ga = this->nodes[a.parent].time;
-                                          auto gb = this->nodes[b.parent].time;
-                                          return ga > gb
-                                                 && (std::tie(a.child, a.left)
-                                                     < std::tie(b.child, b.left));
-                                      });
-            }
 
             void
             clear() noexcept
@@ -342,34 +204,6 @@ namespace fwdpp
                     }
                 std::sort(input_left.begin(), input_left.end());
                 std::sort(output_right.begin(), output_right.end());
-            }
-
-            void
-            rebuild_site_table()
-            /// Complete rebuild of the site table.
-            {
-                auto site_table_copy(sites);
-                sites.clear();
-                for (auto& mr : mutations)
-                    {
-                        auto os = mr.site;
-                        record_site_during_rebuild(site_table_copy[mr.site], mr);
-                        if (site_table_copy[os].position != sites[mr.site].position)
-                            {
-                                throw tables_error("error rebuilding site table");
-                            }
-                    }
-            }
-
-            void
-            sort_mutations_rebuild_site_table()
-            /// O(n*log(n)) time plus O(n) additional memory.
-            /// This is called by sort_tables, but also should
-            /// be called after adding mutations by some manual
-            /// means to a table collection.
-            {
-                sort_mutations();
-                rebuild_site_table();
             }
 
             std::size_t

--- a/fwdpp/ts/table_collection_functions.hpp
+++ b/fwdpp/ts/table_collection_functions.hpp
@@ -55,12 +55,17 @@ namespace fwdpp
         inline void
         sort_edge_table(std::ptrdiff_t offset, TableCollectionType& tables)
         {
-            if(offset < 0 || offset >= static_cast<std::ptrdiff_t>(tables.edges.size()))
-            {
-                throw std::out_of_range("invalid edge table offset");
-            }
+            if (offset < 0 || offset >= static_cast<std::ptrdiff_t>(tables.edges.size()))
+                {
+                    throw std::out_of_range("invalid edge table offset");
+                }
             auto cmp = get_edge_sort_cmp(tables);
             std::sort(tables.edges.begin() + offset, tables.edges.end(), cmp);
+            if (offset > 0)
+                {
+                    std::rotate(begin(tables.edges), begin(tables.edges) + offset,
+                                end(tables.edges));
+                }
         }
 
         template <typename TableCollectionType>
@@ -159,8 +164,8 @@ namespace fwdpp
         }
 
         template <typename TableCollectionType>
-        inline void sort_tables(std::ptrdiff_t edge_table_offset,
-                                TableCollectionType& tables)
+        inline void
+        sort_tables(std::ptrdiff_t edge_table_offset, TableCollectionType& tables)
         /// Sort all tables.  The site table is rebuilt.
         {
             sort_edge_table(edge_table_offset, tables);

--- a/fwdpp/ts/table_collection_functions.hpp
+++ b/fwdpp/ts/table_collection_functions.hpp
@@ -1,0 +1,172 @@
+#ifndef FWDPP_TS_TABLE_COLLECTION_FUNCTIONS_HPP
+#define FWDPP_TS_TABLE_COLLECTION_FUNCTIONS_HPP
+
+#include <tuple>
+#include <cstddef>
+#include <algorithm>
+#include <stdexcept>
+#include <fwdpp/ts/exceptions.hpp>
+
+namespace fwdpp
+{
+    namespace ts
+    {
+        template <typename TableCollectionType>
+        inline auto
+        get_edge_sort_cmp(TableCollectionType& tables) noexcept
+        /*!
+         * @version 0.9.0 Added to library
+         */
+        {
+            return [&tables](const typename TableCollectionType::edge_t& a,
+                             const typename TableCollectionType::edge_t& b) {
+                auto ga = tables.nodes[a.parent].time;
+                auto gb = tables.nodes[b.parent].time;
+                if (ga == gb)
+                    {
+                        if (a.parent == b.parent)
+                            {
+                                if (a.child == b.child)
+                                    {
+                                        return a.left < b.left;
+                                    }
+                                return a.child < b.child;
+                            }
+                        return a.parent < b.parent;
+                    }
+                return ga > gb;
+            };
+        }
+
+        template <typename TableCollectionType>
+        inline auto
+        get_minimal_edge_sort_cmp(const TableCollectionType& tables)
+        {
+            return [&tables](const typename TableCollectionType::edge_t& a,
+                             const typename TableCollectionType::edge_t& b) {
+                auto ga = tables.nodes[a.parent].time;
+                auto gb = tables.nodes[b.parent].time;
+                return ga > gb
+                       && (std::tie(a.child, a.left) < std::tie(b.child, b.left));
+            };
+        }
+
+        template <typename TableCollectionType>
+        inline void
+        sort_edge_table(std::ptrdiff_t offset, TableCollectionType& tables)
+        {
+            if(offset < 0 || offset >= static_cast<std::ptrdiff_t>(tables.edges.size()))
+            {
+                throw std::out_of_range("invalid edge table offset");
+            }
+            auto cmp = get_edge_sort_cmp(tables);
+            std::sort(tables.edges.begin() + offset, tables.edges.end(), cmp);
+        }
+
+        template <typename TableCollectionType>
+        inline void
+        sort_edge_table(TableCollectionType& tables) noexcept
+        {
+            sort_edge_table(0, tables);
+        }
+
+        template <typename TableCollectionType>
+        inline bool
+        edge_table_strictly_sorted(const TableCollectionType& tables)
+        {
+            auto cmp = get_edge_sort_cmp(tables);
+            return std::is_sorted(begin(tables.edges), end(tables.edges), cmp);
+        }
+
+        template <typename TableCollectionType>
+        inline bool
+        edge_table_minimally_sorted(const TableCollectionType& tables)
+        {
+            auto cmp = get_minimal_edge_sort_cmp(tables);
+            return std::is_sorted(begin(tables.edges), end(tables.edges), cmp);
+        }
+
+        template <typename TableCollectionType>
+        inline void
+        sort_mutation_table(TableCollectionType& tables)
+        {
+            //mutations are sorted by increasing position
+            std::sort(begin(tables.mutations), end(tables.mutations),
+                      [&tables](const auto& a, const auto& b) {
+                          return tables.sites[a.site].position
+                                 < tables.sites[b.site].position;
+                      });
+        }
+
+        template <typename TableCollectionType>
+        inline void
+        record_site_during_rebuild(const typename TableCollectionType::site_t& s,
+                                   typename TableCollectionType::mutation_t& mr,
+                                   TableCollectionType& tables)
+        {
+            if (tables.sites.empty() || tables.sites.back().position != s.position)
+                {
+                    tables.sites.push_back(s);
+                }
+            mr.site = tables.sites.size() - 1;
+        }
+
+        template <typename TableCollectionType>
+        inline void
+        rebuild_site_table(TableCollectionType& tables)
+        /// Complete rebuild of the site table.
+        {
+            auto site_table_copy(tables.sites);
+            tables.sites.clear();
+            for (auto& mr : tables.mutations)
+                {
+                    auto os = mr.site;
+                    record_site_during_rebuild(site_table_copy[mr.site], mr, tables);
+                    if (site_table_copy[os].position != tables.sites[mr.site].position)
+                        {
+                            throw tables_error("error rebuilding site table");
+                        }
+                }
+        }
+
+        template <typename TableCollectionType>
+        inline void
+        sort_mutation_table_and_rebuild_site_table(TableCollectionType& tables)
+        /// O(n*log(n)) time plus O(n) additional memory.
+        /// This is called by sort_tables, but also should
+        /// be called after adding mutations by some manual
+        /// means to a table collection.
+        {
+            sort_mutation_table(tables);
+            rebuild_site_table(tables);
+        }
+
+        template <typename TableCollectionType>
+        inline void
+        sort_tables_for_simplification(std::ptrdiff_t edge_table_offset,
+                                       TableCollectionType& tables)
+        /// Sorts the tables for simplification, which means only
+        /// sorting edge and mutation tables, as the site table
+        /// will be rebuilt during simplification.
+        ///
+        /// If \a edge_table_offset < 0, the edge table is not sorted.
+        {
+            if (edge_table_offset >= 0)
+                {
+                    sort_edge_table(edge_table_offset, tables);
+                }
+            sort_mutation_table(tables);
+        }
+
+        template <typename TableCollectionType>
+        inline void sort_tables(std::ptrdiff_t edge_table_offset,
+                                TableCollectionType& tables)
+        /// Sort all tables.  The site table is rebuilt.
+        {
+            sort_edge_table(edge_table_offset, tables);
+            sort_mutation_table_and_rebuild_site_table(tables);
+        }
+    }
+}
+
+#endif

--- a/testsuite/tree_sequences/simple_table_collection.hpp
+++ b/testsuite/tree_sequences/simple_table_collection.hpp
@@ -2,6 +2,7 @@
 #define FWDPP_TESTSUITE_SIMPLE_TABLE_COLLECTION_HPP
 
 #include <fwdpp/ts/std_table_collection.hpp>
+#include <fwdpp/ts/table_collection_functions.hpp>
 #include <fwdpp/ts/tree_visitor.hpp>
 
 class simple_table_collection
@@ -32,7 +33,7 @@ class simple_table_collection
         t.push_back_edge(0, 1, 5, 3);
         t.push_back_edge(0, 1, 4, 1);
         t.push_back_edge(0, 1, 4, 0);
-        t.sort_edges();
+        fwdpp::ts::sort_edge_table(t);
         t.build_indexes(); //NOTE: critical!
         return t;
     }

--- a/testsuite/tree_sequences/simple_table_collection_polytomy.hpp
+++ b/testsuite/tree_sequences/simple_table_collection_polytomy.hpp
@@ -1,7 +1,8 @@
 #ifndef FWDPP_TESTSUITE_SIMPLE_TABLE_COLLECTION_POLYTOMY_HPP
 #define FWDPP_TESTSUITE_SIMPLE_TABLE_COLLECTION_POLYTOMY_HPP
 
-#include <fwdpp/ts/table_collection.hpp>
+#include <fwdpp/ts/std_table_collection.hpp>
+#include <fwdpp/ts/table_collection_functions.hpp>
 #include <fwdpp/ts/tree_visitor.hpp>
 
 class simple_table_collection_polytomy
@@ -35,7 +36,7 @@ class simple_table_collection_polytomy
         t.push_back_edge(0, 1, 5, 0);
         t.push_back_edge(0, 1, 5, 1);
         t.push_back_edge(0, 1, 5, 2);
-        t.sort_edges();
+        fwdpp::ts::sort_edge_table(t);
         t.build_indexes(); //NOTE: critical!
         return t;
     }

--- a/testsuite/tree_sequences/test_table_collection.cc
+++ b/testsuite/tree_sequences/test_table_collection.cc
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <boost/test/unit_test.hpp>
 #include <fwdpp/ts/std_table_collection.hpp>
+#include <fwdpp/ts/table_collection_functions.hpp>
 
 BOOST_AUTO_TEST_SUITE(test_mutation_and_site_tables)
 
@@ -18,7 +19,7 @@ BOOST_AUTO_TEST_CASE(test_rebuild_one_mutation_per_site_inconsistent_data)
     // Mutation refers to site 1
     tables.emplace_back_mutation(0, 0lu, 1lu, fwdpp::ts::default_derived_state,
                                  true);
-    tables.sort_mutations_rebuild_site_table();
+    fwdpp::ts::sort_mutation_table_and_rebuild_site_table(tables);
     BOOST_REQUIRE_EQUAL(tables.sites.size(), 1);
     BOOST_REQUIRE_EQUAL(tables.mutations.size(), 1);
     BOOST_REQUIRE_EQUAL(tables.mutations[0].site, 0);
@@ -34,7 +35,7 @@ BOOST_AUTO_TEST_CASE(
                                  fwdpp::ts::default_derived_state, true);
     site = tables.emplace_back_site(0.1, fwdpp::ts::default_ancestral_state);
     tables.emplace_back_mutation(1, 1lu, site, std::int8_t{ 2 }, true);
-    tables.sort_mutations_rebuild_site_table();
+    fwdpp::ts::sort_mutation_table_and_rebuild_site_table(tables);
     BOOST_REQUIRE_EQUAL(tables.sites.size(), 1);
     BOOST_REQUIRE_EQUAL(tables.mutations.size(), 2);
     BOOST_REQUIRE_EQUAL(tables.mutations[0].site, 0);

--- a/testsuite/tree_sequences/wfevolve_table_collection.hpp
+++ b/testsuite/tree_sequences/wfevolve_table_collection.hpp
@@ -8,6 +8,7 @@
 #include <fwdpp/GSLrng_t.hpp>
 #include <fwdpp/ts/definitions.hpp>
 #include <fwdpp/ts/simplify_tables.hpp>
+#include <fwdpp/ts/table_collection_functions.hpp>
 #include <fwdpp/ts/recording/edge_buffer.hpp>
 #include <fwdpp/ts/recording/diploid_offspring.hpp>
 
@@ -135,25 +136,8 @@ sort_n_simplify(const std::vector<fwdpp::ts::TS_NODE_INT>& samples,
                 SimplificationState& state, TableCollectionType& tables,
                 std::vector<fwdpp::ts::TS_NODE_INT>& node_map)
 {
-    using edge_t = typename TableCollectionType::edge_t;
-    std::sort(begin(tables.edges), end(tables.edges),
-              [&tables](const edge_t& a, const edge_t& b) {
-                  auto ga = tables.nodes[a.parent].time;
-                  auto gb = tables.nodes[b.parent].time;
-                  if (ga == gb)
-                      {
-                          if (a.parent == b.parent)
-                              {
-                                  if (a.child == b.child)
-                                      {
-                                          return a.left < b.left;
-                                      }
-                                  return a.child < b.child;
-                              }
-                          return a.parent < b.parent;
-                      }
-                  return ga > gb;
-              });
+    auto cmp= fwdpp::ts::get_edge_sort_cmp(tables);
+    std::sort(begin(tables.edges), end(tables.edges), cmp);
     std::vector<std::size_t> temp{};
     fwdpp::ts::simplify_tables(samples, state, tables, node_map, temp);
 }


### PR DESCRIPTION
Related to #258, this PR extracts a lot of functionality from the table collection class and puts it in a new header file.

This PR cleans up most of the API except for handling of preserved nodes,  which will get dealt with in a later update.