### PR TITLE
deprecate global ts constants and typenames

### DIFF
--- a/examples/simplify_tables.hpp
+++ b/examples/simplify_tables.hpp
@@ -14,13 +14,13 @@
 #include "fwdpp/ts/exceptions.hpp"
 
 template <typename Simplifier, typename poptype>
-std::pair<std::vector<fwdpp::ts::table_index_t>, std::vector<std::size_t>>
+std::pair<std::vector<fwdpp::ts::table_collection::id_type>, std::vector<std::size_t>>
 simplify_tables(poptype &pop, const fwdpp::uint_t generation,
                 std::vector<fwdpp::uint_t> &mcounts_from_preserved_nodes,
                 fwdpp::ts::table_collection &tables, Simplifier &simplifier,
-                const fwdpp::ts::table_index_t first_sample_node,
+                const fwdpp::ts::table_collection::id_type first_sample_node,
                 const std::size_t num_samples,
-                std::vector<fwdpp::ts::table_index_t> &preserved_nodes,
+                std::vector<fwdpp::ts::table_collection::id_type> &preserved_nodes,
                 const bool preserve_fixations = false)
 {
     fwdpp::ts::sort_tables_for_simplification(tables.edge_offset, tables);
@@ -62,11 +62,16 @@ simplify_tables(poptype &pop, const fwdpp::uint_t generation,
             fwdpp::ts::remove_fixations_from_haploid_genomes(
                 pop.haploid_genomes, pop.mutations, pop.mcounts,
                 mcounts_from_preserved_nodes,
-                2 * static_cast<fwdpp::ts::table_index_t>(pop.diploids.size()), false);
+                2
+                    * static_cast<fwdpp::ts::table_collection::id_type>(
+                        pop.diploids.size()),
+                false);
 
             fwdpp::ts::flag_mutations_for_recycling(
                 pop, mcounts_from_preserved_nodes,
-                2 * static_cast<fwdpp::ts::table_index_t>(pop.diploids.size()),
+                2
+                    * static_cast<fwdpp::ts::table_collection::id_type>(
+                        pop.diploids.size()),
                 generation, std::false_type(), std::false_type());
             confirm_mutation_counts(pop, tables);
         }

--- a/examples/tree_sequence_examples_common.hpp
+++ b/examples/tree_sequence_examples_common.hpp
@@ -36,13 +36,13 @@ std::function<double()> make_dfe(const fwdpp::uint_t N, const GSLrng &r,
 
 void execute_matrix_test(const options &, const ts_examples_poptype &,
                          const fwdpp::ts::table_collection &,
-                         const std::vector<fwdpp::ts::table_index_t> &,
-                         const std::vector<fwdpp::ts::table_index_t> &);
+                         const std::vector<fwdpp::ts::table_collection::id_type> &,
+                         const std::vector<fwdpp::ts::table_collection::id_type> &);
 
 void execute_expensive_leaf_test(
     const options &o, const fwdpp::ts::table_collection &tables,
-    const std::vector<fwdpp::ts::table_index_t> &samples,
-    const std::vector<fwdpp::ts::table_index_t> &preserved_nodes);
+    const std::vector<fwdpp::ts::table_collection::id_type> &samples,
+    const std::vector<fwdpp::ts::table_collection::id_type> &preserved_nodes);
 
 void execute_serialization_test(const options &,
                                 const fwdpp::ts::table_collection &);
@@ -52,11 +52,11 @@ void test_serialization(const fwdpp::ts::table_collection &tables,
 
 void visit_sites_test(const options &o, const ts_examples_poptype &pop,
                       const fwdpp::ts::table_collection &tables,
-                      const std::vector<fwdpp::ts::table_index_t> &samples,
-                      const std::vector<fwdpp::ts::table_index_t> &preserved_nodes);
+                      const std::vector<fwdpp::ts::table_collection::id_type> &samples,
+                      const std::vector<fwdpp::ts::table_collection::id_type> &preserved_nodes);
 
 void write_sfs(const options &o, const GSLrng &rng,
                const fwdpp::ts::table_collection &tables,
-               const std::vector<fwdpp::ts::table_index_t> &samples);
+               const std::vector<fwdpp::ts::table_collection::id_type> &samples);
 
 #endif

--- a/examples/tree_sequence_examples_types.hpp
+++ b/examples/tree_sequence_examples_types.hpp
@@ -5,6 +5,7 @@
 #include <fwdpp/diploid_population.hpp>
 #include <fwdpp/GSLrng_t.hpp>
 #include <fwdpp/types/mutation.hpp>
+#include <fwdpp/ts/table_collection.hpp>
 
 using ts_examples_poptype = fwdpp::diploid_population<fwdpp::mutation>;
 using GSLrng = fwdpp::GSLrng_mt;
@@ -13,9 +14,10 @@ struct diploid_metadata
 {
     std::size_t individual;
     double time, fitness;
-    fwdpp::ts::table_index_t n1, n2;
+    fwdpp::ts::table_collection::id_type n1, n2;
     diploid_metadata(std::size_t i, double t, double w,
-                     fwdpp::ts::table_index_t a, fwdpp::ts::table_index_t b)
+                     fwdpp::ts::table_collection::id_type a,
+                     fwdpp::ts::table_collection::id_type b)
         : individual(i), time(t), fitness(w), n1(a), n2(b)
     {
     }

--- a/examples/wfts_integration_test.cc
+++ b/examples/wfts_integration_test.cc
@@ -64,7 +64,8 @@ main(int argc, char **argv)
 
     ts_examples_poptype pop(o.N);
     fwdpp::ts::table_collection tables(
-        2 * static_cast<fwdpp::ts::table_index_t>(pop.diploids.size()), 0, 0, 1.0);
+        2 * static_cast<fwdpp::ts::table_collection::id_type>(pop.diploids.size()), 0, 0,
+        1.0);
     auto simplifier = fwdpp::ts::make_table_simplifier(tables);
     unsigned generation = 1;
     double recrate = o.rho / static_cast<double>(4 * o.N);
@@ -104,9 +105,10 @@ main(int argc, char **argv)
         };
 
     // Evolve pop for 20N generations
-    fwdpp::ts::table_index_t first_parental_index
+    fwdpp::ts::table_collection::id_type first_parental_index
         = 0,
-        next_index = 2 * static_cast<fwdpp::ts::table_index_t>(pop.diploids.size());
+        next_index
+        = 2 * static_cast<fwdpp::ts::table_collection::id_type>(pop.diploids.size());
     bool simplified = false;
     std::vector<std::size_t> individual_labels(o.N);
     std::iota(individual_labels.begin(), individual_labels.end(), 0);
@@ -132,14 +134,16 @@ main(int argc, char **argv)
     auto genetics = fwdpp::make_genetic_parameters(std::move(ff), std::move(mmodel),
                                                    std::move(recmap));
     auto lookup = calculate_fitnesses(pop, fitnesses, genetics.gvalue);
-    std::vector<fwdpp::ts::table_index_t> preserved_nodes;
+    std::vector<fwdpp::ts::table_collection::id_type> preserved_nodes;
     for (; generation <= 10 * o.N; ++generation)
         {
             auto pick1 = [&lookup, &rng]() {
-                return static_cast<fwdpp::ts::table_index_t>(gsl_ran_discrete(rng.get(), lookup.get()));
+                return static_cast<fwdpp::ts::table_collection::id_type>(
+                    gsl_ran_discrete(rng.get(), lookup.get()));
             };
             auto pick2 = [&lookup, &rng](const auto /*p1*/) {
-                return static_cast<fwdpp::ts::table_index_t>(gsl_ran_discrete(rng.get(), lookup.get()));
+                return static_cast<fwdpp::ts::table_collection::id_type>(
+                    gsl_ran_discrete(rng.get(), lookup.get()));
             };
             evolve_generation(rng, pop, genetics, o.N, pick1, pick2, update_offspring,
                               generation, tables, first_parental_index, next_index);
@@ -150,7 +154,8 @@ main(int argc, char **argv)
                     auto rv = simplify_tables(
                         pop, generation, pop.mcounts_from_preserved_nodes, tables,
                         simplifier,
-                        static_cast<fwdpp::ts::table_index_t>(tables.num_nodes())
+                        static_cast<fwdpp::ts::table_collection::id_type>(
+                            tables.num_nodes())
                             - 2 * o.N,
                         2 * o.N, preserved_nodes, o.preserve_fixations);
                     if (!o.preserve_fixations)
@@ -164,8 +169,8 @@ main(int argc, char **argv)
                                 rv.second, pop.mutations.size());
                         }
                     simplified = true;
-                    next_index
-                        = static_cast<fwdpp::ts::table_index_t>(tables.num_nodes());
+                    next_index = static_cast<fwdpp::ts::table_collection::id_type>(
+                        tables.num_nodes());
                     first_parental_index = 0;
 
                     // When tracking ancient samples, the node ids of those samples change.
@@ -230,7 +235,7 @@ main(int argc, char **argv)
                         {
                             auto x = fwdpp::ts::get_parent_ids(
                                 first_parental_index,
-                                static_cast<fwdpp::ts::table_index_t>(i), 0);
+                                static_cast<fwdpp::ts::table_collection::id_type>(i), 0);
                             assert(x.first >= first_parental_index);
                             assert(x.second >= first_parental_index);
                             assert(x.first < static_cast<int>(tables.num_nodes()));
