### PR TITLE
templatize fundamental treeseq types

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,6 +47,7 @@ AC_CONFIG_FILES([Makefile fwdpp/version.hpp fwdpp/Makefile
                  fwdpp/ts/marginal_tree_functions/Makefile
                  fwdpp/ts/simplification/Makefile
                  fwdpp/ts/recording/Makefile
+                 fwdpp/ts/types/Makefile
 				 fwdpp/util/Makefile
 				 fwdpp/genetic_map/Makefile
 				 examples/Makefile testsuite/Makefile

--- a/examples/simplify_tables.hpp
+++ b/examples/simplify_tables.hpp
@@ -47,8 +47,8 @@ simplify_tables(poptype &pop, const fwdpp::uint_t generation,
                                        pop.mcounts, mcounts_from_preserved_nodes);
             auto itr = std::remove_if(
                 tables.mutations.begin(), tables.mutations.end(),
-                [&pop,
-                 &mcounts_from_preserved_nodes](const fwdpp::ts::mutation_record &mr) {
+                [&pop, &mcounts_from_preserved_nodes](
+                    const fwdpp::ts::table_collection::mutation_record &mr) {
                     return pop.mcounts[mr.key] == 2 * pop.diploids.size()
                            && mcounts_from_preserved_nodes[mr.key] == 0;
                 });

--- a/fwdpp/ts/Makefile.am
+++ b/fwdpp/ts/Makefile.am
@@ -1,6 +1,6 @@
 pkgincludedir=$(prefix)/include/fwdpp/ts
 
-SUBDIRS=simplification recording detail recording marginal_tree_functions
+SUBDIRS=simplification recording detail recording marginal_tree_functions types
 
 pkginclude_HEADERS= definitions.hpp \
 			node.hpp \

--- a/fwdpp/ts/detail/Makefile.am
+++ b/fwdpp/ts/detail/Makefile.am
@@ -1,4 +1,4 @@
 pkgincludedir=$(prefix)/include/fwdpp/ts/detail
 
-pkginclude_HEADERS= table_collection.hpp advance_marginal_tree_policies.hpp \
+pkginclude_HEADERS= advance_marginal_tree_policies.hpp \
 	generate_data_matrix_details.hpp

--- a/fwdpp/ts/edge.hpp
+++ b/fwdpp/ts/edge.hpp
@@ -4,38 +4,15 @@
 #ifndef FWDPP_TS_EDGE_HPP
 #define FWDPP_TS_EDGE_HPP
 
-#include <tuple>
-#include "definitions.hpp"
+#include <cstdint>
+#include "types/edge.hpp"
 
 namespace fwdpp
 {
     namespace ts
     {
-        struct edge
-        /*! An edge in a tree sequence
-         * @version 0.7.0 Added to fwdpp
-         *
-         * Edges define a transmission event
-         * of the genomic interval [left,right)
-         * from parent to child.
-         */ 
-        {
-            /// Left (inclusive) edge of genomic segment
-            double left;
-            /// Right (exclusive) edge of genomic segment
-            double right;
-            /// Parent ID
-            table_index_t parent;
-            /// Child ID
-            table_index_t child;
-        };
-
-        inline bool
-        operator==(const edge& a, const edge& b)
-        {
-            return std::tie(a.parent, a.child, a.left, a.right)
-                   == std::tie(b.parent, b.child, b.left, b.right);
-        }
+        /// 32-bit edge
+        using edge = types::edge<std::int32_t>;
     } // namespace ts
 } // namespace fwdpp
 

--- a/fwdpp/ts/mutation_record.hpp
+++ b/fwdpp/ts/mutation_record.hpp
@@ -1,41 +1,15 @@
 #ifndef FWDPP_TS_MUTATION_RECORD_HPP
 #define FWDPP_TS_MUTATION_RECORD_HPP
 
-#include <tuple>
 #include <cstdint>
+#include "types/mutation_record.hpp"
 
 namespace fwdpp
 {
     namespace ts
     {
-        struct mutation_record
-        /// Tracks mutations on tree sequences.
-        ///  \version 0.7.0 Added to fwdpp
-        {
-            /// The node to which the mutation is
-            /// currently simplified
-            std::int32_t node;
-            /// The index of the mutation in the
-            /// population's mutation container
-            std::size_t key;
-            /// Row in the site table.
-            std::size_t site;
-            /// Character state of the mutation
-            std::int8_t derived_state; // TODO: should this be a template type?
-            /// True if mutation affects fitness, otherwise false.
-            bool neutral;
-        };
-
-        inline bool
-        operator==(const mutation_record& a, const mutation_record& b)
-        {
-            // Test site first b/c two mutations cannot be equal
-            // if they aren't at the same site.
-            return a.site == b.site
-                   && std::tie(a.node, a.key, a.derived_state, a.neutral)
-                          == std::tie(b.node, b.key, b.derived_state,
-                                      b.neutral);
-        }
+        /// 32-bit mutation_record
+        using mutation_record = types::mutation_record<std::int32_t>;
     } // namespace ts
 } // namespace fwdpp
 

--- a/fwdpp/ts/node.hpp
+++ b/fwdpp/ts/node.hpp
@@ -4,30 +4,15 @@
 #ifndef FWDPP_TS_NODE_HPP
 #define FWDPP_TS_NODE_HPP
 
-#include <tuple>
 #include <cstdint>
+#include "types/node.hpp"
 
 namespace fwdpp
 {
     namespace ts
     {
-        struct node
-        /// A node in a tree sequence
-        ///  \version 0.7.0 Added to fwdpp
-        ///  \version 0.8.0 Rename ::population to ::deme
-        {
-            /// Location of the node.
-            /// Used for models of discrete population structure
-            std::int32_t deme;
-            /// Birth time of the node.
-            double time;
-        };
-
-        inline bool
-        operator==(const node& a, const node& b)
-        {
-            return std::tie(a.time, a.deme) == std::tie(b.time, b.deme);
-        }
+        /// 32-bit node
+        using node = types::node<std::int32_t>;
     } // namespace ts
 } // namespace fwdpp
 #endif

--- a/fwdpp/ts/recording/edge_buffer.hpp
+++ b/fwdpp/ts/recording/edge_buffer.hpp
@@ -24,7 +24,7 @@ namespace fwdpp
             //std::int64_t next;
 
             birth_data(double l, double r, table_index_t c)
-                : left{l}, right{r}, child{c}//, next{EDGE_BUFFER_NULL}
+                : left{l}, right{r}, child{c} //, next{EDGE_BUFFER_NULL}
             {
             }
         };
@@ -154,11 +154,10 @@ namespace fwdpp
                     auto n = new_edges.head(ex.parent);
                     while (n != edge_buffer::null)
                         {
-                            const auto & birth = new_edges.fetch(n);
+                            const auto& birth = new_edges.fetch(n);
                             edge_liftover.emplace_back(
-                                typename TableCollectionType::edge_t{
-                                    birth.left, birth.right,
-                                    ex.parent, birth.child});
+                                typename TableCollectionType::edge{
+                                    birth.left, birth.right, ex.parent, birth.child});
                             n = new_edges.next(n);
                         }
                 }
