### PR TITLE
Add ts::simplify_tables_output_t.

### DIFF
--- a/fwdpp/ts/Makefile.am
+++ b/fwdpp/ts/Makefile.am
@@ -12,6 +12,7 @@ pkginclude_HEADERS= definitions.hpp \
 			table_simplifier.hpp \
 			make_simplifier_state.hpp \
 			simplify_tables.hpp \
+			simplify_tables_output.hpp \
 			simplification_flags.hpp \
 			get_parent_ids.hpp \
 			generate_offspring.hpp \

--- a/fwdpp/ts/simplify_tables_output.hpp
+++ b/fwdpp/ts/simplify_tables_output.hpp
@@ -1,0 +1,44 @@
+#ifndef FWDPP_TS_SIMPLIFY_TABLES_OUTPUT_HPP
+#define FWDPP_TS_SIMPLIFY_TABLES_OUTPUT_HPP
+
+#include <vector>
+#include <type_traits>
+#include <fwdpp/ts/definitions.hpp>
+
+namespace fwdpp
+{
+    namespace ts
+    {
+        template <typename NodeIDMap, typename MutationIndexVector>
+        struct simplify_tables_output_t
+        {
+            static_assert(std::is_integral<typename NodeIDMap::value_type>::value,
+                          "NodeIDMap::value_type must be integral");
+            static_assert(std::is_signed<typename NodeIDMap::value_type>::value,
+                          "NodeIDMap::value_type must be signed");
+            static_assert(sizeof(typename NodeIDMap::value_type)
+                              >= sizeof(table_index_t),
+                          "sizeof(NodeIDMap::value_type) must be >= "
+                          "sizeof(fwdpp::ts::table_index_t)");
+            NodeIDMap idmap;
+            MutationIndexVector preserved_mutations;
+
+            simplify_tables_output_t() : idmap{}, preserved_mutations{}
+            {
+            }
+
+            void
+            clear()
+            {
+                idmap.clear();
+                preserved_mutations.clear();
+            }
+        };
+
+        using simplify_tables_output
+            = simplify_tables_output_t<std::vector<table_index_t>,
+                                       std::vector<std::size_t>>;
+    }
+}
+
+#endif

--- a/fwdpp/ts/table_simplifier.hpp
+++ b/fwdpp/ts/table_simplifier.hpp
@@ -60,12 +60,13 @@ namespace fwdpp
             /// node ID map and a vector of keys to mutations preserved in
             /// mutation tables
             {
-                std::vector<table_index_t> idmap;
-                std::vector<std::size_t> preserved_variants;
-                simplify_tables(samples, simplification_flags{}, _state, tables, idmap,
-                                preserved_variants);
+                simplify_tables_output simplification_output;
+                simplify_tables(samples, simplification_flags{}, _state, tables,
+                                simplification_output);
 
-                return std::make_pair(std::move(idmap), std::move(preserved_variants));
+                return std::make_pair(
+                    std::move(simplification_output.idmap),
+                    std::move(simplification_output.preserved_mutations));
             }
         };
 


### PR DESCRIPTION
Add a type to act as a single output type for simplification.

Deprecate current versions of simplify_tables using multiple output arguments.