@@ -259,7 +264,8 @@ main(int argc, char **argv)
         {
             auto rv = simplify_tables(
                 pop, generation, pop.mcounts_from_preserved_nodes, tables, simplifier,
-                static_cast<fwdpp::ts::table_index_t>(tables.num_nodes()) - 2 * o.N,
+                static_cast<fwdpp::ts::table_collection::id_type>(tables.num_nodes())
+                    - 2 * o.N,
                 2 * o.N, preserved_nodes, o.preserve_fixations);
             if (o.preserve_fixations)
                 {
@@ -311,7 +317,7 @@ main(int argc, char **argv)
         }
     assert(tables.input_left.size() == tables.edges.size());
     assert(tables.output_right.size() == tables.edges.size());
-    std::vector<fwdpp::ts::table_index_t> s(2 * o.N);
+    std::vector<fwdpp::ts::table_collection::id_type> s(2 * o.N);
     std::iota(s.begin(), s.end(), 0);
 
     auto neutral_muts

--- a/fwdpp/ts/definitions.hpp
+++ b/fwdpp/ts/definitions.hpp
@@ -10,9 +10,11 @@ namespace fwdpp
     namespace ts
     {
         /// Integer type for table indexes
-        using table_index_t = std::int32_t;
+        using table_index_t [[deprecated("Use member typedefs instead")]] = std::int32_t;
         /// NULL index value
-        constexpr table_index_t NULL_INDEX = -1;
+        constexpr std::int32_t NULL_INDEX
+            [[deprecated("Use member constexpr value null instead")]]
+            = -1;
         /// Convention for the ancestral state of a site
         constexpr std::int8_t default_ancestral_state = 0;
         /// Convention for the derived state of a site

--- a/fwdpp/ts/detail/advance_marginal_tree_policies.hpp
+++ b/fwdpp/ts/detail/advance_marginal_tree_policies.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <type_traits>
 #include <cassert>
+#include "../types/generate_null_id.hpp"
 #include "../marginal_tree.hpp"
 
 namespace fwdpp
@@ -12,19 +13,19 @@ namespace fwdpp
     {
         namespace detail
         {
+            template <typename SignedInteger>
             inline void
-            outgoing_leaf_counts(marginal_tree& marginal,
-                                 const std::int32_t parent,
-                                 const std::int32_t child)
+            outgoing_leaf_counts(marginal_tree<SignedInteger>& marginal,
+                                 const SignedInteger parent, const SignedInteger child)
             {
                 auto p = parent;
                 auto lc = marginal.leaf_counts[child];
                 auto plc = marginal.preserved_leaf_counts[child];
-                if (lc+plc == 0)
-                {
-                    return;
-                }
-                while (p != NULL_INDEX)
+                if (lc + plc == 0)
+                    {
+                        return;
+                    }
+                while (p != types::generate_null_id<SignedInteger>())
                     {
                         marginal.leaf_counts[p] -= lc;
                         marginal.preserved_leaf_counts[p] -= plc;
@@ -34,19 +35,19 @@ namespace fwdpp
                     }
             }
 
+            template <typename SignedInteger>
             inline void
-            incoming_leaf_counts(marginal_tree& marginal,
-                                 const std::int32_t parent,
-                                 const std::int32_t child)
+            incoming_leaf_counts(marginal_tree<SignedInteger>& marginal,
+                                 const SignedInteger parent, const SignedInteger child)
             {
                 auto p = parent;
                 auto lc = marginal.leaf_counts[child];
                 auto plc = marginal.preserved_leaf_counts[child];
-                if (lc+plc == 0)
-                {
-                    return;
-                }
-                while (p != NULL_INDEX)
+                if (lc + plc == 0)
+                    {
+                        return;
+                    }
+                while (p != types::generate_null_id<SignedInteger>())
                     {
                         marginal.leaf_counts[p] += lc;
                         marginal.preserved_leaf_counts[p] += plc;
@@ -54,9 +55,10 @@ namespace fwdpp
                     }
             }
 
+            template <typename SignedInteger>
             inline void
-            update_samples_list(marginal_tree& marginal,
-                                const std::int32_t node)
+            update_samples_list(marginal_tree<SignedInteger>& marginal,
+                                const SignedInteger node)
             {
                 const auto& parents = marginal.parents;
                 const auto& sample_map = marginal.sample_index_map;
@@ -66,25 +68,30 @@ namespace fwdpp
                 auto& right = marginal.right_sample;
                 auto& left = marginal.left_sample;
                 auto& next = marginal.next_sample;
-                for (auto n = node; n != NULL_INDEX; n = parents[n])
+                for (auto n = node; n != types::generate_null_id<SignedInteger>();
+                     n = parents[n])
                     {
                         auto sample_index = sample_map[n];
-                        if (sample_index != NULL_INDEX)
+                        if (sample_index != types::generate_null_id<SignedInteger>())
                             {
                                 right[n] = left[n];
                             }
                         else
                             {
-                                left[n] = NULL_INDEX;
-                                right[n] = NULL_INDEX;
+                                left[n] = types::generate_null_id<SignedInteger>();
+                                right[n] = types::generate_null_id<SignedInteger>();
                             }
-                        for (auto v = left_child[n]; v != NULL_INDEX;
+                        for (auto v = left_child[n];
+                             v != types::generate_null_id<SignedInteger>();
                              v = right_sib[v])
                             {
-                                if (left[v] != NULL_INDEX)
+                                if (left[v] != types::generate_null_id<SignedInteger>())
                                     {
-                                        assert(right[v] != NULL_INDEX);
-                                        if (left[n] == NULL_INDEX)
+                                        assert(
+                                            right[v]
+                                            != types::generate_null_id<SignedInteger>());
+                                        if (left[n]
+                                            == types::generate_null_id<SignedInteger>())
                                             {
                                                 left[n] = left[v];
                                                 right[n] = right[v];

--- a/fwdpp/ts/detail/generate_data_matrix_details.hpp
+++ b/fwdpp/ts/detail/generate_data_matrix_details.hpp
@@ -15,14 +15,14 @@ namespace fwdpp
     {
         namespace detail
         {
-            template<typename SITE_CONST_ITER, typename MUT_CONST_ITR>
+            template <typename SignedInteger, typename SITE_CONST_ITER,
+                      typename MUT_CONST_ITR>
             inline void
-            process_site_range(const marginal_tree & tree,
+            process_site_range(const marginal_tree<SignedInteger>& tree,
                                const SITE_CONST_ITER current_site,
-                               const std::pair<MUT_CONST_ITR,MUT_CONST_ITR> & muts,
+                               const std::pair<MUT_CONST_ITR, MUT_CONST_ITR>& muts,
                                bool record_neutral, bool record_selected,
-                               bool skip_fixed,
-                               std::vector<std::int8_t>& genotypes,
+                               bool skip_fixed, std::vector<std::int8_t>& genotypes,
                                data_matrix& dm)
             {
                 int neutral = -1, selected = -1;
@@ -39,19 +39,14 @@ namespace fwdpp
                         if ((mut->neutral && record_neutral)
                             || (!mut->neutral && record_selected))
                             {
-                                if (lc > 0
-                                    && (!skip_fixed
-                                        || (lc < genotypes.size())))
+                                if (lc > 0 && (!skip_fixed || (lc < genotypes.size())))
                                     {
-                                        const auto f
-                                            = [mut, &nsamples, &genotypes](
-                                                  fwdpp::ts::table_index_t u) {
-                                                  ++nsamples;
-                                                  genotypes[u]
-                                                      = mut->derived_state;
-                                              };
-                                        process_samples(tree, convert,
-                                                        mut->node, f);
+                                        const auto f = [mut, &nsamples,
+                                                        &genotypes](SignedInteger u) {
+                                            ++nsamples;
+                                            genotypes[u] = mut->derived_state;
+                                        };
+                                        process_samples(tree, convert, mut->node, f);
                                     }
                             }
                     }
@@ -64,20 +59,15 @@ namespace fwdpp
                     {
                         if (neutral != -1)
                             {
-                                dm.neutral.positions.push_back(
-                                    current_site->position);
-                                dm.neutral_keys.push_back(
-                                    (muts.second - 1)->key);
+                                dm.neutral.positions.push_back(current_site->position);
+                                dm.neutral_keys.push_back((muts.second - 1)->key);
                                 dm.neutral.data.insert(end(dm.neutral.data),
-                                                       begin(genotypes),
-                                                       end(genotypes));
+                                                       begin(genotypes), end(genotypes));
                             }
                         else
                             {
-                                dm.selected.positions.push_back(
-                                    current_site->position);
-                                dm.selected_keys.push_back(
-                                    (muts.second - 1)->key);
+                                dm.selected.positions.push_back(current_site->position);
+                                dm.selected_keys.push_back((muts.second - 1)->key);
                                 dm.selected.data.insert(end(dm.selected.data),
                                                         begin(genotypes),
                                                         end(genotypes));

--- a/fwdpp/ts/get_parent_ids.hpp
+++ b/fwdpp/ts/get_parent_ids.hpp
@@ -2,15 +2,16 @@
 #define FWDPP_TS_GET_PARENT_IDS_HPP
 
 #include <utility>
-#include "definitions.hpp"
+#include <type_traits>
 
 namespace fwdpp
 {
     namespace ts
     {
-        inline std::pair<table_index_t, table_index_t>
-        get_parent_ids(const table_index_t first_parental_index,
-                       const table_index_t parent, const int did_swap)
+        template <typename SignedInteger>
+        inline std::pair<SignedInteger, SignedInteger>
+        get_parent_ids(const SignedInteger first_parental_index,
+                       const SignedInteger parent, const int did_swap)
         /*! 
          * Convert the index of a parent into the two node IDs.
          *
@@ -22,10 +23,13 @@ namespace fwdpp
          * if a more complex set of rules are needed
          */
         {
+            static_assert(std::is_integral<SignedInteger>::value,
+                          "SignedInteger must be an integral type");
+            static_assert(std::is_signed<SignedInteger>::value,
+                          "SignedInteger must be a signed type");
             return std::make_pair(
-                first_parental_index + 2 * static_cast<table_index_t>(parent)
-                    + did_swap,
-                first_parental_index + 2 * static_cast<table_index_t>(parent)
+                first_parental_index + 2 * static_cast<SignedInteger>(parent) + did_swap,
+                first_parental_index + 2 * static_cast<SignedInteger>(parent)
                     + !did_swap);
         }
     } // namespace ts

--- a/fwdpp/ts/make_simplifier_state.hpp
+++ b/fwdpp/ts/make_simplifier_state.hpp
@@ -2,14 +2,15 @@
 #define FWDPP_TS_MAKE_SIMPLIFIER_STATE_HPP
 
 #include <fwdpp/ts/simplification/simplification.hpp>
+#include "types/table_collection.hpp"
 
 namespace fwdpp
 {
     namespace ts
     {
-        template <typename TableCollectionType>
-        inline simplification::simplifier_internal_state<TableCollectionType>
-        make_simplifier_state(const TableCollectionType& tables)
+        template <typename SignedInteger>
+        inline simplification::simplifier_internal_state<SignedInteger>
+        make_simplifier_state(const types::table_collection<SignedInteger>& tables)
         {
             return simplification::make_simplifier_internal_state(tables);
         }

--- a/fwdpp/ts/marginal_tree_functions/node_traversal_order.hpp
+++ b/fwdpp/ts/marginal_tree_functions/node_traversal_order.hpp
@@ -7,7 +7,7 @@ namespace fwdpp
 {
     namespace ts
     {
-        struct node_traversal_order
+        template <typename SignedInteger> struct node_traversal_order
         /// \brief Interface class for dependency injection
         ///        into node_iterator
         /// \headerfile fwdpp/ts/marginal_tree_functions/node_traversal_order.hpp
@@ -16,12 +16,11 @@ namespace fwdpp
             virtual ~node_traversal_order() = default;
             node_traversal_order(const node_traversal_order&) = default;
             node_traversal_order(node_traversal_order&&) = default;
-            node_traversal_order& operator=(const node_traversal_order&)
-                = default;
+            node_traversal_order& operator=(const node_traversal_order&) = default;
             node_traversal_order& operator=(node_traversal_order&&) = default;
 
-            virtual table_index_t operator()(const marginal_tree&) = 0;
-            virtual void initialize(table_index_t /*root*/) = 0;
+            virtual SignedInteger operator()(const marginal_tree<SignedInteger>&) = 0;
+            virtual void initialize(SignedInteger /*root*/) = 0;
         };
     } // namespace ts
 } // namespace fwdpp

--- a/fwdpp/ts/marginal_tree_functions/node_traversal_preorder.hpp
+++ b/fwdpp/ts/marginal_tree_functions/node_traversal_preorder.hpp
@@ -6,31 +6,31 @@
 #include <memory>
 #include "children.hpp"
 #include "node_traversal_order.hpp"
+#include "../types/generate_null_id.hpp"
 
 namespace fwdpp
 {
     namespace ts
     {
-        class node_traversal_preorder : public node_traversal_order
+        template <typename SignedInteger>
+        class node_traversal_preorder : public node_traversal_order<SignedInteger>
         /// \brief Preorder traversal of nodes for a node_iterator
         /// \headerfile fwdpp/ts/marginal_tree_functions/node_traversal_preorder.hpp
         {
           private:
-            using node_stack
-                = std::stack<table_index_t, std::vector<table_index_t>>;
+            using node_stack = std::stack<SignedInteger, std::vector<SignedInteger>>;
             node_stack nstack;
-            table_index_t current_node;
+            SignedInteger current_node;
 
           public:
-            explicit node_traversal_preorder(table_index_t u)
-                : node_traversal_order(), nstack{ { u } }, current_node{
-                      NULL_INDEX
-                  }
+            explicit node_traversal_preorder(SignedInteger u)
+                : node_traversal_order<SignedInteger>(), nstack{{u}},
+                  current_node{types::generate_null_id<SignedInteger>()}
             {
             }
 
-            table_index_t
-            operator()(const marginal_tree& m) final
+            SignedInteger
+            operator()(const marginal_tree<SignedInteger>& m) final
             {
                 if (!nstack.empty())
                     {
@@ -40,15 +40,15 @@ namespace fwdpp
                             {
                                 process_children(
                                     m, current_node, false,
-                                    [this](table_index_t x) { nstack.push(x); });
+                                    [this](SignedInteger x) { nstack.push(x); });
                             }
                         return current_node;
                     }
-                return NULL_INDEX;
+                return types::generate_null_id<SignedInteger>();
             }
 
             void
-            initialize(table_index_t root) final
+            initialize(SignedInteger root) final
             {
                 nstack.push(root);
             }
@@ -59,12 +59,13 @@ namespace fwdpp
         {
         };
 
-        inline std::unique_ptr<node_traversal_order>
-        node_traversal_dispatch(table_index_t root, nodes_preorder)
+        template <typename SignedInteger>
+        inline std::unique_ptr<node_traversal_order<SignedInteger>>
+        node_traversal_dispatch(SignedInteger root, nodes_preorder)
         /// Handles dependency injection of node_traversal_preorder into node_iterator
         {
-            return std::unique_ptr<node_traversal_order>(
-                new node_traversal_preorder(root));
+            return std::unique_ptr<node_traversal_order<SignedInteger>>(
+                new node_traversal_preorder<SignedInteger>(root));
         }
 
     } // namespace ts

--- a/fwdpp/ts/marginal_tree_functions/statistics.hpp
+++ b/fwdpp/ts/marginal_tree_functions/statistics.hpp
@@ -3,31 +3,31 @@
 
 #include <stdexcept>
 #include "../marginal_tree.hpp"
-#include "../node.hpp"
+#include "../types/generate_null_id.hpp"
+#include "../types/node.hpp"
 #include "nodes.hpp"
 
 namespace fwdpp
 {
     namespace ts
     {
+        template <typename SignedInteger>
         double
-        total_time(const marginal_tree &m, const std::vector<node> &nodes,
+        total_time(const marginal_tree<SignedInteger> &m,
+                   const std::vector<types::node<SignedInteger>> &nodes,
                    bool scale_by_length)
         {
             if (m.parents.size() != nodes.size())
                 {
-                    throw std::invalid_argument(
-                        "inconsistent container sizes");
+                    throw std::invalid_argument("inconsistent container sizes");
                 }
             double ttime = 0.;
-            process_nodes(
-                m, nodes_preorder(), [&ttime, &m, &nodes](table_index_t u) {
-                    if (m.parents[u] != NULL_INDEX)
-                        {
-                            ttime
-                                += (nodes[u].time - nodes[m.parents[u]].time);
-                        }
-                });
+            process_nodes(m, nodes_preorder(), [&ttime, &m, &nodes](SignedInteger u) {
+                if (m.parents[u] != types::generate_null_id<SignedInteger>())
+                    {
+                        ttime += (nodes[u].time - nodes[m.parents[u]].time);
+                    }
+            });
             if (scale_by_length)
                 {
                     ttime *= (m.right - m.left);

--- a/fwdpp/ts/mark_multiple_roots.hpp
+++ b/fwdpp/ts/mark_multiple_roots.hpp
@@ -14,7 +14,8 @@ namespace fwdpp
     {
         // TODO: consider flattening the return value to a vector
         template <typename TableCollectionType, typename SAMPLES>
-        inline std::map<table_index_t, std::vector<std::pair<double, double>>>
+        inline std::map<typename TableCollectionType::id_type,
+                        std::vector<std::pair<double, double>>>
         mark_multiple_roots(const TableCollectionType &tables, SAMPLES &&samples)
         /// \brief Identify root nodes in "marginal forests".
         ///
@@ -25,7 +26,9 @@ namespace fwdpp
         ///
         /// See fwdpp::ts::mutate_tables for discussion.
         {
-            std::map<table_index_t, std::vector<std::pair<double, double>>> rv;
+            std::map<typename TableCollectionType::id_type,
+                     std::vector<std::pair<double, double>>>
+                rv;
             tree_visitor<TableCollectionType> mti(tables, std::forward<SAMPLES>(samples),
                                                   update_samples_list(false));
             while (mti())
@@ -33,9 +36,10 @@ namespace fwdpp
                     auto &tree = mti.tree();
                     if (num_roots(tree) > 1)
                         {
-                            const auto func = [&rv, &tree](table_index_t root) {
-                                rv[root].emplace_back(tree.left, tree.right);
-                            };
+                            const auto func =
+                                [&rv, &tree](typename TableCollectionType::id_type root) {
+                                    rv[root].emplace_back(tree.left, tree.right);
+                                };
                             process_roots(tree, func);
                         }
                 }

--- a/fwdpp/ts/mutate_tables.hpp
+++ b/fwdpp/ts/mutate_tables.hpp
@@ -3,6 +3,7 @@
 
 #include <gsl/gsl_randist.h>
 
+#include <cmath>
 #include <vector>
 #include <functional>
 #include <type_traits>

--- a/fwdpp/ts/recording/diploid_offspring.hpp
+++ b/fwdpp/ts/recording/diploid_offspring.hpp
@@ -15,12 +15,12 @@ namespace fwdpp
 {
     namespace ts
     {
-        template <typename NewEdgeFunction>
+        template <typename SignedInteger, typename NewEdgeFunction>
         inline void
-        split_breakpoints_add_edges(const std::vector<double>& breakpoints,
-                                    const std::tuple<table_index_t, table_index_t>& parents,
-                                    const table_index_t next_index,
-                                    const NewEdgeFunction f, double L)
+        split_breakpoints_add_edges(
+            const std::vector<double>& breakpoints,
+            const std::tuple<SignedInteger, SignedInteger>& parents,
+            const SignedInteger next_index, const NewEdgeFunction f, double L)
         {
             if (breakpoints.front() != 0.0)
                 {
@@ -54,11 +54,11 @@ namespace fwdpp
                 }
         }
 
-        template <typename NewEdgeFunction>
+        template <typename SignedInteger, typename NewEdgeFunction>
         inline void
         split_breakpoints(const std::vector<double>& breakpoints,
-                          const std::tuple<table_index_t, table_index_t>& parents,
-                          const table_index_t next_index, const NewEdgeFunction f,
+                          const std::tuple<SignedInteger, SignedInteger>& parents,
+                          const SignedInteger next_index, const NewEdgeFunction f,
                           double L)
         {
             if (breakpoints.empty())
@@ -101,21 +101,25 @@ namespace fwdpp
         }
 
         template <typename TableCollectionType>
-        inline table_index_t
-        record_diploid_offspring(const std::vector<double>& breakpoints,
-                                 const std::tuple<table_index_t, table_index_t>& parents,
-                                 const std::int32_t population, const double time,
-                                 TableCollectionType& tables)
+        inline typename TableCollectionType::id_type
+        record_diploid_offspring(
+            const std::vector<double>& breakpoints,
+            const std::tuple<typename TableCollectionType::id_type,
+                             typename TableCollectionType::id_type>& parents,
+            const std::int32_t population, const double time,
+            TableCollectionType& tables)
         {
             // TODO: carefully document how to index node times.
             auto next_index = tables.emplace_back_node(population, time);
-            if (next_index >= std::numeric_limits<table_index_t>::max())
+            if (next_index
+                >= std::numeric_limits<typename TableCollectionType::id_type>::max())
                 {
                     throw std::invalid_argument("node index too large");
                 }
             split_breakpoints(
                 breakpoints, parents, next_index,
-                [&tables](double l, double r, table_index_t p, table_index_t c) {
+                [&tables](double l, double r, typename TableCollectionType::id_type p,
+                          typename TableCollectionType::id_type c) {
                     tables.push_back_edge(l, r, p, c);
                 },
                 tables.genome_length());
@@ -123,21 +127,26 @@ namespace fwdpp
         }
 
         template <typename TableCollectionType>
-        inline table_index_t
-        record_diploid_offspring(const std::vector<double>& breakpoints,
-                                 const std::tuple<table_index_t, table_index_t>& parents,
-                                 const std::int32_t population, const double time,
-                                 TableCollectionType& tables, edge_buffer& buffer)
+        inline typename TableCollectionType::id_type
+        record_diploid_offspring(
+            const std::vector<double>& breakpoints,
+            const std::tuple<typename TableCollectionType::id_type,
+                             typename TableCollectionType::id_type>& parents,
+            const std::int32_t population, const double time,
+            TableCollectionType& tables,
+            edge_buffer<typename TableCollectionType::id_type>& buffer)
         {
             // TODO: carefully document how to index node times.
             auto next_index = tables.emplace_back_node(population, time);
-            if (next_index >= std::numeric_limits<table_index_t>::max())
+            if (next_index
+                >= std::numeric_limits<typename TableCollectionType::id_type>::max())
                 {
                     throw std::invalid_argument("node index too large");
                 }
             split_breakpoints(
                 breakpoints, parents, next_index,
-                [&buffer](double l, double r, table_index_t p, table_index_t c) {
+                [&buffer](double l, double r, typename TableCollectionType::id_type p,
+                          typename TableCollectionType::id_type c) {
                     buffer.extend(p, l, r, c);
                 },
                 tables.genome_length());

--- a/fwdpp/ts/recording/mutations.hpp
+++ b/fwdpp/ts/recording/mutations.hpp
@@ -13,7 +13,8 @@ namespace fwdpp
         template <typename TableCollectionType, typename MutationContainerType>
         void
         record_mutations_infinite_sites(
-            const table_index_t u, const MutationContainerType& mutations,
+            const typename TableCollectionType::id_type u,
+            const MutationContainerType& mutations,
             const std::vector<std::uint32_t>& new_mutation_keys,
             TableCollectionType& tables)
         /// \version Added in 0.8.0
@@ -25,7 +26,8 @@ namespace fwdpp
                     auto site
                         = tables.emplace_back_site(mutations[k].pos, ancestral_state);
                     if (site >= static_cast<std::size_t>(
-                            std::numeric_limits<table_index_t>::max()))
+                            std::numeric_limits<
+                                typename TableCollectionType::id_type>::max()))
                         {
                             throw std::invalid_argument("site index out of range");
                         }

--- a/fwdpp/ts/serialization.hpp
+++ b/fwdpp/ts/serialization.hpp
@@ -7,12 +7,13 @@
 #include <vector>
 #include <stdexcept>
 #include <fwdpp/io/scalar_serialization.hpp>
-#include "edge.hpp"
-#include "node.hpp"
-#include "site.hpp"
-#include "mutation_record.hpp"
+#include "types/edge.hpp"
+#include "types/node.hpp"
+#include "types/site.hpp"
+#include "types/mutation_record.hpp"
 #include "serialization_version.hpp"
 #include "table_collection_functions.hpp"
+#include "definitions.hpp"
 
 /*! \namespace fwdpp::ts::io
  *  \brief Binary seriazliation of fwdpp::ts::table_collection
@@ -40,21 +41,22 @@ namespace fwdpp
     {
         namespace io
         {
-            template <std::size_t version> struct serialize_node
+            template <typename SignedInteger, std::size_t version> struct serialize_node
             {
                 template <typename ostreamtype>
                 inline void
-                operator()(ostreamtype&, const node&) const
+                operator()(ostreamtype&, const types::node<SignedInteger>&) const
                 {
                     throw std::runtime_error("invalid serialization version");
                 }
             };
 
-            template <> struct serialize_node<TS_TABLES_VERSION>
+            template <typename SignedInteger>
+            struct serialize_node<SignedInteger, TS_TABLES_VERSION>
             {
                 template <typename ostreamtype>
                 inline void
-                operator()(ostreamtype& o, const node& n) const
+                operator()(ostreamtype& o, const types::node<SignedInteger>& n) const
                 {
                     fwdpp::io::scalar_writer sw;
                     sw(o, &n.deme);
@@ -62,46 +64,49 @@ namespace fwdpp
                 }
             };
 
-            template <std::size_t version> struct deserialize_node
+            template <typename SignedInteger, std::size_t version>
+            struct deserialize_node
             {
                 template <typename istreamtype>
-                inline node
+                inline types::node<SignedInteger>
                 operator()(istreamtype&) const
                 {
                     throw std::runtime_error("invalid serialization version");
                 }
             };
 
-            template <> struct deserialize_node<TS_TABLES_VERSION>
+            template <typename SignedInteger>
+            struct deserialize_node<SignedInteger, TS_TABLES_VERSION>
             {
                 template <typename istreamtype>
-                inline node
+                inline types::node<SignedInteger>
                 operator()(istreamtype& o) const
                 {
                     fwdpp::io::scalar_reader sr;
-                    table_index_t deme;
+                    typename types::node<SignedInteger>::id_type deme;
                     double time;
                     sr(o, &deme);
                     sr(o, &time);
-                    return node{deme, time};
+                    return types::node<SignedInteger>{deme, time};
                 }
             };
 
-            template <std::size_t version> struct serialize_edge
+            template <typename SignedInteger, std::size_t version> struct serialize_edge
             {
                 template <typename ostreamtype>
                 inline void
-                operator()(ostreamtype&, const edge&) const
+                operator()(ostreamtype&, const types::edge<SignedInteger>&) const
                 {
                     throw std::runtime_error("invalid serialization version");
                 }
             };
 
-            template <> struct serialize_edge<TS_TABLES_VERSION>
+            template <typename SignedInteger>
+            struct serialize_edge<SignedInteger, TS_TABLES_VERSION>
             {
                 template <typename ostreamtype>
                 inline void
-                operator()(ostreamtype& o, const edge& e) const
+                operator()(ostreamtype& o, const types::edge<SignedInteger>& e) const
                 {
                     fwdpp::io::scalar_writer sw;
                     sw(o, &e.left);
@@ -111,49 +116,55 @@ namespace fwdpp
                 }
             };
 
-            template <std::size_t version> struct deserialize_edge
+            template <typename SignedInteger, std::size_t version>
+            struct deserialize_edge
             {
                 template <typename istreamtype>
-                inline edge
+                inline types::edge<SignedInteger>
                 operator()(istreamtype&) const
                 {
                     throw std::runtime_error("invalid serialization version");
                 }
             };
 
-            template <> struct deserialize_edge<TS_TABLES_VERSION>
+            template <typename SignedInteger>
+            struct deserialize_edge<SignedInteger, TS_TABLES_VERSION>
             {
                 template <typename istreamtype>
-                inline edge
+                inline types::edge<SignedInteger>
                 operator()(istreamtype& i) const
                 {
                     fwdpp::io::scalar_reader sr;
                     double left, right;
-                    table_index_t parent, child;
+                    typename types::edge<SignedInteger>::id_type parent, child;
                     sr(i, &left);
                     sr(i, &right);
                     sr(i, &parent);
                     sr(i, &child);
-                    return edge{left, right, parent, child};
+                    return types::edge<SignedInteger>{left, right, parent, child};
                 }
             };
 
-            template <std::size_t version> struct serialize_mutation_record
+            template <typename SignedInteger, std::size_t version>
+            struct serialize_mutation_record
             {
                 template <typename ostreamtype>
                 inline void
-                operator()(ostreamtype&, const mutation_record&) const
+                operator()(ostreamtype&,
+                           const types::mutation_record<SignedInteger>&) const
                 {
                     throw std::runtime_error("invalid serialization version");
                 }
             };
 
-            template <> struct serialize_mutation_record<2>
+            template <typename SignedInteger>
+            struct serialize_mutation_record<SignedInteger, 2>
             /// \version 0.8.0 Changes from TS_TABLES_VERSION to 2
             {
                 template <typename ostreamtype>
                 inline void
-                operator()(ostreamtype& o, const mutation_record& mr) const
+                operator()(ostreamtype& o,
+                           const types::mutation_record<SignedInteger>& mr) const
                 {
                     fwdpp::io::scalar_writer sw;
                     sw(o, &mr.node);
@@ -161,31 +172,33 @@ namespace fwdpp
                 }
             };
 
-            template <std::size_t version> struct deserialize_mutation_record
+            template <typename SignedInteger, std::size_t version>
+            struct deserialize_mutation_record
             {
                 template <typename istreamtype>
-                inline mutation_record
+                inline types::mutation_record<SignedInteger>
                 operator()(istreamtype&) const
                 {
                     throw std::runtime_error("invalid serialization version");
                 }
             };
 
-            template <> struct deserialize_mutation_record<2>
+            template <typename SignedInteger>
+            struct deserialize_mutation_record<SignedInteger, 2>
             /// \version 0.8.0 Changed from TS_TABLES_VERSION to 2
             /// \note The fields site, derived_state, and neutral
             ///       are filled in with "junk" values.
             {
                 template <typename istreamtype>
-                inline mutation_record
+                inline types::mutation_record<SignedInteger>
                 operator()(istreamtype& i) const
                 {
                     fwdpp::io::scalar_reader sr;
-                    table_index_t node;
-                    decltype(mutation_record::key) key;
+                    typename types::mutation_record<SignedInteger>::id_type node;
+                    decltype(types::mutation_record<SignedInteger>::key) key;
                     sr(i, &node);
                     sr(i, &key);
-                    return mutation_record{
+                    return types::mutation_record<SignedInteger>{
                         node, key, std::numeric_limits<std::size_t>::max(),
                         std::numeric_limits<std::int8_t>::max(), true};
                 }
@@ -236,22 +249,27 @@ namespace fwdpp
                 if (!tables.edges.empty())
                     {
                         o.write(reinterpret_cast<const char*>(tables.edges.data()),
-                                tables.edges.size() * sizeof(edge));
+                                tables.edges.size()
+                                    * sizeof(typename TableCollectionType::edge));
                     }
                 if (!tables.nodes.empty())
                     {
                         o.write(reinterpret_cast<const char*>(tables.nodes.data()),
-                                tables.nodes.size() * sizeof(node));
+                                tables.nodes.size()
+                                    * sizeof(typename TableCollectionType::node));
                     }
                 if (!tables.mutations.empty())
                     {
-                        o.write(reinterpret_cast<const char*>(tables.mutations.data()),
-                                tables.mutations.size() * sizeof(mutation_record));
+                        o.write(
+                            reinterpret_cast<const char*>(tables.mutations.data()),
+                            tables.mutations.size()
+                                * sizeof(typename TableCollectionType::mutation_record));
                     }
                 if (!tables.sites.empty())
                     {
                         o.write(reinterpret_cast<const char*>(tables.sites.data()),
-                                tables.sites.size() * sizeof(site));
+                                tables.sites.size()
+                                    * sizeof(typename TableCollectionType::site));
                     }
             }
 
@@ -300,20 +318,26 @@ namespace fwdpp
                         {
                             tables.edges.resize(num_edges);
                             i.read(reinterpret_cast<char*>(tables.edges.data()),
-                                   num_edges * sizeof(edge));
+                                   num_edges
+                                       * sizeof(typename TableCollectionType::edge));
                             tables.nodes.resize(num_nodes);
                             i.read(reinterpret_cast<char*>(tables.nodes.data()),
-                                   num_nodes * sizeof(node));
+                                   num_nodes
+                                       * sizeof(typename TableCollectionType::node));
 
                             if (format == TS_TABLES_VERSION)
                                 {
                                     tables.mutations.resize(num_mutations);
                                     i.read(
                                         reinterpret_cast<char*>(tables.mutations.data()),
-                                        num_mutations * sizeof(mutation_record));
+                                        num_mutations
+                                            * sizeof(typename TableCollectionType::
+                                                         mutation_record));
                                     tables.sites.resize(num_sites);
                                     i.read(reinterpret_cast<char*>(tables.sites.data()),
-                                           num_sites * sizeof(site));
+                                           num_sites
+                                               * sizeof(
+                                                   typename TableCollectionType::site));
                                 }
                             else
                                 {
@@ -327,21 +351,29 @@ namespace fwdpp
                                     for (auto t : temp)
                                         {
                                             tables.mutations.emplace_back(
-                                                mutation_record{t.node, t.key,
-                                                                std::numeric_limits<
-                                                                    std::size_t>::max(),
-                                                                std::numeric_limits<
-                                                                    std::int8_t>::min(),
-                                                                true});
+                                                typename TableCollectionType::
+                                                    mutation_record{
+                                                        t.node, t.key,
+                                                        std::numeric_limits<
+                                                            std::size_t>::max(),
+                                                        std::numeric_limits<
+                                                            std::int8_t>::min(),
+                                                        true});
                                         }
                                 }
                         }
                     else if (format == 1)
                         {
-                            deserialize_edge<TS_TABLES_VERSION> edge_reader;
-                            deserialize_node<TS_TABLES_VERSION> node_reader;
+                            deserialize_edge<typename TableCollectionType::id_type,
+                                             TS_TABLES_VERSION>
+                                edge_reader;
+                            deserialize_node<typename TableCollectionType::id_type,
+                                             TS_TABLES_VERSION>
+                                node_reader;
                             // Format versions 1 and 2 have the same mutation_record type
-                            deserialize_mutation_record<2> mutation_record_reader;
+                            deserialize_mutation_record<
+                                typename TableCollectionType::id_type, 2>
+                                mutation_record_reader;
                             tables.edges.reserve(num_edges);
                             for (std::size_t j = 0; j < num_edges; ++j)
                                 {
@@ -370,7 +402,8 @@ namespace fwdpp
                             sr(i, &num_preserved_samples);
                             if (num_preserved_samples)
                                 {
-                                    std::vector<table_index_t> preserved_nodes;
+                                    std::vector<typename TableCollectionType::id_type>
+                                        preserved_nodes;
                                     preserved_nodes.resize(num_preserved_samples);
                                     sr(i, preserved_nodes.data(), num_preserved_samples);
                                 }

--- a/fwdpp/ts/simplify_tables_output.hpp
+++ b/fwdpp/ts/simplify_tables_output.hpp
@@ -9,19 +9,19 @@ namespace fwdpp
 {
     namespace ts
     {
-        template <typename NodeIDMap, typename MutationIndexVector>
+        template <typename SignedInteger, typename UnsignedInteger>
         struct simplify_tables_output_t
         {
-            static_assert(std::is_integral<typename NodeIDMap::value_type>::value,
-                          "NodeIDMap::value_type must be integral");
-            static_assert(std::is_signed<typename NodeIDMap::value_type>::value,
-                          "NodeIDMap::value_type must be signed");
-            static_assert(sizeof(typename NodeIDMap::value_type)
-                              >= sizeof(table_index_t),
-                          "sizeof(NodeIDMap::value_type) must be >= "
-                          "sizeof(fwdpp::ts::table_index_t)");
-            NodeIDMap idmap;
-            MutationIndexVector preserved_mutations;
+            static_assert(std::is_integral<SignedInteger>::value,
+                          "SignedInteger must be integral");
+            static_assert(std::is_signed<SignedInteger>::value,
+                          "SignedInteger must be signed");
+            static_assert(std::is_integral<UnsignedInteger>::value,
+                          "UnsignedInteger must be integral");
+            static_assert(!std::is_signed<UnsignedInteger>::value,
+                          "UnsignedInteger must be signed");
+            std::vector<SignedInteger> idmap;
+            std::vector<UnsignedInteger> preserved_mutations;
 
             simplify_tables_output_t() : idmap{}, preserved_mutations{}
             {
@@ -35,9 +35,9 @@ namespace fwdpp
             }
         };
 
+        template <typename SignedInteger>
         using simplify_tables_output
-            = simplify_tables_output_t<std::vector<table_index_t>,
-                                       std::vector<std::size_t>>;
+            = simplify_tables_output_t<SignedInteger, std::size_t>;
     }
 }
 

--- a/fwdpp/ts/site_visitor.hpp
+++ b/fwdpp/ts/site_visitor.hpp
@@ -49,7 +49,8 @@ namespace fwdpp
             tree_visitor<TableCollectionType>
             init_tree_visitor(const SAMPLES& samples)
             {
-                tree_visitor<TableCollectionType> tv(tables_, samples, update_samples_list(true));
+                tree_visitor<TableCollectionType> tv(tables_, samples,
+                                                     update_samples_list(true));
                 auto t = tv();
                 if (!t)
                     {
@@ -119,7 +120,7 @@ namespace fwdpp
                 return mutations_at_current_site;
             }
 
-            const marginal_tree&
+            const marginal_tree<typename TableCollectionType::id_type>&
             current_tree() const
             {
                 return tv.tree();

--- a/fwdpp/ts/table_simplifier.hpp
+++ b/fwdpp/ts/table_simplifier.hpp
@@ -37,8 +37,8 @@ namespace fwdpp
          */
         {
           private:
-            using simplifier_internal_state
-                = simplification::simplifier_internal_state<TableCollectionType>;
+            using simplifier_internal_state = simplification::simplifier_internal_state<
+                typename TableCollectionType::id_type>;
 
             simplifier_internal_state _state;
 
@@ -47,9 +47,10 @@ namespace fwdpp
             {
             }
 
-            std::pair<std::vector<table_index_t>, std::vector<std::size_t>>
+            std::pair<std::vector<typename TableCollectionType::id_type>,
+                      std::vector<std::size_t>>
             simplify(TableCollectionType& tables,
-                     const std::vector<table_index_t>& samples)
+                     const std::vector<typename TableCollectionType::id_type>& samples)
             /// Simplify algorithm is approximately the same
             /// logic as used in msprime 0.6.0
             ///
@@ -60,7 +61,8 @@ namespace fwdpp
             /// node ID map and a vector of keys to mutations preserved in
             /// mutation tables
             {
-                simplify_tables_output simplification_output;
+                simplify_tables_output<typename TableCollectionType::id_type>
+                    simplification_output;
                 simplify_tables(samples, simplification_flags{}, _state, tables,
                                 simplification_output);
 

--- a/fwdpp/ts/types/table_collection.hpp
+++ b/fwdpp/ts/types/table_collection.hpp
@@ -235,7 +235,12 @@ namespace fwdpp
                     return !(*this == b);
                 }
             };
-        } // namespace detail
+
+#if __cplusplus < 201703L
+            template <typename SignedInteger>
+            constexpr SignedInteger table_collection<SignedInteger>::null;
+#endif
+        } // namespace types
     }     // namespace ts
 } // namespace fwdpp
 

--- a/testsuite/tree_sequences/empty_table_collection.hpp
+++ b/testsuite/tree_sequences/empty_table_collection.hpp
@@ -6,9 +6,11 @@
 struct empty_table_collection
 {
     fwdpp::ts::table_collection tables;
-    std::vector<fwdpp::ts::table_index_t> empty_samples;
+    std::vector<fwdpp::ts::table_collection::id_type> empty_samples;
 
-    empty_table_collection() : tables(1.), empty_samples{} {}
+    empty_table_collection() : tables(1.), empty_samples{}
+    {
+    }
 };
 
 #endif

--- a/testsuite/tree_sequences/independent_implementations.cc
+++ b/testsuite/tree_sequences/independent_implementations.cc
@@ -1,16 +1,18 @@
 #include <algorithm>
 #include <fwdpp/ts/node.hpp>
 #include <fwdpp/ts/marginal_tree.hpp>
+#include <fwdpp/ts/table_collection.hpp>
 #include <fwdpp/ts/marginal_tree_functions/children.hpp>
 
 void
-get_tip(const fwdpp::ts::marginal_tree &m, fwdpp::ts::table_index_t u,
-        std::vector<fwdpp::ts::table_index_t> &samples)
+get_tip(const fwdpp::ts::marginal_tree<fwdpp::ts::table_collection::id_type> &m,
+        fwdpp::ts::table_collection::id_type u,
+        std::vector<fwdpp::ts::table_collection::id_type> &samples)
 {
     if (fwdpp::ts::num_children(m, u) > 0)
         {
             fwdpp::ts::process_children(
-                m, u, true, [&m, &samples](fwdpp::ts::table_index_t x) {
+                m, u, true, [&m, &samples](fwdpp::ts::table_collection::id_type x) {
                     get_tip(m, x, samples);
                 });
             return;
@@ -18,35 +20,38 @@ get_tip(const fwdpp::ts::marginal_tree &m, fwdpp::ts::table_index_t u,
     samples.push_back(u);
 }
 
-std::vector<fwdpp::ts::table_index_t>
-naive_get_samples(const fwdpp::ts::marginal_tree &m, fwdpp::ts::table_index_t u)
+std::vector<fwdpp::ts::table_collection::id_type>
+naive_get_samples(
+    const fwdpp::ts::marginal_tree<fwdpp::ts::table_collection::id_type> &m,
+    fwdpp::ts::table_collection::id_type u)
 {
     if (!m.advancing_sample_list())
         {
             throw std::invalid_argument("sample lists are not being updated");
         }
-    std::vector<fwdpp::ts::table_index_t> temp,
-        samples_list(m.samples_list_begin(), m.samples_list_end()),
-        intersection;
+    std::vector<fwdpp::ts::table_collection::id_type> temp,
+        samples_list(m.samples_list_begin(), m.samples_list_end()), intersection;
     std::sort(begin(samples_list), end(samples_list));
     get_tip(m, u, temp);
     std::sort(begin(temp), end(temp));
-    std::set_intersection(begin(temp), end(temp), begin(samples_list),
-                          end(samples_list), std::back_inserter(intersection));
+    std::set_intersection(begin(temp), end(temp), begin(samples_list), end(samples_list),
+                          std::back_inserter(intersection));
     return intersection;
 }
 
 std::size_t
-naive_num_samples(const fwdpp::ts::marginal_tree &m, fwdpp::ts::table_index_t u)
+naive_num_samples(
+    const fwdpp::ts::marginal_tree<fwdpp::ts::table_collection::id_type> &m,
+    fwdpp::ts::table_collection::id_type u)
 {
     auto s = naive_get_samples(m, u);
     return s.size();
 }
 
 double
-naive_branch_length(const fwdpp::ts::marginal_tree &m,
-                    const std::vector<fwdpp::ts::node> &nodes,
-                    bool scale_by_length)
+naive_branch_length(
+    const fwdpp::ts::marginal_tree<fwdpp::ts::table_collection::id_type> &m,
+    const std::vector<fwdpp::ts::node> &nodes, bool scale_by_length)
 // Sample-to-root implementation requiring O(nnodes) extra memory,
 // and makes multiple passes through same ancestral nodes.
 {
@@ -55,10 +60,10 @@ naive_branch_length(const fwdpp::ts::marginal_tree &m,
     for (auto s = m.samples_list_begin(); s != m.samples_list_end(); ++s)
         {
             auto u = *s;
-            while (u != fwdpp::ts::NULL_INDEX)
+            while (u != -1)
                 {
                     auto p = m.parents[u];
-                    if (!processed[u] && p != fwdpp::ts::NULL_INDEX)
+                    if (!processed[u] && p != -1)
                         {
                             ttime += (nodes[u].time - nodes[p].time);
                         }

--- a/testsuite/tree_sequences/independent_implementations.hpp
+++ b/testsuite/tree_sequences/independent_implementations.hpp
@@ -8,21 +8,24 @@
 #include <vector>
 #include <fwdpp/ts/node.hpp>
 #include <fwdpp/ts/marginal_tree.hpp>
+#include <fwdpp/ts/table_collection.hpp>
 
-void get_tip(const fwdpp::ts::marginal_tree &m, fwdpp::ts::table_index_t u,
-             std::vector<fwdpp::ts::table_index_t> &samples);
+void get_tip(const fwdpp::ts::marginal_tree<fwdpp::ts::table_collection::id_type> &m,
+             fwdpp::ts::table_collection::id_type u,
+             std::vector<fwdpp::ts::table_collection::id_type> &samples);
 
-std::vector<fwdpp::ts::table_index_t>
-naive_get_samples(const fwdpp::ts::marginal_tree &m, fwdpp::ts::table_index_t u);
+std::vector<fwdpp::ts::table_collection::id_type> naive_get_samples(
+    const fwdpp::ts::marginal_tree<fwdpp::ts::table_collection::id_type> &m,
+    fwdpp::ts::table_collection::id_type u);
 
-std::size_t naive_num_samples(const fwdpp::ts::marginal_tree &m,
-                              fwdpp::ts::table_index_t u);
+std::size_t naive_num_samples(
+    const fwdpp::ts::marginal_tree<fwdpp::ts::table_collection::id_type> &m,
+    fwdpp::ts::table_collection::id_type u);
 
 // Sample-to-root implementation requiring O(nnodes) extra memory,
 // and makes multiple passes through same ancestral nodes.
-double
-naive_branch_length(const fwdpp::ts::marginal_tree &m,
-                    const std::vector<fwdpp::ts::node> &nodes,
-                    bool scale_by_length);
+double naive_branch_length(
+    const fwdpp::ts::marginal_tree<fwdpp::ts::table_collection::id_type> &m,
+    const std::vector<fwdpp::ts::node> &nodes, bool scale_by_length);
 
 #endif

--- a/testsuite/tree_sequences/preorder_adl.hpp
+++ b/testsuite/tree_sequences/preorder_adl.hpp
@@ -4,27 +4,24 @@
 #include <fwdpp/ts/marginal_tree_functions/node_traversal_order.hpp>
 #include <fwdpp/ts/marginal_tree_functions/children.hpp>
 
-class node_traversal_preorder_test : public fwdpp::ts::node_traversal_order
+class node_traversal_preorder_test : public fwdpp::ts::node_traversal_order<std::int32_t>
 /// This is an exact copy of fwdpp::ts::node_traversal_preorder,
 /// moved into gloal namespace to mimic client-side code using ADL +
 /// tag dispatch
 {
   private:
-    using node_stack = std::stack<fwdpp::ts::table_index_t,
-                                  std::vector<fwdpp::ts::table_index_t>>;
+    using node_stack = std::stack<std::int32_t, std::vector<std::int32_t>>;
     node_stack nstack;
-    fwdpp::ts::table_index_t current_node;
+    std::int32_t current_node;
 
   public:
-    explicit node_traversal_preorder_test(fwdpp::ts::table_index_t u)
-        : node_traversal_order(), nstack{ { u } }, current_node{
-              fwdpp::ts::NULL_INDEX
-          }
+    explicit node_traversal_preorder_test(std::int32_t u)
+        : node_traversal_order(), nstack{{u}}, current_node{-1}
     {
     }
 
-    fwdpp::ts::table_index_t
-    operator()(const fwdpp::ts::marginal_tree& m) final
+    std::int32_t
+    operator()(const fwdpp::ts::marginal_tree<std::int32_t>& m) final
     {
         if (!nstack.empty())
             {
@@ -33,17 +30,15 @@ class node_traversal_preorder_test : public fwdpp::ts::node_traversal_order
                 if (num_children(m, current_node) != 0)
                     {
                         process_children(m, current_node, false,
-                                         [this](fwdpp::ts::table_index_t x) {
-                                             nstack.push(x);
-                                         });
+                                         [this](std::int32_t x) { nstack.push(x); });
                     }
                 return current_node;
             }
-        return fwdpp::ts::NULL_INDEX;
+        return -1;
     }
 
     void
-    initialize(fwdpp::ts::table_index_t root) final
+    initialize(std::int32_t root) final
     {
         nstack.push(root);
     }
@@ -53,9 +48,9 @@ struct nodes_preorder_test
 {
 };
 
-inline std::unique_ptr<fwdpp::ts::node_traversal_order>
-node_traversal_dispatch(fwdpp::ts::table_index_t root, nodes_preorder_test)
+inline std::unique_ptr<fwdpp::ts::node_traversal_order<std::int32_t>>
+node_traversal_dispatch(std::int32_t root, nodes_preorder_test)
 {
-    return std::unique_ptr<fwdpp::ts::node_traversal_order>(
+    return std::unique_ptr<fwdpp::ts::node_traversal_order<std::int32_t>>(
         new node_traversal_preorder_test(root));
 }

--- a/testsuite/tree_sequences/simple_table_collection.hpp
+++ b/testsuite/tree_sequences/simple_table_collection.hpp
@@ -40,7 +40,7 @@ class simple_table_collection
 
   public:
     fwdpp::ts::table_collection tables;
-    std::vector<fwdpp::ts::table_index_t> samples;
+    std::vector<fwdpp::ts::table_collection::id_type> samples;
     // NOTE: tv is auto advanced to the first tree
     // by the constructor
     fwdpp::ts::tree_visitor<fwdpp::ts::table_collection> tv;
@@ -62,7 +62,7 @@ class simple_table_collection
 
     void
     reset_visitor_and_samples(
-        const std::vector<fwdpp::ts::table_index_t>& new_samples_list,
+        const std::vector<fwdpp::ts::table_collection::id_type>& new_samples_list,
         bool update_samples_list)
     {
         samples = new_samples_list;

--- a/testsuite/tree_sequences/simple_table_collection_polytomy.hpp
+++ b/testsuite/tree_sequences/simple_table_collection_polytomy.hpp
@@ -43,7 +43,7 @@ class simple_table_collection_polytomy
 
   public:
     fwdpp::ts::table_collection tables;
-    std::vector<fwdpp::ts::table_index_t> samples;
+    std::vector<fwdpp::ts::table_collection::id_type> samples;
     // NOTE: tv is auto advanced to the first tree
     // by the constructor
     fwdpp::ts::tree_visitor<fwdpp::ts::table_collection> tv;
@@ -65,7 +65,7 @@ class simple_table_collection_polytomy
 
     void
     reset_visitor_and_samples(
-        const std::vector<fwdpp::ts::table_index_t>& new_samples_list,
+        const std::vector<fwdpp::ts::table_collection::id_type>& new_samples_list,
         bool update_samples_list)
     {
         samples = new_samples_list;

--- a/testsuite/tree_sequences/test_marginal_tree.cc
+++ b/testsuite/tree_sequences/test_marginal_tree.cc
@@ -7,12 +7,14 @@ BOOST_AUTO_TEST_SUITE()
 BOOST_FIXTURE_TEST_CASE(test_construction_with_sample_groups,
                         simple_table_collection_infinite_sites)
 {
-    std::vector<fwdpp::ts::sample_group_map> groups;
+    std::vector<fwdpp::ts::sample_group_map<fwdpp::ts::table_collection::id_type>>
+        groups;
     for (auto i : samples)
         {
             groups.emplace_back(i, 0);
         }
-    fwdpp::ts::marginal_tree m(tables.nodes.size(), groups, true);
+    fwdpp::ts::marginal_tree<fwdpp::ts::table_collection::id_type> m(tables.nodes.size(),
+                                                                     groups, true);
     BOOST_CHECK_EQUAL(m.sample_size(), groups.size());
     decltype(samples) scopy(m.samples_list_begin(), m.samples_list_end());
     BOOST_REQUIRE(samples == scopy);
@@ -21,14 +23,17 @@ BOOST_FIXTURE_TEST_CASE(test_construction_with_sample_groups,
 BOOST_FIXTURE_TEST_CASE(test_construction_with_sample_groups_and_preserved_nodes,
                         simple_table_collection_infinite_sites)
 {
-    std::vector<fwdpp::ts::sample_group_map> groups;
+    std::vector<fwdpp::ts::sample_group_map<fwdpp::ts::table_collection::id_type>>
+        groups;
     for (auto i : samples)
         {
             groups.emplace_back(i, 0);
         }
-    std::vector<fwdpp::ts::table_index_t> preserved_nodes;
-    preserved_nodes.push_back(static_cast<fwdpp::ts::table_index_t>(samples.size()));
-    fwdpp::ts::marginal_tree m(tables.nodes.size(), groups, preserved_nodes, true);
+    std::vector<fwdpp::ts::table_collection::id_type> preserved_nodes;
+    preserved_nodes.push_back(
+        static_cast<fwdpp::ts::table_collection::id_type>(samples.size()));
+    fwdpp::ts::marginal_tree<fwdpp::ts::table_collection::id_type> m(
+        tables.nodes.size(), groups, preserved_nodes, true);
     BOOST_CHECK_EQUAL(m.sample_size(), groups.size() + preserved_nodes.size());
     decltype(samples) scopy(m.samples_list_begin(), m.samples_list_end());
     samples.insert(end(samples), begin(preserved_nodes), end(preserved_nodes));
@@ -39,7 +44,10 @@ BOOST_FIXTURE_TEST_CASE(test_sample_preserved_node_overlap,
                         simple_table_collection_infinite_sites)
 {
     BOOST_REQUIRE_THROW(
-        { fwdpp::ts::marginal_tree m(tables.nodes.size(), samples, samples, true); },
+        {
+            fwdpp::ts::marginal_tree<fwdpp::ts::table_collection::id_type> m(
+                tables.nodes.size(), samples, samples, true);
+        },
         fwdpp::ts::samples_error);
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/testsuite/tree_sequences/test_node_children_traversal.cc
+++ b/testsuite/tree_sequences/test_node_children_traversal.cc
@@ -23,7 +23,7 @@ BOOST_FIXTURE_TEST_CASE(test_polytomy, simple_table_collection_polytomy)
     decltype(c) c2;
     fwdpp::ts::process_children(
         tv.tree(), 5, false,
-        [&c2](fwdpp::ts::table_index_t u) { c2.push_back(u); });
+        [&c2](fwdpp::ts::table_collection::id_type u) { c2.push_back(u); });
     BOOST_REQUIRE(c == c2);
 }
 

--- a/testsuite/tree_sequences/test_preorder_node_traversal.cc
+++ b/testsuite/tree_sequences/test_preorder_node_traversal.cc
@@ -12,32 +12,35 @@ BOOST_FIXTURE_TEST_SUITE(test_simple_table_collection, simple_table_collection)
 
 BOOST_AUTO_TEST_CASE(test_construction)
 {
-    BOOST_REQUIRE_NO_THROW(
-        { fwdpp::ts::node_iterator(tv.tree(), fwdpp::ts::nodes_preorder()); });
+    BOOST_REQUIRE_NO_THROW({
+        fwdpp::ts::node_iterator<fwdpp::ts::table_collection::id_type>(
+            tv.tree(), fwdpp::ts::nodes_preorder());
+    });
 }
 
 BOOST_AUTO_TEST_CASE(test_complete_traversal)
 {
-    fwdpp::ts::node_iterator ni(tv.tree(), fwdpp::ts::nodes_preorder());
-    std::vector<fwdpp::ts::table_index_t> nodes;
+    fwdpp::ts::node_iterator<fwdpp::ts::table_collection::id_type> ni(
+        tv.tree(), fwdpp::ts::nodes_preorder());
+    std::vector<fwdpp::ts::table_collection::id_type> nodes;
     auto n = ni();
-    while (n != fwdpp::ts::NULL_INDEX)
+    while (n != fwdpp::ts::table_collection::null)
         {
             nodes.push_back(n);
             n = ni();
         }
     BOOST_REQUIRE_EQUAL(
-        nodes == std::vector<fwdpp::ts::table_index_t>({ 6, 4, 0, 1, 5, 2, 3 }),
+        nodes
+            == std::vector<fwdpp::ts::table_collection::id_type>({6, 4, 0, 1, 5, 2, 3}),
         true);
-    auto nodes_from_fxn
-        = fwdpp::ts::get_nodes(tv.tree(), fwdpp::ts::nodes_preorder());
+    auto nodes_from_fxn = fwdpp::ts::get_nodes(tv.tree(), fwdpp::ts::nodes_preorder());
     BOOST_REQUIRE_EQUAL(nodes == nodes_from_fxn, true);
 }
 
 BOOST_AUTO_TEST_CASE(test_subtree_traversal)
 {
     auto n = fwdpp::ts::get_nodes(tv.tree(), 5, fwdpp::ts::nodes_preorder());
-    std::vector<fwdpp::ts::table_index_t> expected_nodes{ 5, 2, 3 };
+    std::vector<fwdpp::ts::table_collection::id_type> expected_nodes{5, 2, 3};
     BOOST_REQUIRE_EQUAL(n.size(), expected_nodes.size());
     BOOST_REQUIRE_EQUAL(n == expected_nodes, true);
 }
@@ -47,7 +50,7 @@ BOOST_AUTO_TEST_CASE(test_subtree_traversal_after_decapitation)
     fwdpp::ts::decapitate(tables, 1., false);
     reset_visitor(false);
     auto nodes = fwdpp::ts::get_nodes(tv.tree(), fwdpp::ts::nodes_preorder());
-    std::vector<fwdpp::ts::table_index_t> expected_nodes = { 4, 0, 1, 2, 3 };
+    std::vector<fwdpp::ts::table_collection::id_type> expected_nodes = {4, 0, 1, 2, 3};
     BOOST_REQUIRE_EQUAL(nodes.size(), expected_nodes.size());
     BOOST_REQUIRE_EQUAL(nodes.size() == expected_nodes.size(), true);
 }
@@ -59,31 +62,32 @@ BOOST_FIXTURE_TEST_SUITE(test_simple_table_collection_polytomy,
 
 BOOST_AUTO_TEST_CASE(test_construction)
 {
-    BOOST_REQUIRE_NO_THROW(
-        { fwdpp::ts::node_iterator(tv.tree(), fwdpp::ts::nodes_preorder()); });
+    BOOST_REQUIRE_NO_THROW({
+        fwdpp::ts::node_iterator<fwdpp::ts::table_collection::id_type>(
+            tv.tree(), fwdpp::ts::nodes_preorder());
+    });
 }
 
 BOOST_AUTO_TEST_CASE(test_complete_traversal)
 {
     auto n = fwdpp::ts::get_nodes(tv.tree(), fwdpp::ts::nodes_preorder());
     BOOST_REQUIRE_EQUAL(n.size(), tables.num_nodes());
-    std::vector<fwdpp::ts::table_index_t> expected_nodes{
-        7, 5, 0, 1, 2, 6, 3, 4
-    };
+    std::vector<fwdpp::ts::table_collection::id_type> expected_nodes{7, 5, 0, 1,
+                                                                     2, 6, 3, 4};
     BOOST_REQUIRE_EQUAL(n == expected_nodes, true);
 }
 
 BOOST_AUTO_TEST_CASE(test_subtree_traversal)
 {
     auto n = fwdpp::ts::get_nodes(tv.tree(), 5, fwdpp::ts::nodes_preorder());
-    std::vector<fwdpp::ts::table_index_t> expected_nodes{ 5, 0, 1, 2 };
+    std::vector<fwdpp::ts::table_collection::id_type> expected_nodes{5, 0, 1, 2};
     BOOST_REQUIRE_EQUAL(n == expected_nodes, true);
 }
 
 BOOST_AUTO_TEST_CASE(test_other_subtree_traversal)
 {
     auto n = fwdpp::ts::get_nodes(tv.tree(), 6, fwdpp::ts::nodes_preorder());
-    std::vector<fwdpp::ts::table_index_t> expected_nodes{ 6, 3, 4 };
+    std::vector<fwdpp::ts::table_collection::id_type> expected_nodes{6, 3, 4};
     BOOST_REQUIRE_EQUAL(n == expected_nodes, true);
 }
 
@@ -92,8 +96,8 @@ BOOST_AUTO_TEST_CASE(test_subtree_traversal_after_decaptitation)
     fwdpp::ts::decapitate(tables, 0., false);
     reset_visitor(false);
     auto nodes = fwdpp::ts::get_nodes(tv.tree(), fwdpp::ts::nodes_preorder());
-    std::vector<fwdpp::ts::table_index_t> expected_nodes
-        = { 5, 0, 1, 2, 6, 3, 4 };
+    std::vector<fwdpp::ts::table_collection::id_type> expected_nodes
+        = {5, 0, 1, 2, 6, 3, 4};
     BOOST_REQUIRE_EQUAL(nodes.size(), expected_nodes.size());
     BOOST_REQUIRE_EQUAL(nodes.size() == expected_nodes.size(), true);
 }

--- a/testsuite/tree_sequences/test_root_traversal.cc
+++ b/testsuite/tree_sequences/test_root_traversal.cc
@@ -16,7 +16,7 @@ BOOST_AUTO_TEST_CASE(test_roots)
 BOOST_AUTO_TEST_CASE(test_roots_after_decapitation)
 {
     fwdpp::ts::decapitate(tables, 0., false);
-    std::vector<fwdpp::ts::table_index_t> expected_roots{ 4, 5 };
+    std::vector<fwdpp::ts::table_collection::id_type> expected_roots{ 4, 5 };
 	reset_visitor(false);
     auto r = fwdpp::ts::get_roots(tv.tree());
     BOOST_REQUIRE_EQUAL(r.size(), 2);

--- a/testsuite/tree_sequences/test_sample_traversal.cc
+++ b/testsuite/tree_sequences/test_sample_traversal.cc
@@ -17,9 +17,10 @@ BOOST_FIXTURE_TEST_CASE(num_samples_simple_table_collection, simple_table_collec
     for (std::size_t i = 0; i < tables.nodes.size(); ++i)
         {
             BOOST_REQUIRE_EQUAL(
-                fwdpp::ts::num_samples(tv.tree(),
-                                       static_cast<fwdpp::ts::table_index_t>(i)),
-                naive_num_samples(tv.tree(), static_cast<fwdpp::ts::table_index_t>(i)));
+                fwdpp::ts::num_samples(
+                    tv.tree(), static_cast<fwdpp::ts::table_collection::id_type>(i)),
+                naive_num_samples(tv.tree(),
+                                  static_cast<fwdpp::ts::table_collection::id_type>(i)));
         }
 }
 
@@ -27,15 +28,16 @@ BOOST_FIXTURE_TEST_CASE(test_sample_lists, simple_table_collection)
 {
     for (std::size_t i = 0; i < tables.nodes.size(); ++i)
         {
-            auto x = fwdpp::ts::get_samples(tv.tree(),
-                                            static_cast<fwdpp::ts::table_index_t>(i));
-            auto y
-                = naive_get_samples(tv.tree(), static_cast<fwdpp::ts::table_index_t>(i));
+            auto x = fwdpp::ts::get_samples(
+                tv.tree(), static_cast<fwdpp::ts::table_collection::id_type>(i));
+            auto y = naive_get_samples(
+                tv.tree(), static_cast<fwdpp::ts::table_collection::id_type>(i));
             BOOST_CHECK_EQUAL(x.size(), y.size());
-            BOOST_CHECK(fwdpp::ts::get_samples(tv.tree(),
-                                               static_cast<fwdpp::ts::table_index_t>(i))
-                        == naive_get_samples(tv.tree(),
-                                             static_cast<fwdpp::ts::table_index_t>(i)));
+            BOOST_CHECK(
+                fwdpp::ts::get_samples(
+                    tv.tree(), static_cast<fwdpp::ts::table_collection::id_type>(i))
+                == naive_get_samples(
+                    tv.tree(), static_cast<fwdpp::ts::table_collection::id_type>(i)));
         }
 }
 
@@ -43,9 +45,10 @@ BOOST_FIXTURE_TEST_CASE(test_process_samples_as_nodes, simple_table_collection)
 {
     samples = {1, 2};
     reset_visitor(true);
-    std::vector<fwdpp::ts::table_index_t> s;
-    fwdpp::ts::process_samples(tv.tree(), fwdpp::ts::convert_sample_index_to_nodes(true),
-                               6, [&s](fwdpp::ts::table_index_t u) { s.push_back(u); });
+    std::vector<fwdpp::ts::table_collection::id_type> s;
+    fwdpp::ts::process_samples(
+        tv.tree(), fwdpp::ts::convert_sample_index_to_nodes(true), 6,
+        [&s](fwdpp::ts::table_collection::id_type u) { s.push_back(u); });
     BOOST_REQUIRE(s == samples);
 }
 
@@ -53,10 +56,10 @@ BOOST_FIXTURE_TEST_CASE(test_process_samples_as_indexes, simple_table_collection
 {
     samples = {1, 2};
     reset_visitor(true);
-    std::vector<fwdpp::ts::table_index_t> s;
-    fwdpp::ts::process_samples(tv.tree(),
-                               fwdpp::ts::convert_sample_index_to_nodes(false), 6,
-                               [&s](fwdpp::ts::table_index_t u) { s.push_back(u); });
+    std::vector<fwdpp::ts::table_collection::id_type> s;
+    fwdpp::ts::process_samples(
+        tv.tree(), fwdpp::ts::convert_sample_index_to_nodes(false), 6,
+        [&s](fwdpp::ts::table_collection::id_type u) { s.push_back(u); });
     for (auto& i : samples)
         {
             i -= 1;

--- a/testsuite/tree_sequences/test_tree_visitor.cc
+++ b/testsuite/tree_sequences/test_tree_visitor.cc
@@ -15,17 +15,20 @@ namespace
         unsigned nsteps;
         fwdpp::ts::table_collection tables;
         wf_simulation_results results;
-        std::vector<fwdpp::ts::sample_group_map> samples;
+        std::vector<fwdpp::ts::sample_group_map<fwdpp::ts::table_collection::id_type>>
+            samples;
 
-        std::vector<fwdpp::ts::sample_group_map>
+        std::vector<fwdpp::ts::sample_group_map<fwdpp::ts::table_collection::id_type>>
         fill_samples(const wf_simulation_results& results)
         {
-            std::vector<fwdpp::ts::sample_group_map> rv;
+            std::vector<
+                fwdpp::ts::sample_group_map<fwdpp::ts::table_collection::id_type>>
+                rv;
             for (auto& p : results.alive_individuals)
                 {
                     for (auto n : p.nodes)
                         {
-                            if (n < static_cast<fwdpp::ts::table_index_t>(
+                            if (n < static_cast<fwdpp::ts::table_collection::id_type>(
                                     results.alive_individuals.size()))
                                 {
                                     rv.emplace_back(n, 0);
@@ -51,8 +54,10 @@ namespace
     };
 
     bool
-    validate_sample_group_counts(const std::vector<fwdpp::ts::sample_group_map>& samples,
-                                 int group, int observed_number)
+    validate_sample_group_counts(
+        const std::vector<
+            fwdpp::ts::sample_group_map<fwdpp::ts::table_collection::id_type>>& samples,
+        int group, int observed_number)
     {
         int expected_number = 0;
         for (auto& s : samples)
@@ -113,7 +118,8 @@ BOOST_AUTO_TEST_SUITE(test_sample_groups)
 
 BOOST_FIXTURE_TEST_CASE(test_group_labels, simple_table_collection_polytomy)
 {
-    std::vector<fwdpp::ts::sample_group_map> groups;
+    std::vector<fwdpp::ts::sample_group_map<fwdpp::ts::table_collection::id_type>>
+        groups;
     for (auto i : samples)
         {
             groups.emplace_back(i, 0);
@@ -148,7 +154,7 @@ BOOST_FIXTURE_TEST_CASE(test_group_labels_from_simulation,
                 {
                     for (auto n : p.nodes)
                         {
-                            if (n < static_cast<fwdpp::ts::table_index_t>(
+                            if (n < static_cast<fwdpp::ts::table_collection::id_type>(
                                     ll.results.alive_individuals.size()))
                                 {
                                     BOOST_REQUIRE_EQUAL(tv.tree().sample_group(n), 0);
@@ -169,7 +175,10 @@ BOOST_FIXTURE_TEST_CASE(test_group_labels_from_simulation,
                 {
                     if (is_sample[i] == 0)
                         {
-                            BOOST_REQUIRE(tv.tree().sample_group(static_cast<fwdpp::ts::table_index_t>(i)) < 0);
+                            BOOST_REQUIRE(
+                                tv.tree().sample_group(
+                                    static_cast<fwdpp::ts::table_collection::id_type>(i))
+                                < 0);
                         }
                 }
         }
@@ -190,7 +199,7 @@ BOOST_FIXTURE_TEST_CASE(test_group_labels_from_simulation_with_recombination,
                 {
                     for (auto n : p.nodes)
                         {
-                            if (n < static_cast<fwdpp::ts::table_index_t>(
+                            if (n < static_cast<fwdpp::ts::table_collection::id_type>(
                                     ll.results.alive_individuals.size()))
                                 {
                                     BOOST_REQUIRE_EQUAL(tv.tree().sample_group(n), 0);
@@ -211,7 +220,10 @@ BOOST_FIXTURE_TEST_CASE(test_group_labels_from_simulation_with_recombination,
                 {
                     if (is_sample[i] == 0)
                         {
-                            BOOST_REQUIRE(tv.tree().sample_group(static_cast<fwdpp::ts::table_index_t>(i)) < 0);
+                            BOOST_REQUIRE(
+                                tv.tree().sample_group(
+                                    static_cast<fwdpp::ts::table_collection::id_type>(i))
+                                < 0);
                         }
                 }
         }

--- a/testsuite/tree_sequences/test_visit_sites.cc
+++ b/testsuite/tree_sequences/test_visit_sites.cc
@@ -7,17 +7,18 @@ BOOST_AUTO_TEST_SUITE(test_visit_sites)
 BOOST_FIXTURE_TEST_CASE(test_simple_iteration, simple_table_collection_infinite_sites)
 {
     std::size_t num_sites = 0;
-    auto f = [&num_sites](
-                 const fwdpp::ts::marginal_tree& /*m*/,
-                 const fwdpp::ts::table_collection::site& /*s*/,
-                 const fwdpp::ts::table_collection::mutation_table::const_iterator b,
-                 const fwdpp::ts::table_collection::mutation_table::const_iterator e) {
-        if (std::distance(b, e) != 1)
-            {
-                throw std::runtime_error("incorrect number of mutations");
-            }
-        ++num_sites;
-    };
+    auto f =
+        [&num_sites](
+            const fwdpp::ts::marginal_tree<fwdpp::ts::table_collection::id_type>& /*m*/,
+            const fwdpp::ts::table_collection::site& /*s*/,
+            const fwdpp::ts::table_collection::mutation_table::const_iterator b,
+            const fwdpp::ts::table_collection::mutation_table::const_iterator e) {
+            if (std::distance(b, e) != 1)
+                {
+                    throw std::runtime_error("incorrect number of mutations");
+                }
+            ++num_sites;
+        };
     BOOST_REQUIRE_NO_THROW(
         { fwdpp::ts::visit_sites(tables, samples, f, 0, tables.genome_length()); });
     BOOST_REQUIRE_EQUAL(num_sites, tables.sites.size());


### PR DESCRIPTION
This PR deprecates the global typedefs and constants that specify a 32-bit tables interface.

The bit-ness of a tables API is now handled via templates.

This creates more verbose code, which is a trade-off.  Some of the verbosity can, in principle, be reduced in a later PR using standard template methods.
