### PR TITLE
Change return types for operators in fwdpp::enum_bitflags.

### DIFF
--- a/fwdpp/util/enum_bitflags.hpp
+++ b/fwdpp/util/enum_bitflags.hpp
@@ -16,14 +16,14 @@ namespace fwdpp
                           "underlying type must be integral");
             static_assert(std::is_unsigned<T>::value,
                           "underlying type must be unsigned");
-            return static_cast<E>(static_cast<T>(a) | static_cast<T>(b));
+            return static_cast<T>(a) | static_cast<T>(b);
         }
 
         template <typename E>
         auto&
         operator|=(E& a, E b)
         {
-            a = a | b;
+            a = static_cast<E>(a | b);
             return a;
         }
 
@@ -36,14 +36,14 @@ namespace fwdpp
                           "underlying type must be integral");
             static_assert(std::is_unsigned<T>::value,
                           "underlying type must be unsigned");
-            return static_cast<E>(static_cast<T>(a) & static_cast<T>(b));
+            return static_cast<T>(a) & static_cast<T>(b);
         }
 
         template <typename E>
         auto&
         operator&=(E& a, E b)
         {
-            a = a & b;
+            a = static_cast<E>(a & b);
             return a;
         }
 
@@ -56,14 +56,14 @@ namespace fwdpp
                           "underlying type must be integral");
             static_assert(std::is_unsigned<T>::value,
                           "underlying type must be unsigned");
-            return static_cast<E>(static_cast<T>(a) ^ static_cast<T>(b));
+            return static_cast<T>(a) ^ static_cast<T>(b);
         }
 
         template <typename E>
         auto&
         operator^=(E& a, E b)
         {
-            a = a ^ b;
+            a = static_cast<E>(a ^ b);
             return a;
         }
 
@@ -76,7 +76,7 @@ namespace fwdpp
                           "underlying type must be integral");
             static_assert(std::is_unsigned<T>::value,
                           "underlying type must be unsigned");
-            return static_cast<E>(~static_cast<T>(a));
+            return ~static_cast<T>(a);
         }
     }
 }

--- a/testsuite/unit/test_enum_bitflags.cc
+++ b/testsuite/unit/test_enum_bitflags.cc
@@ -20,10 +20,8 @@ BOOST_AUTO_TEST_CASE(test_bitwise_OR)
 {
     using fwdpp::enum_bitflags::operator|;
     E e{E::a};
-    e = e | E::b;
-    unsigned x = 1 << 0;
-    x |= 1 << 1;
-    BOOST_REQUIRE_EQUAL(static_cast<std::underlying_type_t<E>>(e), x);
+    BOOST_REQUIRE_EQUAL(!!(e | E::a), true);
+    BOOST_REQUIRE_EQUAL(!!(e | E::b), true);
 }
 
 BOOST_AUTO_TEST_CASE(test_bitwise_OR_EQ)
@@ -40,10 +38,9 @@ BOOST_AUTO_TEST_CASE(test_bitwise_XOR)
 {
     using fwdpp::enum_bitflags::operator^;
     E e{E::a};
-    e = e ^ E::b;
     unsigned x = 1 << 0;
     x ^= 1 << 1;
-    BOOST_REQUIRE_EQUAL(static_cast<std::underlying_type_t<E>>(e), x);
+    BOOST_REQUIRE_EQUAL(e^E::b, x);
 }
 
 BOOST_AUTO_TEST_CASE(test_bitwise_XOR_EQ)
@@ -60,10 +57,8 @@ BOOST_AUTO_TEST_CASE(test_bitwise_AND)
 {
     using fwdpp::enum_bitflags::operator&;
     E e{E::a};
-    e = e & E::b;
-    unsigned x = 1 << 0;
-    x &= 1 << 1;
-    BOOST_REQUIRE_EQUAL(static_cast<std::underlying_type_t<E>>(e), x);
+    BOOST_REQUIRE_EQUAL(!!(e & E::a), true);
+    BOOST_REQUIRE_EQUAL(!!(e & E::b), false);
 }
 
 BOOST_AUTO_TEST_CASE(test_bitwise_AND_EQ)
@@ -80,10 +75,7 @@ BOOST_AUTO_TEST_CASE(test_bitwise_NEGATE)
 {
     using fwdpp::enum_bitflags::operator~;
     E e{E::b};
-    e = ~e;
-    unsigned x = 1 << 1;
-    x = ~x;
-    BOOST_REQUIRE_EQUAL(static_cast<std::underlying_type_t<E>>(e), x);
+    BOOST_REQUIRE_EQUAL(~e, ~2u);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR changes the behavior of operators introduced in #279.  Now, the `|` operator returns the underlying type and `|=` returns the enum type.  The reason is that the former is often used to ask about the existence of values and the latter used to update a flag.  We want the first case to be boolean-like and the latter to retain its "enum-ness".