@@ -182,14 +181,14 @@ namespace fwdpp
             for (auto b = new_edges.rbegin(); b < new_edges.rend(); ++b)
                 {
                     auto parent = new_edges.convert_to_head_index(b);
-                    if(parent < 0)
-                    {
-                        throw std::runtime_error("negative parent value");
-                    }
-                    if(parent >= std::numeric_limits<table_index_t>::max())
-                    {
-                        throw std::overflow_error("parent value overflows");
-                    }
+                    if (parent < 0)
+                        {
+                            throw std::runtime_error("negative parent value");
+                        }
+                    if (parent >= std::numeric_limits<table_index_t>::max())
+                        {
+                            throw std::overflow_error("parent value overflows");
+                        }
                     auto cast_parent = static_cast<table_index_t>(parent);
                     auto ptime = tables.nodes[parent].time;
                     if (*b != edge_buffer::null && ptime > max_time)
@@ -197,11 +196,10 @@ namespace fwdpp
                             auto n = *b;
                             while (n != edge_buffer::null)
                                 {
-                                    const auto & birth = new_edges.fetch(n);
+                                    const auto& birth = new_edges.fetch(n);
                                     edge_liftover.emplace_back(
-                                        typename TableCollectionType::edge_t{
-                                            birth.left,
-                                            birth.right, cast_parent,
+                                        typename TableCollectionType::edge{
+                                            birth.left, birth.right, cast_parent,
                                             birth.child});
                                     n = new_edges.next(n);
                                 }

--- a/fwdpp/ts/simplification/simplification.hpp
+++ b/fwdpp/ts/simplification/simplification.hpp
@@ -200,8 +200,8 @@ namespace fwdpp
             /// \version Added in 0.9
             {
                 using table_type = TableCollectionType;
-                using edge_t = typename TableCollectionType::edge_t;
-                using node_t = typename TableCollectionType::node_t;
+                using edge_t = typename TableCollectionType::edge;
+                using node_t = typename TableCollectionType::node;
                 typename table_type::edge_table new_edge_table;
                 typename table_type::edge_table temp_edge_buffer;
                 typename table_type::node_table new_node_table;
@@ -349,7 +349,7 @@ namespace fwdpp
                                 if (output_id == NULL_INDEX)
                                     {
                                         state.new_node_table.emplace_back(
-                                            typename TableCollectionType::node_t{
+                                            typename TableCollectionType::node{
                                                 input_node_table[parent_input_id].deme,
                                                 input_node_table[parent_input_id].time});
                                         output_id = static_cast<decltype(output_id)>(
@@ -443,8 +443,8 @@ namespace fwdpp
                                 throw std::invalid_argument("invalid sample list");
                             }
                         state.new_node_table.emplace_back(
-                            typename TableCollectionType::node_t{tables.nodes[s].deme,
-                                                                 tables.nodes[s].time});
+                            typename TableCollectionType::node{tables.nodes[s].deme,
+                                                               tables.nodes[s].time});
                         add_ancestry(
                             s, 0, tables.genome_length(),
                             static_cast<table_index_t>(state.new_node_table.size() - 1),
@@ -557,7 +557,7 @@ namespace fwdpp
                 // ancestry and may be removed.
                 auto itr = std::remove_if(
                     begin(input_tables.mutations), end(input_tables.mutations),
-                    [](const typename TableCollectionType::mutation_t& mr) {
+                    [](const typename TableCollectionType::mutation_record& mr) {
                         return mr.node == NULL_INDEX;
                     });
                 preserved_variants.clear();
@@ -574,8 +574,9 @@ namespace fwdpp
                 //TODO: replace assert with exception
                 assert(std::is_sorted(
                     begin(input_tables.mutations), end(input_tables.mutations),
-                    [&input_tables](const typename TableCollectionType::mutation_t& a,
-                                    const typename TableCollectionType::mutation_t& b) {
+                    [&input_tables](
+                        const typename TableCollectionType::mutation_record& a,
+                        const typename TableCollectionType::mutation_record& b) {
                         return input_tables.sites[a.site].position
                                < input_tables.sites[b.site].position;
                     }));

--- a/fwdpp/ts/site.hpp
+++ b/fwdpp/ts/site.hpp
@@ -1,33 +1,13 @@
 #ifndef FWDPP_TS_SITE_HPP
 #define FWDPP_TS_SITE_HPP
 
-#include <tuple>
-#include <cstdint>
+#include "types/site.hpp"
 
 namespace fwdpp
 {
     namespace ts
     {
-        struct site
-        /// Entry in a site table
-        /// \version 0.8.0 Added to llibrary
-        {
-            double position;
-            std::int8_t ancestral_state;
-        };
-
-        inline bool
-        operator<(const site& a, const site& b)
-        {
-            return a.position < b.position;
-        }
-
-        inline bool
-        operator==(const site& a, const site& b)
-        {
-            return std::tie(a.position, a.ancestral_state)
-                   == std::tie(b.position, b.ancestral_state);
-        }
+        using site = types::site;
     } // namespace ts
 } // namespace fwdpp
 

--- a/fwdpp/ts/site_visitor.hpp
+++ b/fwdpp/ts/site_visitor.hpp
@@ -127,7 +127,7 @@ namespace fwdpp
         };
 
         template <typename TableCollectionType>
-        inline typename TableCollectionType::site_table_t::const_iterator
+        inline typename TableCollectionType::site_table::const_iterator
         end(site_visitor<TableCollectionType>& sv)
         {
             return sv.end();

--- a/fwdpp/ts/table_collection.hpp
+++ b/fwdpp/ts/table_collection.hpp
@@ -1,20 +1,15 @@
 #ifndef FWDPP_TS_TABLE_COLLECTION_HPP
 #define FWDPP_TS_TABLE_COLLECTION_HPP
 
-#include <vector>
-#include "node.hpp"
-#include "edge.hpp"
-#include "site.hpp"
-#include "mutation_record.hpp"
-#include "detail/table_collection.hpp"
+#include <cstdint>
+#include "definitions.hpp"
+#include "types/table_collection.hpp"
 
 namespace fwdpp
 {
     namespace ts
     {
-        using table_collection
-            = detail::table_collection<std::vector<node>, std::vector<edge>,
-                                       std::vector<site>, std::vector<mutation_record>>;
+        using table_collection = types::table_collection<std::int32_t>;
     }
 }
 

--- a/fwdpp/ts/table_collection_functions.hpp
+++ b/fwdpp/ts/table_collection_functions.hpp
@@ -18,8 +18,8 @@ namespace fwdpp
          * @version 0.9.0 Added to library
          */
         {
-            return [&tables](const typename TableCollectionType::edge_t& a,
-                             const typename TableCollectionType::edge_t& b) {
+            return [&tables](const typename TableCollectionType::edge& a,
+                             const typename TableCollectionType::edge& b) {
                 auto ga = tables.nodes[a.parent].time;
                 auto gb = tables.nodes[b.parent].time;
                 if (ga == gb)
@@ -42,8 +42,8 @@ namespace fwdpp
         inline auto
         get_minimal_edge_sort_cmp(const TableCollectionType& tables)
         {
-            return [&tables](const typename TableCollectionType::edge_t& a,
-                             const typename TableCollectionType::edge_t& b) {
+            return [&tables](const typename TableCollectionType::edge& a,
+                             const typename TableCollectionType::edge& b) {
                 auto ga = tables.nodes[a.parent].time;
                 auto gb = tables.nodes[b.parent].time;
                 return ga > gb
@@ -105,8 +105,8 @@ namespace fwdpp
 
         template <typename TableCollectionType>
         inline void
-        record_site_during_rebuild(const typename TableCollectionType::site_t& s,
-                                   typename TableCollectionType::mutation_t& mr,
+        record_site_during_rebuild(const typename TableCollectionType::site& s,
+                                   typename TableCollectionType::mutation_record& mr,
                                    TableCollectionType& tables)
         {
             if (tables.sites.empty() || tables.sites.back().position != s.position)

--- a/fwdpp/ts/types/Makefile.am
+++ b/fwdpp/ts/types/Makefile.am
@@ -1,0 +1,8 @@
+pkgincludedir=$(prefix)/include/fwdpp/ts/types
+
+pkginclude_HEADERS= node.hpp \
+					edge.hpp \
+					site.hpp \
+					mutation_record.hpp \
+					generate_null_id.hpp \
+					table_collection.hpp

--- a/fwdpp/ts/types/edge.hpp
+++ b/fwdpp/ts/types/edge.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <tuple>
+#include <type_traits>
+#include "generate_null_id.hpp"
+
+namespace fwdpp
+{
+    namespace ts
+    {
+        namespace types
+        {
+            template <typename SignedInteger> struct edge
+            /*! An edge in a tree sequence
+             * @version 0.7.0 Added to fwdpp
+             *
+             * Edges define a transmission event
+             * of the genomic interval [left,right)
+             * from parent to child.
+             */
+            {
+                static_assert(std::is_integral<SignedInteger>::value,
+                              "SignedInteger must be an integral type");
+                static_assert(std::is_signed<SignedInteger>::value,
+                              "SignedInteger must be a signed type");
+                using id_type = SignedInteger;
+                /// Null ID value
+                static constexpr SignedInteger null = generate_null_id<id_type>();
+                /// Left (inclusive) edge of genomic segment
+                double left;
+                /// Right (exclusive) edge of genomic segment
+                double right;
+                /// Parent ID
+                id_type parent;
+                /// Child ID
+                id_type child;
+            };
+
+#if __cplusplus < 201703L
+            template <typename SignedInteger>
+            constexpr SignedInteger edge<SignedInteger>::null;
+#endif
+
+            template <typename SignedInteger>
+            inline bool
+            operator==(const edge<SignedInteger>& self,
+                       const edge<SignedInteger>& other)
+            {
+                return std::tie(self.parent, self.child, self.left, self.right)
+                       == std::tie(other.parent, other.child, other.left, other.right);
+            }
+        }
+    }
+}

--- a/fwdpp/ts/types/generate_null_id.hpp
+++ b/fwdpp/ts/types/generate_null_id.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <type_traits>
+
+namespace fwdpp
+{
+    namespace ts
+    {
+        namespace types
+        {
+            template <typename SignedInteger>
+            inline constexpr SignedInteger
+            generate_null_id()
+            {
+                static_assert(std::is_integral<SignedInteger>::value,
+                              "T must be an integral type");
+                static_assert(std::is_signed<SignedInteger>::value,
+                              "T must be a signed type");
+                return SignedInteger{-1};
+            }
+        }
+    }
+}

--- a/fwdpp/ts/types/mutation_record.hpp
+++ b/fwdpp/ts/types/mutation_record.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <cstdint>
+#include <tuple>
+#include <type_traits>
+#include "generate_null_id.hpp"
+
+namespace fwdpp
+{
+    namespace ts
+    {
+        namespace types
+        {
+            template <typename SignedInteger> struct mutation_record
+            /// Tracks mutations on tree sequences.
+            ///  \version 0.7.0 Added to fwdpp
+            {
+                using id_type = SignedInteger;
+                /// Null ID value
+                static constexpr SignedInteger null = generate_null_id<id_type>();
+                /// The node to which the mutation is
+                /// currently simplified
+                id_type node;
+                /// The index of the mutation in the
+                /// population's mutation container
+                std::size_t key;
+                /// Row in the site table.
+                std::size_t site;
+                /// Character state of the mutation
+                std::int8_t derived_state; // TODO: should this be a template type?
+                /// True if mutation affects fitness, otherwise false.
+                bool neutral;
+            };
+
+#if __cplusplus < 201703L
+            template <typename SignedInteger>
+            constexpr SignedInteger mutation_record<SignedInteger>::null;
+#endif
+
+            template <typename SignedInteger>
+            inline bool
+            operator==(const mutation_record<SignedInteger>& self,
+                       const mutation_record<SignedInteger>& other)
+            {
+                // Test site first b/c two mutations cannot be equal
+                // if they aren't at the same site.
+                return self.site == other.site
+                       && std::tie(self.node, self.key, self.derived_state, self.neutral)
+                              == std::tie(other.node, other.key, other.derived_state,
+                                          other.neutral);
+            }
+
+        }
+    }
+}

--- a/fwdpp/ts/types/node.hpp
+++ b/fwdpp/ts/types/node.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <tuple>
+#include <type_traits>
+#include "generate_null_id.hpp"
+
+namespace fwdpp
+{
+    namespace ts
+    {
+        namespace types
+        {
+            template <typename SignedInteger> struct node
+            /// A node in a tree sequence
+            ///  \version 0.7.0 Added to fwdpp
+            ///  \version 0.8.0 Rename ::population to ::deme
+            {
+                static_assert(std::is_integral<SignedInteger>::value,
+                              "SignedInteger must be an integral type");
+                static_assert(std::is_signed<SignedInteger>::value,
+                              "SignedInteger must be a signed type");
+                using id_type = SignedInteger;
+                /// Null ID value
+                static constexpr SignedInteger null = generate_null_id<id_type>();
+                /// Location of the node.
+                /// Used for models of discrete population structure
+                id_type deme;
+                /// Birth time of the node.
+                double time;
+            };
+
+#if __cplusplus < 201703L
+            template <typename SignedInteger>
+            constexpr SignedInteger node<SignedInteger>::null;
+#endif
+
+            template <typename SignedInteger>
+            inline bool
+            operator==(const node<SignedInteger>& self,
+                       const node<SignedInteger>& other)
+            {
+                return std::tie(self.time, self.deme)
+                       == std::tie(other.time, other.deme);
+            }
+        }
+    }
+}

--- a/fwdpp/ts/types/site.hpp
+++ b/fwdpp/ts/types/site.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <tuple>
+#include <cstdint>
+
+namespace fwdpp
+{
+    namespace ts
+    {
+        namespace types
+        {
+            struct site
+            /// Entry in a site table
+            /// \version 0.8.0 Added to llibrary
+            {
+                double position;
+                std::int8_t ancestral_state;
+            };
+
+            inline bool
+            operator<(const site& a, const site& b)
+            {
+                return a.position < b.position;
+            }
+
+            inline bool
+            operator==(const site& a, const site& b)
+            {
+                return std::tie(a.position, a.ancestral_state)
+                       == std::tie(b.position, b.ancestral_state);
+            }
+        }
+    }
+}

--- a/testsuite/tree_sequences/test_visit_sites.cc
+++ b/testsuite/tree_sequences/test_visit_sites.cc
@@ -7,17 +7,17 @@ BOOST_AUTO_TEST_SUITE(test_visit_sites)
 BOOST_FIXTURE_TEST_CASE(test_simple_iteration, simple_table_collection_infinite_sites)
 {
     std::size_t num_sites = 0;
-    auto f
-        = [&num_sites](
-              const fwdpp::ts::marginal_tree& /*m*/, const fwdpp::ts::site& /*s*/,
-              const fwdpp::ts::table_collection::mutation_table::const_iterator b,
-              const fwdpp::ts::table_collection::mutation_table::const_iterator e) {
-              if (std::distance(b, e) != 1)
-                  {
-                      throw std::runtime_error("incorrect number of mutations");
-                  }
-              ++num_sites;
-          };
+    auto f = [&num_sites](
+                 const fwdpp::ts::marginal_tree& /*m*/,
+                 const fwdpp::ts::table_collection::site& /*s*/,
+                 const fwdpp::ts::table_collection::mutation_table::const_iterator b,
+                 const fwdpp::ts::table_collection::mutation_table::const_iterator e) {
+        if (std::distance(b, e) != 1)
+            {
+                throw std::runtime_error("incorrect number of mutations");
+            }
+        ++num_sites;
+    };
     BOOST_REQUIRE_NO_THROW(
         { fwdpp::ts::visit_sites(tables, samples, f, 0, tables.genome_length()); });
     BOOST_REQUIRE_EQUAL(num_sites, tables.sites.size());


### PR DESCRIPTION
This PR turns the low-level types for tables into templates.

We also start to abstract out the concept of a "null" ID to
a constexpr template function.
