### PR TITLE
Templatize genetic map types

### DIFF
--- a/testsuite/unit/test_genetic_map.cc
+++ b/testsuite/unit/test_genetic_map.cc
@@ -1,5 +1,6 @@
 #include <config.h>
 #include <cmath>
+#include <cstdint>
 #include <iostream>
 #include <fwdpp/genetic_map/poisson_interval.hpp>
 #include <fwdpp/genetic_map/poisson_point.hpp>
@@ -24,10 +25,8 @@ BOOST_FIXTURE_TEST_SUITE(test_poisson_interval, rng_fixture)
 BOOST_AUTO_TEST_CASE(test_construction)
 {
     BOOST_REQUIRE_NO_THROW(fwdpp::poisson_interval(0., 1., 1e-3));
-    BOOST_REQUIRE_THROW(fwdpp::poisson_interval(0., 1., -1e-3),
-                        std::invalid_argument);
-    BOOST_REQUIRE_THROW(fwdpp::poisson_interval(1., 0., 1e-3),
-                        std::invalid_argument);
+    BOOST_REQUIRE_THROW(fwdpp::poisson_interval(0., 1., -1e-3), std::invalid_argument);
+    BOOST_REQUIRE_THROW(fwdpp::poisson_interval(1., 0., 1e-3), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(test_callback_nothrow)
@@ -48,9 +47,8 @@ BOOST_AUTO_TEST_CASE(test_clone_and_cast)
     fwdpp::poisson_interval p(0, 1, 1e-3);
     auto c = p.clone();
     BOOST_REQUIRE_EQUAL(c == nullptr, false);
-    auto cast = dynamic_cast<fwdpp::poisson_interval*>(c.release());
+    auto cast = dynamic_cast<fwdpp::poisson_interval*>(c.get());
     BOOST_REQUIRE_EQUAL(cast != nullptr, true);
-    BOOST_REQUIRE_EQUAL(c == nullptr, true);
     BOOST_REQUIRE_EQUAL(cast->beg, p.beg);
     BOOST_REQUIRE_EQUAL(cast->end, p.end);
     BOOST_REQUIRE_EQUAL(cast->mean, p.mean);
@@ -63,10 +61,8 @@ BOOST_FIXTURE_TEST_SUITE(test_binomial_interval, rng_fixture)
 BOOST_AUTO_TEST_CASE(test_construction)
 {
     BOOST_REQUIRE_NO_THROW(fwdpp::binomial_interval(0., 1., 1e-3));
-    BOOST_REQUIRE_THROW(fwdpp::binomial_interval(0., 1., -1e-3),
-                        std::invalid_argument);
-    BOOST_REQUIRE_THROW(fwdpp::binomial_interval(1., 0., 1e-3),
-                        std::invalid_argument);
+    BOOST_REQUIRE_THROW(fwdpp::binomial_interval(0., 1., -1e-3), std::invalid_argument);
+    BOOST_REQUIRE_THROW(fwdpp::binomial_interval(1., 0., 1e-3), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(test_callback_nothrow)
@@ -88,9 +84,8 @@ BOOST_AUTO_TEST_CASE(test_clone_and_cast)
     fwdpp::binomial_interval p(0, 1, 1e-3);
     auto c = p.clone();
     BOOST_REQUIRE_EQUAL(c == nullptr, false);
-    auto cast = dynamic_cast<fwdpp::binomial_interval*>(c.release());
+    auto cast = dynamic_cast<fwdpp::binomial_interval*>(c.get());
     BOOST_REQUIRE_EQUAL(cast != nullptr, true);
-    BOOST_REQUIRE_EQUAL(c == nullptr, true);
     BOOST_REQUIRE_EQUAL(cast->beg, p.beg);
     BOOST_REQUIRE_EQUAL(cast->end, p.end);
     BOOST_REQUIRE_EQUAL(cast->prob, p.prob);
@@ -103,8 +98,7 @@ BOOST_FIXTURE_TEST_SUITE(test_poisson_point, rng_fixture)
 BOOST_AUTO_TEST_CASE(test_construction)
 {
     BOOST_REQUIRE_NO_THROW(fwdpp::poisson_point(0., 1e-3));
-    BOOST_REQUIRE_THROW(fwdpp::poisson_point(0., -1e-3),
-                        std::invalid_argument);
+    BOOST_REQUIRE_THROW(fwdpp::poisson_point(0., -1e-3), std::invalid_argument);
     BOOST_REQUIRE_THROW(
         fwdpp::poisson_point(1., std::numeric_limits<double>::quiet_NaN()),
         std::invalid_argument);
@@ -128,9 +122,8 @@ BOOST_AUTO_TEST_CASE(test_clone_and_cast)
     fwdpp::poisson_point p(0, 1e-3);
     auto c = p.clone();
     BOOST_REQUIRE_EQUAL(c == nullptr, false);
-    auto cast = dynamic_cast<fwdpp::poisson_point*>(c.release());
+    auto cast = dynamic_cast<fwdpp::poisson_point*>(c.get());
     BOOST_REQUIRE_EQUAL(cast != nullptr, true);
-    BOOST_REQUIRE_EQUAL(c == nullptr, true);
     BOOST_REQUIRE_EQUAL(cast->position, p.position);
     BOOST_REQUIRE_EQUAL(cast->mean, p.mean);
 }
@@ -142,8 +135,7 @@ BOOST_FIXTURE_TEST_SUITE(test_binomial_point, rng_fixture)
 BOOST_AUTO_TEST_CASE(test_construction)
 {
     BOOST_REQUIRE_NO_THROW(fwdpp::binomial_point(0., 1e-3));
-    BOOST_REQUIRE_THROW(fwdpp::binomial_point(0., -1e-3),
-                        std::invalid_argument);
+    BOOST_REQUIRE_THROW(fwdpp::binomial_point(0., -1e-3), std::invalid_argument);
     BOOST_REQUIRE_THROW(
         fwdpp::binomial_point(1., std::numeric_limits<double>::quiet_NaN()),
         std::invalid_argument);
@@ -169,9 +161,8 @@ BOOST_AUTO_TEST_CASE(test_clone_and_cast)
     fwdpp::binomial_point p(0, 1e-3);
     auto c = p.clone();
     BOOST_REQUIRE_EQUAL(c == nullptr, false);
-    auto cast = dynamic_cast<fwdpp::binomial_point*>(c.release());
+    auto cast = dynamic_cast<fwdpp::binomial_point*>(c.get());
     BOOST_REQUIRE_EQUAL(cast != nullptr, true);
-    BOOST_REQUIRE_EQUAL(c == nullptr, true);
     BOOST_REQUIRE_EQUAL(cast->position, p.position);
     BOOST_REQUIRE_EQUAL(cast->prob, p.prob);
 }
@@ -183,16 +174,14 @@ BOOST_FIXTURE_TEST_SUITE(test_fixed_number_crossovers, rng_fixture)
 BOOST_AUTO_TEST_CASE(test_construction)
 {
     BOOST_REQUIRE_NO_THROW(fwdpp::fixed_number_crossovers(0, 1, 10));
-    BOOST_REQUIRE_THROW(fwdpp::fixed_number_crossovers(1, 0, 10),
-                        std::invalid_argument);
-    BOOST_REQUIRE_THROW(fwdpp::fixed_number_crossovers(0, 1, -1),
-                        std::invalid_argument);
-    BOOST_REQUIRE_THROW(fwdpp::fixed_number_crossovers(
-                            std::numeric_limits<double>::quiet_NaN(), 1, 1),
-                        std::invalid_argument);
-    BOOST_REQUIRE_THROW(fwdpp::fixed_number_crossovers(
-                            1., std::numeric_limits<double>::quiet_NaN(), 1),
-                        std::invalid_argument);
+    BOOST_REQUIRE_THROW(fwdpp::fixed_number_crossovers(1, 0, 10), std::invalid_argument);
+    BOOST_REQUIRE_THROW(fwdpp::fixed_number_crossovers(0, 1, -1), std::invalid_argument);
+    BOOST_REQUIRE_THROW(
+        fwdpp::fixed_number_crossovers(std::numeric_limits<double>::quiet_NaN(), 1, 1),
+        std::invalid_argument);
+    BOOST_REQUIRE_THROW(
+        fwdpp::fixed_number_crossovers(1., std::numeric_limits<double>::quiet_NaN(), 1),
+        std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(test_callback_nothrow)
@@ -214,9 +203,8 @@ BOOST_AUTO_TEST_CASE(test_clone_and_cast)
     fwdpp::fixed_number_crossovers p(0, 1, 1);
     auto c = p.clone();
     BOOST_REQUIRE_EQUAL(c == nullptr, false);
-    auto cast = dynamic_cast<fwdpp::fixed_number_crossovers*>(c.release());
+    auto cast = dynamic_cast<fwdpp::fixed_number_crossovers*>(c.get());
     BOOST_REQUIRE_EQUAL(cast != nullptr, true);
-    BOOST_REQUIRE_EQUAL(c == nullptr, true);
     BOOST_REQUIRE_EQUAL(cast->beg, p.beg);
     BOOST_REQUIRE_EQUAL(cast->end, p.end);
     BOOST_REQUIRE_EQUAL(cast->nxovers, p.nxovers);
@@ -266,6 +254,68 @@ BOOST_AUTO_TEST_CASE(test_adding_binomial_point)
     BOOST_REQUIRE_EQUAL(gm.size(), 1);
     auto r = fwdpp::recbinder(std::cref(gm), rng.get());
     auto breakpoints = r();
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+using poisson_interval_int64 = fwdpp::poisson_interval_t<std::int64_t>;
+using poisson_point_int64 = fwdpp::poisson_point_t<std::int64_t>;
+using binomial_interval_int64 = fwdpp::binomial_interval_t<std::int64_t>;
+using binomial_point_int64 = fwdpp::binomial_point_t<std::int64_t>;
+using fixed_number_crossovers_int64 = fwdpp::fixed_number_crossovers_t<std::int64_t>;
+
+BOOST_FIXTURE_TEST_SUITE(test_int64_types, rng_fixture)
+
+BOOST_AUTO_TEST_CASE(test_poisson_interval_callback_output)
+{
+    poisson_interval_int64 p(0, 1, 10);
+    auto rv = apply_callback(p, rng.get());
+    BOOST_REQUIRE(!rv.empty());
+    for (auto i : rv)
+        {
+            BOOST_REQUIRE_EQUAL(i, std::floor(i));
+        }
+}
+
+BOOST_AUTO_TEST_CASE(test_poisson_point_callback_output)
+{
+    poisson_point_int64 p(0, 10);
+    auto rv = apply_callback(p, rng.get());
+    BOOST_REQUIRE(!rv.empty());
+    for (auto i : rv)
+        {
+            BOOST_REQUIRE_EQUAL(i, 0);
+        }
+}
+
+BOOST_AUTO_TEST_CASE(test_binomial_interval_callback_output)
+{
+    binomial_interval_int64 p(0, 1, 1.);
+    auto rv = apply_callback(p, rng.get());
+    BOOST_REQUIRE(!rv.empty());
+    BOOST_REQUIRE_EQUAL(rv[0], 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_binomial_point_callback_output)
+{
+    binomial_point_int64 p(0, 1);
+    auto rv = apply_callback(p, rng.get());
+    BOOST_REQUIRE(!rv.empty());
+    for (auto i : rv)
+        {
+            BOOST_REQUIRE_EQUAL(i, 0);
+        }
+}
+
+BOOST_AUTO_TEST_CASE(test_fixed_number_crossovers_callback_output)
+{
+    fixed_number_crossovers_int64 f(0, 100, 3);
+    auto rv = apply_callback(f, rng.get());
+    BOOST_REQUIRE_EQUAL(rv.size(), 3);
+    for (auto i : rv)
+        {
+            BOOST_REQUIRE_EQUAL(i, std::floor(i));
+        }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is an alternative to #291 that doesn't require any API changes, etc..  IMO, this is more in spirit with fwdpp's overall design, allowing discrete crossover positions to be determined via templates.