### PR TITLE
deprecate fwdpp/diploid.hh header

### DIFF
--- a/examples/K_linked_regions_extensions.cc
+++ b/examples/K_linked_regions_extensions.cc
@@ -4,11 +4,14 @@
 */
 
 #include <iostream>
-#include <fwdpp/diploid.hh>
 #include <vector>
 #include <list>
 #include <sstream>
 #include <fwdpp/debug.hpp>
+#include <fwdpp/fitness_models.hpp>
+#include <fwdpp/sample_diploid.hpp>
+#include <fwdpp/sampling_functions.hpp>
+#include <fwdpp/util.hpp>
 // Use mutation model from sugar layer
 #include <fwdpp/types/mutation.hpp>
 #include <fwdpp/extensions/callbacks.hpp>

--- a/examples/diploid_fixed_sh_ind.cc
+++ b/examples/diploid_fixed_sh_ind.cc
@@ -5,12 +5,15 @@
   mutations with fixed 's' and 'h'.
  */
 
-#include <fwdpp/diploid.hh>
 #include <fwdpp/recbinder.hpp>
 #include <numeric>
 #include <functional>
 #include <cassert>
 #include <iomanip>
+#include <fwdpp/fitness_models.hpp>
+#include <fwdpp/sample_diploid.hpp>
+#include <fwdpp/sampling_functions.hpp>
+#include <fwdpp/util.hpp>
 #include <fwdpp/debug.hpp>
 #include <fwdpp/types/mutation.hpp>
 #include <fwdpp/genetic_map/genetic_map.hpp>

--- a/examples/diploid_ind.cc
+++ b/examples/diploid_ind.cc
@@ -9,11 +9,15 @@
   4.  Outputting a sample in "ms" format
 */
 #include <iostream>
+#include <iterator>
 #include <unordered_map>
 #include <type_traits>
 #include <vector>
-#include <fwdpp/diploid.hh>
 #include <fwdpp/recbinder.hpp>
+#include <fwdpp/fitness_models.hpp>
+#include <fwdpp/sample_diploid.hpp>
+#include <fwdpp/sampling_functions.hpp>
+#include <fwdpp/util.hpp>
 #include <fwdpp/types/mutation.hpp>
 #include <fwdpp/genetic_map/genetic_map.hpp>
 #include <fwdpp/genetic_map/poisson_interval.hpp>

--- a/examples/juvenile_migration.cc
+++ b/examples/juvenile_migration.cc
@@ -61,7 +61,6 @@
  * the goal here it to show the book-keeping of parental fitnesses
  * and the mapping back to deme labels.
  */
-#include <fwdpp/diploid.hh>
 #include <fwdpp/recbinder.hpp>
 #ifdef HAVE_LIBSEQUENCE
 #include <Sequence/SimData.hpp>
@@ -71,6 +70,10 @@
 #include <cassert>
 #include <unordered_set>
 #include <fwdpp/debug.hpp>
+#include <fwdpp/fitness_models.hpp>
+#include <fwdpp/sample_diploid.hpp>
+#include <fwdpp/sampling_functions.hpp>
+#include <fwdpp/util.hpp>
 #include <fwdpp/types/mutation.hpp>
 #include <fwdpp/genetic_map/genetic_map.hpp>
 #include <fwdpp/genetic_map/poisson_interval.hpp>

--- a/fwdpp/diploid.hh
+++ b/fwdpp/diploid.hh
@@ -10,6 +10,8 @@
 #ifndef __DIPLOID_HH__
 #define __DIPLOID_HH__
 
+#warning("This header is deprecated and will be removed by 0.10.0 or soon thereafter")
+
 // namespace std
 #include <vector>
 #include <list>

--- a/fwdpp/recbinder.hpp
+++ b/fwdpp/recbinder.hpp
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <functional>
+#include <gsl/gsl_rng.h>
 
 namespace fwdpp
 {

--- a/testsuite/unit/gamete_cleanerTest.cc
+++ b/testsuite/unit/gamete_cleanerTest.cc
@@ -5,8 +5,8 @@
 */
 #include <config.h>
 #include <boost/test/unit_test.hpp>
-#include <fwdpp/diploid.hh>
 #include <fwdpp/debug.hpp>
+#include "../../fwdpp/internal/haploid_genome_cleaner.hpp"
 #include "../fixtures/fwdpp_fixtures.hpp"
 
 BOOST_FIXTURE_TEST_SUITE(haploid_genome_cleanerTest,


### PR DESCRIPTION
This header is obsolete and hard to maintain. Best to move on.