### PR TITLE
Add checks to ensure that discrete genetic_map_unit objects have lengths > 1

### DIFF
--- a/fwdpp/genetic_map/binomial_interval.hpp
+++ b/fwdpp/genetic_map/binomial_interval.hpp
@@ -32,6 +32,7 @@ namespace fwdpp
         /// @param p Probability of a breakpoint
         /// @note The interval is half-open on [b, e).
         {
+            internal::validate_minimum_interval_size(b, e);
             if (!std::isfinite(beg))
                 {
                     throw std::invalid_argument("beg must be finite");

--- a/fwdpp/genetic_map/fixed_number_crossovers.hpp
+++ b/fwdpp/genetic_map/fixed_number_crossovers.hpp
@@ -28,6 +28,7 @@ namespace fwdpp
         /// @param n Number of braekpoints to generate
         /// @note The interval is half-open on [b, e).
         {
+            internal::validate_minimum_interval_size(b, e);
             if (!std::isfinite(b))
                 {
                     throw std::invalid_argument("beg must be finite");

--- a/fwdpp/genetic_map/genetic_map_unit.hpp
+++ b/fwdpp/genetic_map/genetic_map_unit.hpp
@@ -1,6 +1,8 @@
 #ifndef FWDPP_GENETIC_MAP_UNIT_HPP
 #define FWDPP_GENETIC_MAP_UNIT_HPP
 
+#include <stdexcept>
+#include <type_traits>
 #include <vector>
 #include <gsl/gsl_rng.h>
 #include <fwdpp/util/abstract_cloneable.hpp>
@@ -19,6 +21,32 @@
 
 namespace fwdpp
 {
+    namespace internal
+    {
+        template <typename T>
+        inline void
+        validate_minimum_interval_size(T b, T e, std::true_type)
+        {
+            if (e - b <= 1)
+                {
+                    throw std::invalid_argument(
+                        "discrete intervals must have length greater than one.");
+                }
+        }
+
+        template <typename T>
+        inline void validate_minimum_interval_size(T, T, std::false_type)
+        {
+        }
+
+        template <typename T>
+        inline void
+        validate_minimum_interval_size(T b, T e)
+        {
+            validate_minimum_interval_size(b, e, typename std::is_integral<T>::type());
+        }
+    }
+
     /// @struct genetic_map_unit genetic_map_unit.hpp fwdpp/genetic_map/genetic_map_unit.hpp
     /// @brief Interface class
     /// @ingroup genetic_map_types

--- a/fwdpp/genetic_map/poisson_interval.hpp
+++ b/fwdpp/genetic_map/poisson_interval.hpp
@@ -29,6 +29,7 @@ namespace fwdpp
         /// @param m Mean number of breakpoints
         /// @note The interval is half-open on [b, e).
         {
+            internal::validate_minimum_interval_size(b, e);
             if (!std::isfinite(beg))
                 {
                     throw std::invalid_argument("beg must be finite");

--- a/testsuite/unit/test_genetic_map.cc
+++ b/testsuite/unit/test_genetic_map.cc
@@ -10,6 +10,7 @@
 #include <fwdpp/genetic_map/genetic_map.hpp>
 #include <fwdpp/recbinder.hpp>
 #include <boost/test/unit_test.hpp>
+#include <stdexcept>
 #include "../fixtures/rng_fixture.hpp"
 
 std::vector<double>
@@ -268,13 +269,18 @@ BOOST_FIXTURE_TEST_SUITE(test_int64_types, rng_fixture)
 
 BOOST_AUTO_TEST_CASE(test_poisson_interval_callback_output)
 {
-    poisson_interval_int64 p(0, 1, 10);
+    poisson_interval_int64 p(0, 2, 10);
     auto rv = apply_callback(p, rng.get());
     BOOST_REQUIRE(!rv.empty());
     for (auto i : rv)
         {
             BOOST_REQUIRE_EQUAL(i, std::floor(i));
         }
+}
+
+BOOST_AUTO_TEST_CASE(test_poisson_interval_too_short)
+{
+    BOOST_REQUIRE_THROW({ poisson_interval_int64 p(0, 1, 10); }, std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(test_poisson_point_callback_output)
@@ -290,10 +296,15 @@ BOOST_AUTO_TEST_CASE(test_poisson_point_callback_output)
 
 BOOST_AUTO_TEST_CASE(test_binomial_interval_callback_output)
 {
-    binomial_interval_int64 p(0, 1, 1.);
+    binomial_interval_int64 p(0, 2, 1.);
     auto rv = apply_callback(p, rng.get());
     BOOST_REQUIRE(!rv.empty());
-    BOOST_REQUIRE_EQUAL(rv[0], 0);
+    BOOST_REQUIRE_EQUAL(rv[0], std::floor(rv[0]));
+}
+
+BOOST_AUTO_TEST_CASE(test_binomial_interval_too_short)
+{
+    BOOST_REQUIRE_THROW({ binomial_interval_int64 p(0, 1, 10); }, std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(test_binomial_point_callback_output)
@@ -316,6 +327,12 @@ BOOST_AUTO_TEST_CASE(test_fixed_number_crossovers_callback_output)
         {
             BOOST_REQUIRE_EQUAL(i, std::floor(i));
         }
+}
+
+BOOST_AUTO_TEST_CASE(test_fixed_interval_too_short)
+{
+    BOOST_REQUIRE_THROW({ fixed_number_crossovers_int64 p(0, 1, 10); },
+                        std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
See #325 